### PR TITLE
Add OS24 S5 forward-tube lift support

### DIFF
--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValueLimits.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValueLimits.lean
@@ -466,6 +466,73 @@ private theorem exists_flattened_bvt_F_dualCone_distribution_with_fourierLaplace
   · intro z hz
     exact hFL_repr z hz
 
+/-- The Fourier-Laplace representation data for the same flattened
+frequency-side distribution used to represent the Wightman boundary value.
+
+This packet is deliberately small: it records only the flattened cone facts and
+the interior `bvt_F` Fourier-Laplace formula for the specified `Tflat`. -/
+structure section43TflatFourierLaplaceWitness
+    (OS : OsterwalderSchraderAxioms d) (lgc : OSLinearGrowthCondition d OS)
+    (N : ℕ)
+    (Tflat : SchwartzMap (Fin (N * (d + 1)) → ℝ) ℂ →L[ℂ] ℂ) where
+  hCflat_open :
+    IsOpen
+      ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N)
+  hCflat_conv :
+    Convex ℝ
+      ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N)
+  hCflat_cone :
+    IsCone
+      ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N)
+  hCflat_salient :
+    IsSalientCone
+      ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N)
+  hFL :
+    ∀ z : Fin N → Fin (d + 1) → ℂ,
+      z ∈ TubeDomainSetPi (ForwardConeAbs d N) →
+        bvt_F OS lgc N z =
+          fourierLaplaceExtMultiDim
+            ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N)
+            hCflat_open hCflat_conv hCflat_cone hCflat_salient
+            Tflat (flattenCLEquiv N (d + 1) z)
+
+/-- Public Section 4.3 `Tflat` packet with Wightman spectral support, boundary
+representation, and the interior Fourier-Laplace representation for the same
+flattened distribution.
+
+This is the data needed by the OS-route S5 scalar-recognition packet; the
+Fourier-Laplace witness is obtained before the boundary-value witness is
+projected to spectral-region support, so no uniqueness theorem is needed. -/
+theorem bvt_W_flattened_distribution_hasFourierSupportIn_wightmanSpectralRegion_with_fourierLaplaceWitness
+    (OS : OsterwalderSchraderAxioms d) (lgc : OSLinearGrowthCondition d OS)
+    (N : ℕ) :
+    ∃ (Tflat : SchwartzMap (Fin (N * (d + 1)) → ℝ) ℂ →L[ℂ] ℂ),
+      HasFourierSupportIn (OSReconstruction.section43WightmanSpectralRegion d N) Tflat ∧
+        (∀ (φflat : SchwartzMap (Fin (N * (d + 1)) → ℝ) ℂ),
+          bvt_W OS lgc N (unflattenSchwartzNPoint (d := d) φflat) =
+            Tflat (physicsFourierFlatCLM φflat)) ∧
+        section43TflatFourierLaplaceWitness (d := d) OS lgc N Tflat := by
+  obtain
+    ⟨Tflat, hCflat_open, hCflat_conv, hCflat_cone, hCflat_salient,
+      hTflat_dualSupp, hTflat_bv, hTflat_FL⟩ :=
+    exists_flattened_bvt_F_dualCone_distribution_with_fourierLaplace_repr
+      (d := d) OS lgc N
+  refine ⟨Tflat, ?_, hTflat_bv, ?_⟩
+  · have hphase :=
+      tflat_totalMomentumPhase_invariant_of_bvt_W_translationInvariant_local
+        (d := d) OS lgc Tflat hTflat_bv
+    have htotal :=
+      OSReconstruction.hasFourierSupportIn_totalMomentumZero_of_phase_invariant
+        d Tflat hphase
+    exact
+      OSReconstruction.hasFourierSupportIn_inter_of_dualCone_and_totalMomentumZero
+        d N hTflat_dualSupp htotal
+  · exact
+      ⟨hCflat_open, hCflat_conv, hCflat_cone, hCflat_salient,
+        by
+          intro z hz
+          exact hTflat_FL z hz⟩
+
 /-- Reindex a flattened sum that only samples the time-coordinate slots. -/
 private theorem sum_over_flat_timeSlots
     {n : ℕ}

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43OS24KernelComparison.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43OS24KernelComparison.lean
@@ -1,0 +1,794 @@
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43SpectralFactorization
+import OSReconstruction.Wightman.Reconstruction.WickRotation.OSToWightmanBoundaryValueLimits
+
+noncomputable section
+
+open scoped Topology FourierTransform LineDeriv
+open Set MeasureTheory
+
+namespace OSReconstruction
+
+/-- The raw OS `xiShift` shell for a successor-right split.  This is the shell
+used by the already compiled Schwinger-side bridge; it is not asserted to lie
+in the forward tube. -/
+private def section43RawXiShiftConfig_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1))) :
+    Fin (n + (m + 1)) → Fin (d + 1) → ℂ :=
+  xiShift ⟨n, Nat.lt_add_of_pos_right (Nat.succ_pos m)⟩ 0
+    (fun i => wickRotatePoint (y i)) ((t : ℂ) * Complex.I)
+
+/-- Chronological reversal of the OS-reflected left block, fixing the right
+tail. -/
+private def section43LeftBlockReversePerm_succRight
+    (n m : ℕ) :
+    Equiv.Perm (Fin (n + (m + 1))) :=
+  (finSumFinEquiv (m := n) (n := m + 1)).symm.trans
+    ((Equiv.sumCongr Fin.revPerm (Equiv.refl (Fin (m + 1)))).trans
+      (finSumFinEquiv (m := n) (n := m + 1)))
+
+@[simp] private theorem section43LeftBlockReversePerm_succRight_castAdd
+    (n m : ℕ) (i : Fin n) :
+    section43LeftBlockReversePerm_succRight n m
+        (Fin.castAdd (m + 1) i) =
+      Fin.castAdd (m + 1) (Fin.rev i) := by
+  simp [section43LeftBlockReversePerm_succRight]
+
+@[simp] private theorem section43LeftBlockReversePerm_succRight_natAdd
+    (n m : ℕ) (j : Fin (m + 1)) :
+    section43LeftBlockReversePerm_succRight n m
+        (Fin.natAdd n j) =
+      Fin.natAdd n j := by
+  simp [section43LeftBlockReversePerm_succRight]
+
+private theorem section43_eq_castAdd_of_val_lt
+    {n m : ℕ} {i : Fin (n + (m + 1))} (hi : i.val < n) :
+    i = Fin.castAdd (m + 1) (⟨i.val, hi⟩ : Fin n) := by
+  ext
+  rfl
+
+private theorem section43_eq_natAdd_of_not_val_lt
+    {n m : ℕ} {i : Fin (n + (m + 1))} (hi : ¬ i.val < n) :
+    i = Fin.natAdd n (⟨i.val - n, by omega⟩ : Fin (m + 1)) := by
+  ext
+  simp [Fin.natAdd]
+  omega
+
+/-- The raw shell after the left block has been put into Borchers
+chronological order. -/
+private def section43OSBorchersTimeShiftConfig_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1))) :
+    Fin (n + (m + 1)) → Fin (d + 1) → ℂ :=
+  fun i =>
+    section43RawXiShiftConfig_succRight d t y
+      (section43LeftBlockReversePerm_succRight n m i)
+
+private def section43FirstIndex_succRight
+    {n m : ℕ} : Fin (n + (m + 1)) :=
+  ⟨0, by omega⟩
+
+/-- A y-dependent diagonal translation making the first imaginary time equal
+to `1`; later support lemmas prove the translated configuration is in the
+forward tube on OS support. -/
+private def section43OSForwardTubeLiftTranslation_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1))) :
+    Fin (d + 1) → ℂ :=
+  fun μ =>
+    if μ = 0 then
+      Complex.I *
+        (((1 : ℝ) -
+          (section43OSBorchersTimeShiftConfig_succRight d t y
+            section43FirstIndex_succRight 0).im : ℝ) : ℂ)
+    else 0
+
+/-- The forward-tube lift used for the Fourier-Laplace side of S5. -/
+private def section43OSForwardTubeLift_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1))) :
+    Fin (n + (m + 1)) → Fin (d + 1) → ℂ :=
+  fun i =>
+    section43OSBorchersTimeShiftConfig_succRight d t y i +
+      section43OSForwardTubeLiftTranslation_succRight d t y
+
+@[simp] private theorem section43OSBorchersTimeShiftConfig_castAdd_time_im_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1)))
+    (i : Fin n) :
+    (section43OSBorchersTimeShiftConfig_succRight d t y
+        (Fin.castAdd (m + 1) i) 0).im =
+      y (Fin.castAdd (m + 1) (Fin.rev i)) 0 := by
+  have hleft : ¬ n ≤ n - (i.val + 1) := by
+    omega
+  simp [section43OSBorchersTimeShiftConfig_succRight,
+    section43RawXiShiftConfig_succRight, xiShift, wickRotatePoint, hleft]
+
+@[simp] private theorem section43OSBorchersTimeShiftConfig_natAdd_time_im_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1)))
+    (j : Fin (m + 1)) :
+    (section43OSBorchersTimeShiftConfig_succRight d t y
+        (Fin.natAdd n j) 0).im =
+      y (Fin.natAdd n j) 0 + t := by
+  simp [section43OSBorchersTimeShiftConfig_succRight,
+    section43RawXiShiftConfig_succRight, xiShift, wickRotatePoint]
+
+@[simp] private theorem section43OSForwardTubeLift_first_time_im_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1))) :
+    (section43OSForwardTubeLift_succRight d t y
+        (section43FirstIndex_succRight : Fin (n + (m + 1))) 0).im = 1 := by
+  simp [section43OSForwardTubeLift_succRight,
+    section43OSForwardTubeLiftTranslation_succRight]
+
+private def section43ComplexDiagonalTranslationFlat
+    (d N : ℕ) [NeZero d]
+    (a : Fin (d + 1) → ℂ) : Fin (N * (d + 1)) → ℂ :=
+  fun i =>
+    let p := finProdFinEquiv.symm i
+    a p.2
+
+private theorem section43ComplexDiagonalTranslationFlat_pair_eq_totalMomentum
+    (d N : ℕ) [NeZero d]
+    (a : Fin (d + 1) → ℂ)
+    (ξ : Fin (N * (d + 1)) → ℝ) :
+    (∑ i : Fin (N * (d + 1)),
+        section43ComplexDiagonalTranslationFlat d N a i * (ξ i : ℂ))
+      =
+    ∑ μ : Fin (d + 1),
+      a μ * (section43TotalMomentumFlat d N ξ μ : ℂ) := by
+  classical
+  calc
+    (∑ i : Fin (N * (d + 1)),
+        section43ComplexDiagonalTranslationFlat d N a i * (ξ i : ℂ))
+        = ∑ p : Fin N × Fin (d + 1),
+            a p.2 * (ξ (finProdFinEquiv p) : ℂ) := by
+          simpa [section43ComplexDiagonalTranslationFlat] using
+            (finProdFinEquiv.sum_comp
+              (fun i : Fin (N * (d + 1)) =>
+                section43ComplexDiagonalTranslationFlat d N a i *
+                  (ξ i : ℂ))).symm
+    _ = ∑ k : Fin N, ∑ μ : Fin (d + 1),
+            a μ * (ξ (finProdFinEquiv (k, μ)) : ℂ) := by
+          simpa using
+            (Finset.sum_product (s := (Finset.univ : Finset (Fin N)))
+              (t := (Finset.univ : Finset (Fin (d + 1))))
+              (f := fun p : Fin N × Fin (d + 1) =>
+                a p.2 * (ξ (finProdFinEquiv p) : ℂ)))
+    _ = ∑ μ : Fin (d + 1), ∑ k : Fin N,
+            a μ * (ξ (finProdFinEquiv (k, μ)) : ℂ) := by
+          rw [Finset.sum_comm]
+    _ = ∑ μ : Fin (d + 1),
+          a μ * (section43TotalMomentumFlat d N ξ μ : ℂ) := by
+          simp [section43TotalMomentumFlat, Finset.mul_sum]
+
+private theorem section43OSForwardTubeLift_phase_cancel_of_totalMomentumZero_succRight
+    (d : ℕ) [NeZero d] {n m : ℕ}
+    (t : ℝ)
+    (y : NPointDomain d (n + (m + 1)))
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ)
+    (hξ_zero :
+      ξ ∈ section43TotalMomentumZeroFlat d (n + (m + 1))) :
+    Complex.exp
+      (Complex.I *
+        ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+          flattenCLEquiv (n + (m + 1)) (d + 1)
+            (section43OSForwardTubeLift_succRight d t y) i *
+            (ξ i : ℂ)) =
+    Complex.exp
+      (Complex.I *
+        ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+          flattenCLEquiv (n + (m + 1)) (d + 1)
+            (section43OSBorchersTimeShiftConfig_succRight d t y) i *
+            (ξ i : ℂ)) := by
+  classical
+  let N := n + (m + 1)
+  let a : Fin (d + 1) → ℂ :=
+    section43OSForwardTubeLiftTranslation_succRight d t y
+  have hsum :
+      (∑ i : Fin (N * (d + 1)),
+          flattenCLEquiv N (d + 1)
+            (section43OSForwardTubeLift_succRight d t y) i *
+            (ξ i : ℂ)) =
+        (∑ i : Fin (N * (d + 1)),
+          flattenCLEquiv N (d + 1)
+            (section43OSBorchersTimeShiftConfig_succRight d t y) i *
+            (ξ i : ℂ)) +
+        ∑ i : Fin (N * (d + 1)),
+          section43ComplexDiagonalTranslationFlat d N a i * (ξ i : ℂ) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl ?_
+    intro i _hi
+    simp [N, a, section43OSForwardTubeLift_succRight,
+      section43ComplexDiagonalTranslationFlat, add_mul]
+  have htrans :
+      (∑ i : Fin (N * (d + 1)),
+          section43ComplexDiagonalTranslationFlat d N a i * (ξ i : ℂ)) = 0 := by
+    rw [section43ComplexDiagonalTranslationFlat_pair_eq_totalMomentum]
+    have hzero : section43TotalMomentumFlat d N ξ = 0 := by
+      simpa [N] using hξ_zero
+    simp [hzero]
+  rw [hsum, htrans, add_zero]
+
+private theorem section43OSConjTensorProduct_support_left_reflected_ordered_succRight
+    (d : ℕ) [NeZero d] {n m : ℕ}
+    (f : euclideanPositiveTimeSubmodule (d := d) n)
+    (g : euclideanPositiveTimeSubmodule (d := d) (m + 1))
+    {y : NPointDomain d (n + (m + 1))}
+    (hy :
+      y ∈ Function.support
+        ((f.1.osConjTensorProduct g.1) :
+          NPointDomain d (n + (m + 1)) → ℂ)) :
+    timeReflectionN d (splitFirst n (m + 1) y) ∈
+      OrderedPositiveTimeRegion d n := by
+  have hprod_ne :
+      (f.1.osConjTensorProduct g.1 : SchwartzNPoint d (n + (m + 1))) y ≠ 0 := by
+    simpa [Function.mem_support] using hy
+  have hmul_ne :
+      f.1.osConj (splitFirst n (m + 1) y) *
+          g.1 (splitLast n (m + 1) y) ≠ 0 := by
+    simpa [SchwartzNPoint.osConjTensorProduct, SchwartzMap.tensorProduct_apply]
+      using hprod_ne
+  have hleft_ne : f.1.osConj (splitFirst n (m + 1) y) ≠ 0 :=
+    (mul_ne_zero_iff.mp hmul_ne).1
+  have hf_ne :
+      f.1 (timeReflectionN d (splitFirst n (m + 1) y)) ≠ 0 := by
+    intro hf_zero
+    exact hleft_ne (by simp [SchwartzNPoint.osConj_apply, hf_zero])
+  exact f.2 (subset_tsupport _ (Function.mem_support.mpr hf_ne))
+
+private theorem section43OSConjTensorProduct_support_right_ordered_succRight
+    (d : ℕ) [NeZero d] {n m : ℕ}
+    (f : euclideanPositiveTimeSubmodule (d := d) n)
+    (g : euclideanPositiveTimeSubmodule (d := d) (m + 1))
+    {y : NPointDomain d (n + (m + 1))}
+    (hy :
+      y ∈ Function.support
+        ((f.1.osConjTensorProduct g.1) :
+          NPointDomain d (n + (m + 1)) → ℂ)) :
+    splitLast n (m + 1) y ∈
+      OrderedPositiveTimeRegion d (m + 1) := by
+  have hprod_ne :
+      (f.1.osConjTensorProduct g.1 : SchwartzNPoint d (n + (m + 1))) y ≠ 0 := by
+    simpa [Function.mem_support] using hy
+  have hmul_ne :
+      f.1.osConj (splitFirst n (m + 1) y) *
+          g.1 (splitLast n (m + 1) y) ≠ 0 := by
+    simpa [SchwartzNPoint.osConjTensorProduct, SchwartzMap.tensorProduct_apply]
+      using hprod_ne
+  have hright_ne : g.1 (splitLast n (m + 1) y) ≠ 0 :=
+    (mul_ne_zero_iff.mp hmul_ne).2
+  exact g.2 (subset_tsupport _ (Function.mem_support.mpr hright_ne))
+
+private theorem section43OSBorchersTimeShiftConfig_strictOrdered_of_osSupport_succRight
+    (d : ℕ) [NeZero d] {n m : ℕ}
+    (f : euclideanPositiveTimeSubmodule (d := d) n)
+    (g : euclideanPositiveTimeSubmodule (d := d) (m + 1))
+    {t : ℝ} (ht : 0 < t)
+    {y : NPointDomain d (n + (m + 1))}
+    (hy :
+      y ∈ Function.support
+        ((f.1.osConjTensorProduct g.1) :
+          NPointDomain d (n + (m + 1)) → ℂ)) :
+    StrictMono
+      (fun i : Fin (n + (m + 1)) =>
+        (section43OSBorchersTimeShiftConfig_succRight d t y i 0).im) := by
+  intro i j hij
+  have hij_val : i.val < j.val := hij
+  have hleftOrd :=
+    section43OSConjTensorProduct_support_left_reflected_ordered_succRight
+      d f g hy
+  have hrightOrd :=
+    section43OSConjTensorProduct_support_right_ordered_succRight
+      d f g hy
+  by_cases hj_left : j.val < n
+  · have hi_left : i.val < n := lt_trans hij_val hj_left
+    let ii : Fin n := ⟨i.val, hi_left⟩
+    let jj : Fin n := ⟨j.val, hj_left⟩
+    have hi_eq : i = Fin.castAdd (m + 1) ii :=
+      section43_eq_castAdd_of_val_lt (m := m) hi_left
+    have hj_eq : j = Fin.castAdd (m + 1) jj :=
+      section43_eq_castAdd_of_val_lt (m := m) hj_left
+    have hij_tail : ii < jj := by
+      change i.val < j.val
+      exact hij_val
+    have hrev : Fin.rev jj < Fin.rev ii := by
+      rw [Fin.rev_lt_iff]
+      simpa [ii, jj] using hij_tail
+    have hneg :=
+      (hleftOrd (Fin.rev jj)).2 (Fin.rev ii) hrev
+    have hneg' :
+        -(y (Fin.castAdd (m + 1) (Fin.rev jj)) 0) <
+          -(y (Fin.castAdd (m + 1) (Fin.rev ii)) 0) := by
+      simpa [timeReflectionN, timeReflection, splitFirst] using hneg
+    rw [hi_eq, hj_eq]
+    simp
+    nlinarith
+  · by_cases hi_left : i.val < n
+    · let ii : Fin n := ⟨i.val, hi_left⟩
+      let jj : Fin (m + 1) := ⟨j.val - n, by omega⟩
+      have hi_eq : i = Fin.castAdd (m + 1) ii :=
+        section43_eq_castAdd_of_val_lt (m := m) hi_left
+      have hj_eq : j = Fin.natAdd n jj :=
+        section43_eq_natAdd_of_not_val_lt (m := m) hj_left
+      have hleft_pos : 0 <
+          timeReflectionN d (splitFirst n (m + 1) y) (Fin.rev ii) 0 :=
+        (hleftOrd (Fin.rev ii)).1
+      have hleft_neg :
+          y (Fin.castAdd (m + 1) (Fin.rev ii)) 0 < 0 := by
+        have hneg : 0 < -(y (Fin.castAdd (m + 1) (Fin.rev ii)) 0) := by
+          simpa [timeReflectionN, timeReflection, splitFirst] using hleft_pos
+        nlinarith
+      have hright_pos : 0 < y (Fin.natAdd n jj) 0 :=
+        (hrightOrd jj).1
+      rw [hi_eq, hj_eq]
+      simp
+      nlinarith
+    · let ii : Fin (m + 1) := ⟨i.val - n, by omega⟩
+      let jj : Fin (m + 1) := ⟨j.val - n, by omega⟩
+      have hi_eq : i = Fin.natAdd n ii :=
+        section43_eq_natAdd_of_not_val_lt (m := m) hi_left
+      have hj_eq : j = Fin.natAdd n jj :=
+        section43_eq_natAdd_of_not_val_lt (m := m) hj_left
+      have hij_tail : ii < jj := by
+        change i.val - n < j.val - n
+        omega
+      have hright_lt :=
+        (hrightOrd ii).2 jj hij_tail
+      have hright_lt' :
+          y (Fin.natAdd n ii) 0 < y (Fin.natAdd n jj) 0 := by
+        simpa [splitLast] using hright_lt
+      rw [hi_eq, hj_eq]
+      simp
+      nlinarith
+
+private def section43OSForwardTubeLiftRealConfig_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1))) :
+    NPointDomain d (n + (m + 1)) :=
+  fun i μ =>
+    if μ = 0 then
+      (section43OSForwardTubeLift_succRight d t y i 0).im
+    else
+      (section43OSForwardTubeLift_succRight d t y i μ).re
+
+private theorem section43OSForwardTubeLift_eq_wickRotatePoint_succRight
+    (d : ℕ) {n m : ℕ} (t : ℝ)
+    (y : NPointDomain d (n + (m + 1))) :
+    section43OSForwardTubeLift_succRight d t y =
+      fun i => wickRotatePoint
+        (section43OSForwardTubeLiftRealConfig_succRight d t y i) := by
+  ext i μ
+  by_cases hμ : μ = 0
+  · subst hμ
+    by_cases hi : n ≤ ((section43LeftBlockReversePerm_succRight n m) i).val
+    · by_cases h0 :
+        n ≤ ((section43LeftBlockReversePerm_succRight n m)
+          (section43FirstIndex_succRight : Fin (n + (m + 1)))).val
+      · simp [section43OSForwardTubeLiftRealConfig_succRight,
+          section43OSForwardTubeLift_succRight,
+          section43OSForwardTubeLiftTranslation_succRight,
+          section43OSBorchersTimeShiftConfig_succRight,
+          section43RawXiShiftConfig_succRight, xiShift, wickRotatePoint, hi, h0]
+        ring_nf
+      · simp [section43OSForwardTubeLiftRealConfig_succRight,
+          section43OSForwardTubeLift_succRight,
+          section43OSForwardTubeLiftTranslation_succRight,
+          section43OSBorchersTimeShiftConfig_succRight,
+          section43RawXiShiftConfig_succRight, xiShift, wickRotatePoint, hi, h0]
+        ring_nf
+    · by_cases h0 :
+        n ≤ ((section43LeftBlockReversePerm_succRight n m)
+          (section43FirstIndex_succRight : Fin (n + (m + 1)))).val
+      · simp [section43OSForwardTubeLiftRealConfig_succRight,
+          section43OSForwardTubeLift_succRight,
+          section43OSForwardTubeLiftTranslation_succRight,
+          section43OSBorchersTimeShiftConfig_succRight,
+          section43RawXiShiftConfig_succRight, xiShift, wickRotatePoint, hi, h0]
+        ring_nf
+      · simp [section43OSForwardTubeLiftRealConfig_succRight,
+          section43OSForwardTubeLift_succRight,
+          section43OSForwardTubeLiftTranslation_succRight,
+          section43OSBorchersTimeShiftConfig_succRight,
+          section43RawXiShiftConfig_succRight, xiShift, wickRotatePoint, hi, h0]
+        ring_nf
+  · simp [section43OSForwardTubeLiftRealConfig_succRight,
+      section43OSForwardTubeLift_succRight,
+      section43OSForwardTubeLiftTranslation_succRight,
+      section43OSBorchersTimeShiftConfig_succRight,
+      section43RawXiShiftConfig_succRight, xiShift, wickRotatePoint, hμ]
+
+private theorem section43OSForwardTubeLift_mem_forwardTube_of_osSupport_succRight
+    (d : ℕ) [NeZero d] {n m : ℕ}
+    (f : euclideanPositiveTimeSubmodule (d := d) n)
+    (g : euclideanPositiveTimeSubmodule (d := d) (m + 1))
+    {t : ℝ} (ht : 0 < t)
+    {y : NPointDomain d (n + (m + 1))}
+    (hy :
+      y ∈ Function.support
+        ((f.1.osConjTensorProduct g.1) :
+          NPointDomain d (n + (m + 1)) → ℂ)) :
+    section43OSForwardTubeLift_succRight d t y ∈
+      TubeDomainSetPi (ForwardConeAbs d (n + (m + 1))) := by
+  let N := n + (m + 1)
+  let xs : NPointDomain d N :=
+    section43OSForwardTubeLiftRealConfig_succRight d t y
+  have hborch_strict :=
+    section43OSBorchersTimeShiftConfig_strictOrdered_of_osSupport_succRight
+      d f g ht hy
+  have hlift_eq :=
+    section43OSForwardTubeLift_eq_wickRotatePoint_succRight d t y
+  have hord : ∀ k j : Fin N, k < j → xs k 0 < xs j 0 := by
+    intro k j hkj
+    have hstrict := hborch_strict hkj
+    dsimp [xs, section43OSForwardTubeLiftRealConfig_succRight]
+    simp [section43OSForwardTubeLift_succRight]
+    nlinarith
+  have hpos : ∀ k : Fin N, xs k 0 > 0 := by
+    intro k
+    let first : Fin N := section43FirstIndex_succRight
+    by_cases hk : k = first
+    · subst hk
+      have hfirst :=
+        section43OSForwardTubeLift_first_time_im_succRight
+          (d := d) (n := n) (m := m) t y
+      change (section43OSForwardTubeLift_succRight d t y first 0).im > 0
+      rw [hfirst]
+      norm_num
+    · have hkval : k.val ≠ 0 := by
+        intro hk0
+        apply hk
+        ext
+        simpa [first, section43FirstIndex_succRight] using hk0
+      have hfirst_lt : first < k := by
+        change first.val < k.val
+        simpa [first, section43FirstIndex_succRight] using
+          Nat.pos_of_ne_zero hkval
+      have hfirst_time : xs first 0 = 1 := by
+        have hfirst :=
+          section43OSForwardTubeLift_first_time_im_succRight
+            (d := d) (n := n) (m := m) t y
+        change (section43OSForwardTubeLift_succRight d t y first 0).im = 1
+        exact hfirst
+      have hk_gt := hord first k hfirst_lt
+      nlinarith
+  have hft : (fun k => wickRotatePoint (xs k)) ∈ ForwardTube d N :=
+    euclidean_ordered_in_forwardTube (d := d) (n := N) xs hord hpos
+  rw [hlift_eq]
+  simpa [N, TubeDomainSetPi, forwardTube_eq_imPreimage] using hft
+
+private theorem section43OSForwardTubeLift_multiDimPsiZExt_apply_of_spectralRegion_succRight
+    (d : ℕ) [NeZero d]
+    (OS : OsterwalderSchraderAxioms d) (lgc : OSLinearGrowthCondition d OS)
+    {n m : ℕ}
+    (f : euclideanPositiveTimeSubmodule (d := d) n)
+    (g : euclideanPositiveTimeSubmodule (d := d) (m + 1))
+    {t : ℝ} (ht : 0 < t)
+    (Tflat : SchwartzMap
+        (Fin ((n + (m + 1)) * (d + 1)) → ℝ) ℂ →L[ℂ] ℂ)
+    (hTflat_FL :
+      section43TflatFourierLaplaceWitness OS lgc (n + (m + 1)) Tflat)
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ)
+    (hξ :
+      ξ ∈ section43WightmanSpectralRegion d (n + (m + 1)))
+    (y : NPointDomain d (n + (m + 1)))
+    (hy :
+      y ∈ Function.support
+        ((f.1.osConjTensorProduct g.1) :
+          NPointDomain d (n + (m + 1)) → ℂ)) :
+    multiDimPsiZExt
+      ((flattenCLEquivReal (n + (m + 1)) (d + 1)) ''
+        ForwardConeAbs d (n + (m + 1)))
+      hTflat_FL.hCflat_open hTflat_FL.hCflat_conv
+      hTflat_FL.hCflat_cone hTflat_FL.hCflat_salient
+      (flattenCLEquiv (n + (m + 1)) (d + 1)
+        (section43OSForwardTubeLift_succRight d t y)) ξ =
+    Complex.exp
+      (Complex.I *
+        ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+          flattenCLEquiv (n + (m + 1)) (d + 1)
+            (section43OSBorchersTimeShiftConfig_succRight d t y) i *
+            (ξ i : ℂ)) := by
+  let N := n + (m + 1)
+  have hξ_spec :
+      ξ ∈
+        DualConeFlat ((flattenCLEquivReal N (d + 1)) ''
+            ForwardConeAbs d N) ∩
+          section43TotalMomentumZeroFlat d N := by
+    simpa [N, section43WightmanSpectralRegion] using hξ
+  have hz_tube :
+      section43OSForwardTubeLift_succRight d t y ∈
+        TubeDomainSetPi (ForwardConeAbs d N) := by
+    simpa [N] using
+      section43OSForwardTubeLift_mem_forwardTube_of_osSupport_succRight
+        (d := d) f g ht hy
+  have hz_flat :
+      flattenCLEquiv N (d + 1)
+          (section43OSForwardTubeLift_succRight d t y) ∈
+        SCV.TubeDomain
+          ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N) := by
+    exact flattenCLEquiv_mem_tubeDomain_image (n := N) (r := d) hz_tube
+  suffices h :
+      multiDimPsiZExt
+        ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N)
+        hTflat_FL.hCflat_open hTflat_FL.hCflat_conv
+        hTflat_FL.hCflat_cone hTflat_FL.hCflat_salient
+        (flattenCLEquiv N (d + 1)
+          (section43OSForwardTubeLift_succRight d t y)) ξ =
+      Complex.exp
+        (Complex.I *
+          ∑ i : Fin (N * (d + 1)),
+            flattenCLEquiv N (d + 1)
+              (section43OSBorchersTimeShiftConfig_succRight d t y) i *
+              (ξ i : ℂ)) by
+    simpa [N] using h
+  calc
+    multiDimPsiZExt
+        ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N)
+        hTflat_FL.hCflat_open hTflat_FL.hCflat_conv
+        hTflat_FL.hCflat_cone hTflat_FL.hCflat_salient
+        (flattenCLEquiv N (d + 1)
+          (section43OSForwardTubeLift_succRight d t y)) ξ
+        =
+      Complex.exp
+        (Complex.I *
+          ∑ i : Fin (N * (d + 1)),
+            flattenCLEquiv N (d + 1)
+              (section43OSForwardTubeLift_succRight d t y) i *
+              (ξ i : ℂ)) := by
+          exact
+            multiDimPsiZExt_apply_of_mem_dualCone
+              ((flattenCLEquivReal N (d + 1)) '' ForwardConeAbs d N)
+              hTflat_FL.hCflat_open hTflat_FL.hCflat_conv
+              hTflat_FL.hCflat_cone hTflat_FL.hCflat_salient
+              (flattenCLEquiv N (d + 1)
+                (section43OSForwardTubeLift_succRight d t y))
+              hz_flat hξ_spec.1
+    _ =
+      Complex.exp
+        (Complex.I *
+          ∑ i : Fin (N * (d + 1)),
+            flattenCLEquiv N (d + 1)
+              (section43OSBorchersTimeShiftConfig_succRight d t y) i *
+              (ξ i : ℂ)) := by
+          simpa [N] using
+            section43OSForwardTubeLift_phase_cancel_of_totalMomentumZero_succRight
+              (d := d) (n := n) (m := m) t y ξ
+              (by simpa [N] using hξ_spec.2)
+
+/-- The local Section 4.3 flat time-shift direction agrees with the semigroup
+time-shift convention used by `timeShiftFlatOrbit`. -/
+theorem section43FlatTimeShiftDirection_eq_flatTimeShiftDirection
+    (d m : ℕ) :
+    section43FlatTimeShiftDirection d m = flatTimeShiftDirection d m := by
+  ext i
+  rfl
+
+/-- The embedded successor-right time-shift direction agrees with the
+`timeShiftFlatOrbit` direction from the boundary-value layer. -/
+theorem section43SuccRightTimeShiftFlatDirection_eq_flatTimeShiftDirection
+    (d n m : ℕ) [NeZero d] :
+    section43SuccRightTimeShiftFlatDirection d n m =
+      castFinCLE (Nat.add_mul n (m + 1) (d + 1)).symm
+        (zeroHeadBlockShift
+          (m := n * (d + 1)) (n := (m + 1) * (d + 1))
+          (flatTimeShiftDirection d (m + 1))) := by
+  ext i
+  simp [section43SuccRightTimeShiftFlatDirection,
+    section43FlatTimeShiftDirection_eq_flatTimeShiftDirection]
+
+/-- The `eta` CLM is exactly `-lambda/(2π)` for the
+`timeShiftFlatOrbit` pairing convention. -/
+theorem section43SuccRightEtaCLM_eq_timeShiftFlatOrbit_eta
+    (d n m : ℕ) [NeZero d]
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ) :
+    section43SuccRightEtaCLM d n m ξ =
+      -(∑ i : Fin ((n + (m + 1)) * (d + 1)),
+          (((castFinCLE (Nat.add_mul n (m + 1) (d + 1)).symm)
+            (zeroHeadBlockShift
+              (m := n * (d + 1)) (n := (m + 1) * (d + 1))
+              (flatTimeShiftDirection d (m + 1)))) i) * ξ i) /
+        (2 * Real.pi) := by
+  rw [section43SuccRightEtaCLM_apply]
+  rw [section43SuccRightTimeShiftFlatDirection_eq_flatTimeShiftDirection]
+
+private theorem section43SuccRightEtaCLM_nonneg_of_mem_dualCone
+    (d n m : ℕ) [NeZero d]
+    {ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ}
+    (hξ :
+      ξ ∈ DualConeFlat
+        ((flattenCLEquivReal (n + (m + 1)) (d + 1)) ''
+          ForwardConeAbs d (n + (m + 1)))) :
+    0 ≤ section43SuccRightEtaCLM d n m ξ := by
+  have hlam :=
+    zeroHeadBlockShift_flatTimeShiftDirection_pairing_nonpos_of_mem_dualCone
+      (d := d) (n := n) (m := m + 1) (ξ := ξ) hξ
+  have hlam' :
+      ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+        section43SuccRightTimeShiftFlatDirection d n m i * ξ i ≤ 0 := by
+    simpa [section43SuccRightTimeShiftFlatDirection_eq_flatTimeShiftDirection]
+      using hlam
+  rw [section43SuccRightEtaCLM_apply]
+  exact div_nonneg (neg_nonneg.mpr hlam') Real.two_pi_pos.le
+
+private theorem section43SuccRightEtaCLM_nonneg_of_mem_spectralRegion
+    (d n m : ℕ) [NeZero d]
+    {ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ}
+    (hξ : ξ ∈ section43WightmanSpectralRegion d (n + (m + 1))) :
+    0 ≤ section43SuccRightEtaCLM d n m ξ :=
+  section43SuccRightEtaCLM_nonneg_of_mem_dualCone d n m hξ.1
+
+private theorem section43TailShiftPhase_eq_psiZTimeTest_of_spectralRegion_succRight
+    (d n m : ℕ) [NeZero d]
+    {t : ℝ} (ht : 0 < t)
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ)
+    (hξ :
+      ξ ∈ section43WightmanSpectralRegion d (n + (m + 1))) :
+    let lamξ : ℝ :=
+      ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+        (((castFinCLE (Nat.add_mul n (m + 1) (d + 1)).symm)
+          (zeroHeadBlockShift
+            (m := n * (d + 1)) (n := (m + 1) * (d + 1))
+            (flatTimeShiftDirection d (m + 1)))) i) * ξ i
+    let ηξ : ℝ := -lamξ / (2 * Real.pi)
+    Complex.exp (-(2 * Real.pi * t : ℂ) * (ηξ : ℂ)) =
+      section43PsiZTimeTest t ht ηξ := by
+  let lamξ : ℝ :=
+    ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+      (((castFinCLE (Nat.add_mul n (m + 1) (d + 1)).symm)
+        (zeroHeadBlockShift
+          (m := n * (d + 1)) (n := (m + 1) * (d + 1))
+          (flatTimeShiftDirection d (m + 1)))) i) * ξ i
+  let ηξ : ℝ := -lamξ / (2 * Real.pi)
+  have heta :
+      section43SuccRightEtaCLM d n m ξ = ηξ := by
+    dsimp [ηξ, lamξ]
+    exact section43SuccRightEtaCLM_eq_timeShiftFlatOrbit_eta d n m ξ
+  have hη_nonneg : 0 ≤ ηξ := by
+    rw [← heta]
+    exact section43SuccRightEtaCLM_nonneg_of_mem_spectralRegion d n m hξ
+  change Complex.exp (-(2 * Real.pi * t : ℂ) * (ηξ : ℂ)) =
+    section43PsiZTimeTest t ht ηξ
+  rw [section43PsiZTimeTest_apply]
+  rw [SCV.psiZ_eq_exp_of_nonneg hη_nonneg]
+  congr 1
+  have harg :
+      Complex.I * (2 * (Real.pi : ℂ) * ((t : ℂ) * Complex.I)) =
+        -(2 * (Real.pi : ℂ) * (t : ℂ)) := by
+    rw [show
+      2 * (Real.pi : ℂ) * ((t : ℂ) * Complex.I) =
+        (2 * (Real.pi : ℂ) * (t : ℂ)) * Complex.I by ring]
+    rw [show
+      Complex.I * (2 * (Real.pi : ℂ) * (t : ℂ) * Complex.I) =
+        (2 * (Real.pi : ℂ) * (t : ℂ)) * (Complex.I * Complex.I) by ring]
+    rw [Complex.I_mul_I]
+    ring
+  rw [harg]
+
+/-- The explicit time-shift/`ψ_Z` Fourier kernel agrees with the OS I `(4.24)`
+kernel on the Section 4.3 Wightman spectral region. -/
+theorem section43_timeShiftKernel_psiZ_eq_OS24Kernel_on_spectralRegion_succRight
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    {t : ℝ} (ht : 0 < t)
+    (KψZ_t : SchwartzMap
+      (Fin ((n + (m + 1)) * (d + 1)) → ℝ) ℂ)
+    (hKψZ_eval :
+      ∀ ξ,
+        KψZ_t ξ =
+          ∫ τ : ℝ,
+            timeShiftFlatOrbit (d := d) φ ψ τ ξ *
+              (SchwartzMap.fourierTransformCLM ℂ
+                (section43PsiZTimeTest t ht)) τ) :
+    Set.EqOn
+      (fun ξ => KψZ_t ξ)
+      (fun ξ => section43OS24Kernel_succRight d n m φ ψ t ht ξ)
+      (section43WightmanSpectralRegion d (n + (m + 1))) := by
+  intro ξ hξ
+  let ψZt : SchwartzMap ℝ ℂ := section43PsiZTimeTest t ht
+  let base : ℂ :=
+    physicsFourierFlatCLM
+      (reindexSchwartzFin
+        (Nat.add_mul n (m + 1) (d + 1)).symm
+        (((flattenSchwartzNPoint (d := d) φ.borchersConj).tensorProduct
+          (flattenSchwartzNPoint (d := d) ψ)))) ξ
+  let lam : ℝ :=
+    ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+      (((castFinCLE (Nat.add_mul n (m + 1) (d + 1)).symm)
+        (zeroHeadBlockShift
+          (m := n * (d + 1)) (n := (m + 1) * (d + 1))
+          (flatTimeShiftDirection d (m + 1)))) i) * ξ i
+  have hbase :
+      base =
+        star
+          ((section43FrequencyRepresentative (d := d) n φ)
+            (section43LeftBorchersBlock d n (m + 1) (Nat.succ_pos m)
+              (section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ))) *
+          (section43FrequencyRepresentative (d := d) (m + 1) ψ)
+            (section43RightTailBlock d n (m + 1)
+              (section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ)) := by
+    dsimp [base]
+    simpa using
+      physicsFourierFlatCLM_borchersTensor_eq_frequencyRepresentatives_on_spectralRegion
+        (d := d) (n := n) (m := m) φ ψ hξ
+  have heta :
+      section43SuccRightEtaCLM d n m ξ = -lam / (2 * Real.pi) := by
+    dsimp [lam]
+    exact section43SuccRightEtaCLM_eq_timeShiftFlatOrbit_eta d n m ξ
+  have hphase :
+      (∫ τ : ℝ,
+          timeShiftFlatOrbit (d := d) φ ψ τ ξ *
+            (SchwartzMap.fourierTransformCLM ℂ ψZt) τ) =
+        section43HorizontalPhasePairingCLM base lam
+          ((SchwartzMap.fourierTransformCLM ℂ) ψZt) := by
+    calc
+      (∫ τ : ℝ,
+          timeShiftFlatOrbit (d := d) φ ψ τ ξ *
+            (SchwartzMap.fourierTransformCLM ℂ ψZt) τ)
+          =
+        ∫ τ : ℝ,
+          base *
+            (Complex.exp (-(Complex.I * (lam : ℂ) * (τ : ℂ))) *
+              (SchwartzMap.fourierTransformCLM ℂ ψZt) τ) := by
+            refine MeasureTheory.integral_congr_ae ?_
+            filter_upwards with τ
+            rw [timeShiftFlatOrbit_apply_phase]
+            dsimp only [base, lam]
+            ac_rfl
+      _ =
+        base *
+          ∫ τ : ℝ,
+            Complex.exp (-(Complex.I * (lam : ℂ) * (τ : ℂ))) *
+              (SchwartzMap.fourierTransformCLM ℂ ψZt) τ := by
+            exact
+              MeasureTheory.integral_const_mul
+                (μ := MeasureTheory.volume) base
+                (fun τ : ℝ =>
+                  Complex.exp (-(Complex.I * (lam : ℂ) * (τ : ℂ))) *
+                    (SchwartzMap.fourierTransformCLM ℂ ψZt) τ)
+      _ =
+        section43HorizontalPhasePairingCLM base lam
+          ((SchwartzMap.fourierTransformCLM ℂ) ψZt) := by
+            exact
+              (section43HorizontalPhasePairingCLM_apply base lam
+                ((SchwartzMap.fourierTransformCLM ℂ) ψZt)).symm
+  calc
+    KψZ_t ξ
+        =
+      ∫ τ : ℝ,
+        timeShiftFlatOrbit (d := d) φ ψ τ ξ *
+          (SchwartzMap.fourierTransformCLM ℂ (section43PsiZTimeTest t ht)) τ :=
+          hKψZ_eval ξ
+    _ = section43HorizontalPhasePairingCLM base lam
+          ((SchwartzMap.fourierTransformCLM ℂ) ψZt) := by
+          simpa [ψZt] using hphase
+    _ = base * ψZt (-lam / (2 * Real.pi)) := by
+          rw [section43HorizontalPhasePairingCLM_fourierTransform]
+    _ =
+      (star
+          ((section43FrequencyRepresentative (d := d) n φ)
+            (section43LeftBorchersBlock d n (m + 1) (Nat.succ_pos m)
+              (section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ))) *
+        (section43FrequencyRepresentative (d := d) (m + 1) ψ)
+          (section43RightTailBlock d n (m + 1)
+            (section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ))) *
+        ψZt (-lam / (2 * Real.pi)) := by
+          rw [hbase]
+    _ =
+      ψZt (-lam / (2 * Real.pi)) *
+        (star
+          ((section43FrequencyRepresentative (d := d) n φ)
+            (section43LeftBorchersBlock d n (m + 1) (Nat.succ_pos m)
+              (section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ))) *
+        (section43FrequencyRepresentative (d := d) (m + 1) ψ)
+          (section43RightTailBlock d n (m + 1)
+            (section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ))) := by
+          rw [mul_comm]
+    _ = section43OS24Kernel_succRight d n m φ ψ t ht ξ := by
+          rw [section43OS24Kernel_succRight_apply_of_mem_spectralRegion
+            (d := d) (n := n) (m := m) (φ := φ) (ψ := ψ) ht ξ hξ]
+          dsimp [section43OS24VisibleKernel_succRight, ψZt]
+          rw [heta]
+
+end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43SpectralFactorization.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43SpectralFactorization.lean
@@ -11,6 +11,16 @@ namespace OSReconstruction
     (x : Fin a → ℝ) (i : Fin b) :
     castFinCLE h x i = x ((finCongr h).symm i) := rfl
 
+/-- Reindex an `NPointDomain` along an equality of its point count. -/
+abbrev section43CastNPointCLE (d : ℕ) {a b : ℕ} (h : a = b) :
+    NPointDomain d a ≃L[ℝ] NPointDomain d b :=
+  ContinuousLinearEquiv.piCongrLeft ℝ (fun _ : Fin b => SpacetimeDim d) (finCongr h)
+
+@[simp] theorem section43CastNPointCLE_apply
+    (d : ℕ) {a b : ℕ} (h : a = b)
+    (q : NPointDomain d a) (i : Fin b) :
+    section43CastNPointCLE d h q i = q ((finCongr h).symm i) := rfl
+
 /-!
 # Section 4.3 Spectral Factorization Coordinates
 
@@ -1161,6 +1171,385 @@ noncomputable def section43VisibleProductZeroLeftSchwartz
           (0 : NPointDomain d 0)) *
         (section43FrequencyRepresentative (d := d) (m + 1) ψ) q := by
   simp [section43VisibleProductZeroLeftSchwartz, smul_eq_mul]
+
+/-- The one-variable Paley test at positive imaginary height `t`, with the
+`2π` scaling used by the Section 4.3 Fourier normalization. -/
+noncomputable def section43PsiZTimeTest (t : ℝ) (ht : 0 < t) :
+    SchwartzMap ℝ ℂ :=
+  SCV.schwartzPsiZ
+    (((2 * Real.pi : ℂ) * (t * Complex.I)))
+    (by
+      simpa [Complex.mul_im, ht.ne'] using
+        mul_pos Real.two_pi_pos ht)
+
+@[simp] theorem section43PsiZTimeTest_apply
+    (t : ℝ) (ht : 0 < t) (η : ℝ) :
+    section43PsiZTimeTest t ht η =
+      SCV.psiZ (((2 * Real.pi : ℂ) * (t * Complex.I))) η := by
+  simp [section43PsiZTimeTest, SCV.schwartzPsiZ_apply]
+
+/-- The flat positive-time shift direction used locally in the Section 4.3
+right block.  It matches the semigroup convention: shifting forward in
+Euclidean time translates flat functions by `-e_time`. -/
+abbrev section43FlatTimeShiftDirection (d n : ℕ) :
+    Fin (n * (d + 1)) → ℝ :=
+  fun k => if (finProdFinEquiv.symm k).2 = 0 then (-1 : ℝ) else 0
+
+/-- The flat right-time-shift direction embedded in the full
+`(n + (m + 1))` frequency coordinate. -/
+noncomputable def section43SuccRightTimeShiftFlatDirection
+    (d n m : ℕ) [NeZero d] :
+    Fin ((n + (m + 1)) * (d + 1)) → ℝ :=
+  castFinCLE (Nat.add_mul n (m + 1) (d + 1)).symm
+    (zeroHeadBlockShift
+      (m := n * (d + 1)) (n := (m + 1) * (d + 1))
+      (section43FlatTimeShiftDirection d (m + 1)))
+
+/-- Pairing with the embedded right-time-shift direction. -/
+noncomputable def section43SuccRightTimeShiftPairingCLM
+    (d n m : ℕ) [NeZero d] :
+    (Fin ((n + (m + 1)) * (d + 1)) → ℝ) →L[ℝ] ℝ :=
+  ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+    (section43SuccRightTimeShiftFlatDirection d n m i) •
+      ContinuousLinearMap.proj (R := ℝ)
+        (ι := Fin ((n + (m + 1)) * (d + 1))) (φ := fun _ => ℝ) i
+
+@[simp] theorem section43SuccRightTimeShiftPairingCLM_apply
+    (d n m : ℕ) [NeZero d]
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ) :
+    section43SuccRightTimeShiftPairingCLM d n m ξ =
+      ∑ i : Fin ((n + (m + 1)) * (d + 1)),
+        section43SuccRightTimeShiftFlatDirection d n m i * ξ i := by
+  simp [section43SuccRightTimeShiftPairingCLM]
+
+/-- The nonnegative Paley frequency on the spectral cone is
+`η = -λ / (2π)`, where `λ` is the right-time-shift pairing. -/
+noncomputable def section43SuccRightEtaCLM
+    (d n m : ℕ) [NeZero d] :
+    (Fin ((n + (m + 1)) * (d + 1)) → ℝ) →L[ℝ] ℝ :=
+  (-(1 / (2 * Real.pi))) •
+    section43SuccRightTimeShiftPairingCLM d n m
+
+@[simp] theorem section43SuccRightEtaCLM_apply
+    (d n m : ℕ) [NeZero d]
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ) :
+    section43SuccRightEtaCLM d n m ξ =
+      -(∑ i : Fin ((n + (m + 1)) * (d + 1)),
+          section43SuccRightTimeShiftFlatDirection d n m i * ξ i) /
+        (2 * Real.pi) := by
+  simp [section43SuccRightEtaCLM, div_eq_mul_inv, mul_assoc, mul_left_comm,
+    mul_comm]
+
+theorem section43PsiZTimeTest_comp_eta_hasTemperateGrowth
+    (d n m : ℕ) [NeZero d] {t : ℝ} (ht : 0 < t) :
+    (fun ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ =>
+      section43PsiZTimeTest t ht (section43SuccRightEtaCLM d n m ξ)
+    ).HasTemperateGrowth :=
+  (section43PsiZTimeTest t ht).hasTemperateGrowth.comp
+    (section43SuccRightEtaCLM d n m).hasTemperateGrowth
+
+private theorem section43_fourierInv_eq_cexp_integral
+    (χ : SchwartzMap ℝ ℂ) (ξ : ℝ) :
+    FourierTransform.fourierInv χ ξ =
+      ∫ x : ℝ, Complex.exp (2 * Real.pi * Complex.I * ξ * x) * χ x := by
+  have hcoe :
+      FourierTransform.fourierInv χ ξ =
+        FourierTransform.fourierInv (χ : ℝ → ℂ) ξ := by
+    simpa using congrArg (fun g => g ξ) (SchwartzMap.fourierInv_coe (f := χ))
+  rw [hcoe, Real.fourierInv_eq' (f := (χ : ℝ → ℂ)) (w := ξ)]
+  congr 1
+  ext v
+  have hinner : ∀ a b : ℝ, @inner ℝ ℝ _ a b = b * a := by
+    intro a b
+    simp [inner, mul_comm]
+  simp only [smul_eq_mul, hinner, Complex.ofReal_mul, Complex.ofReal_ofNat]
+  ring_nf
+
+/-- One-variable phase evaluation for the Section 4.3 horizontal kernel:
+pairing a pure oscillatory phase against the Fourier transform of a Schwartz
+test recovers the test at the matching frequency. -/
+theorem section43_integral_phase_mul_fourierTransform_eq_eval
+    (χ : SchwartzMap ℝ ℂ)
+    (lam : ℝ) :
+    ∫ τ : ℝ,
+      Complex.exp (-(Complex.I * (lam : ℂ) * τ)) *
+        (SchwartzMap.fourierTransformCLM ℂ χ) τ =
+      χ (-lam / (2 * Real.pi)) := by
+  have hfourierInv :
+      FourierTransform.fourierInv
+          ((SchwartzMap.fourierTransformCLM ℂ) χ) (-lam / (2 * Real.pi)) =
+        χ (-lam / (2 * Real.pi)) := by
+    set f := (SchwartzMap.fourierTransformCLM ℂ) χ
+    have hf : FourierTransform.fourierInv f = χ := by
+      simp [f, FourierTransform.fourierInv_fourier_eq χ]
+    exact congrArg (fun g : SchwartzMap ℝ ℂ => g (-lam / (2 * Real.pi))) hf
+  rw [section43_fourierInv_eq_cexp_integral
+      (χ := (SchwartzMap.fourierTransformCLM ℂ) χ)
+      (ξ := -lam / (2 * Real.pi))] at hfourierInv
+  calc
+    ∫ τ : ℝ,
+        Complex.exp (-(Complex.I * (lam : ℂ) * τ)) *
+          (SchwartzMap.fourierTransformCLM ℂ χ) τ
+      =
+        ∫ τ : ℝ,
+          Complex.exp
+              (2 * Real.pi * Complex.I *
+                ((-lam / (2 * Real.pi) : ℝ) : ℂ) * (τ : ℂ)) *
+            (SchwartzMap.fourierTransformCLM ℂ χ) τ := by
+              refine MeasureTheory.integral_congr_ae ?_
+              filter_upwards with τ
+              congr 2
+              have harg :
+                  2 * Real.pi * Complex.I *
+                      ((-lam / (2 * Real.pi) : ℝ) : ℂ) * (τ : ℂ) =
+                    -(Complex.I * (lam : ℂ) * τ) := by
+                have hscalar_real :
+                    (2 * Real.pi) * (-lam / (2 * Real.pi)) * τ =
+                      -(lam * τ) := by
+                  field_simp [Real.pi_ne_zero]
+                have hscalar :
+                    ((2 * Real.pi : ℂ) *
+                        (((-lam / (2 * Real.pi) : ℝ) : ℂ))) * (τ : ℂ) =
+                      -((lam : ℂ) * τ) := by
+                  exact_mod_cast hscalar_real
+                calc
+                  2 * Real.pi * Complex.I *
+                      ((-lam / (2 * Real.pi) : ℝ) : ℂ) * (τ : ℂ)
+                      = Complex.I *
+                          ((((2 * Real.pi : ℂ) *
+                              (((-lam / (2 * Real.pi) : ℝ) : ℂ))) *
+                            (τ : ℂ))) := by
+                            ring_nf
+                  _ = Complex.I * (-((lam : ℂ) * τ)) := by rw [hscalar]
+                  _ = -(Complex.I * (lam : ℂ) * τ) := by ring_nf
+              rw [harg]
+    _ = χ (-lam / (2 * Real.pi)) := hfourierInv
+
+/-- Fixed-frequency one-variable functional for the horizontal Paley kernel. -/
+noncomputable def section43HorizontalPhasePairingCLM
+    (base : ℂ) (lam : ℝ) :
+    SchwartzMap ℝ ℂ →L[ℂ] ℂ :=
+  base •
+    ((SchwartzMap.integralCLM ℂ
+      (MeasureTheory.volume : MeasureTheory.Measure ℝ)).comp
+      (SchwartzMap.smulLeftCLM ℂ
+        (fun τ : ℝ =>
+          Complex.exp (-(Complex.I * (lam : ℂ) * (τ : ℂ))))))
+
+theorem section43HorizontalPhasePairingCLM_apply
+    (base : ℂ) (lam : ℝ) (χ : SchwartzMap ℝ ℂ) :
+    section43HorizontalPhasePairingCLM base lam χ =
+      base *
+        ∫ τ : ℝ,
+          Complex.exp (-(Complex.I * (lam : ℂ) * (τ : ℂ))) * χ τ := by
+  simp [section43HorizontalPhasePairingCLM, SchwartzMap.integralCLM_apply,
+    SchwartzMap.smulLeftCLM_apply_apply
+      (section43_realOscillatoryPhase_hasTemperateGrowth lam),
+    smul_eq_mul]
+
+theorem section43HorizontalPhasePairingCLM_fourierTransform
+    (base : ℂ) (lam : ℝ) (χ : SchwartzMap ℝ ℂ) :
+    section43HorizontalPhasePairingCLM base lam
+        ((SchwartzMap.fourierTransformCLM ℂ) χ) =
+      base * χ (-lam / (2 * Real.pi)) := by
+  rw [section43HorizontalPhasePairingCLM_apply]
+  rw [section43_integral_phase_mul_fourierTransform_eq_eval]
+
+/-- The branchwise cumulative-tail OS I `(4.24)` product, made Schwartz by the
+total-momentum cutoff when `0 < n` and by the zero-left visible product when
+`n = 0`. -/
+noncomputable def section43OS24CumulativeTailProduct
+    (d : ℕ) [NeZero d] :
+    (n m : ℕ) →
+      SchwartzNPoint d n → SchwartzNPoint d (m + 1) →
+        SchwartzMap (NPointDomain d (n + (m + 1))) ℂ
+  | 0, m, φ, ψ =>
+      SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+        (section43CastNPointCLE d (Nat.zero_add (m + 1)))
+        (section43VisibleProductZeroLeftSchwartz d m φ ψ)
+  | n + 1, m, φ, ψ =>
+      section43TotalMomentumCutoffSchwartz d (n + 1) m (Nat.succ_pos n) φ ψ
+
+theorem section43TailToBorchersProductCLM_left_tail_eq_leftBorchersBlock
+    (d n m : ℕ) [NeZero d] (hn : 0 < n)
+    (q : NPointDomain d (n + (m + 1))) :
+    (section43TailToBorchersProductCLM d n m hn
+      (fun j : Fin (n + m) => q j.succ)).1 =
+      section43LeftBorchersBlock d n (m + 1) (Nat.succ_pos m) q := by
+  ext i μ
+  have hidx :
+      (⟨n - 1 - i.val, by omega⟩ : Fin (n + m)).succ =
+        (⟨n - i.val, by omega⟩ : Fin (n + (m + 1))) := by
+    ext
+    simp
+    omega
+  simpa [section43LeftBorchersBlock] using congrFun (congrArg q hidx) μ
+
+theorem section43TailToBorchersProductCLM_right_tail_eq_rightTailBlock
+    (d n m : ℕ) [NeZero d] (hn : 0 < n)
+    (q : NPointDomain d (n + (m + 1))) :
+    (section43TailToBorchersProductCLM d n m hn
+      (fun j : Fin (n + m) => q j.succ)).2 =
+      section43RightTailBlock d n (m + 1) q := by
+  ext j μ
+  have hidx :
+      (⟨n - 1 + j.val, by omega⟩ : Fin (n + m)).succ =
+        Fin.natAdd n j := by
+    ext
+    simp
+    omega
+  simpa [section43RightTailBlock] using congrFun (congrArg q hidx) μ
+
+theorem section43OS24CumulativeTailProduct_eq_visible_of_head_zero
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    {q : NPointDomain d (n + (m + 1))}
+    (hq0 : q 0 = 0) :
+    section43OS24CumulativeTailProduct d n m φ ψ q =
+      star
+        ((section43FrequencyRepresentative (d := d) n φ)
+          (section43LeftBorchersBlock d n (m + 1) (Nat.succ_pos m) q)) *
+        (section43FrequencyRepresentative (d := d) (m + 1) ψ)
+          (section43RightTailBlock d n (m + 1) q) := by
+  cases n with
+  | zero =>
+      let e := section43CastNPointCLE d (Nat.zero_add (m + 1))
+      have hright : section43RightTailBlock d 0 (m + 1) q = e q := by
+        ext j μ
+        simp [e, section43RightTailBlock]
+      rw [section43OS24CumulativeTailProduct]
+      rw [SchwartzMap.compCLMOfContinuousLinearEquiv_apply]
+      rw [hright]
+      simp [e, section43LeftBorchersBlock_zero_left]
+  | succ n =>
+      have hcut :=
+        section43TotalMomentumCutoffSchwartz_one_on_totalMomentum_zero
+          (d := d) (n := n + 1) (m := m) (Nat.succ_pos n)
+          (φ := φ) (ψ := ψ) (q := q) hq0
+      have hleft :=
+        section43TailToBorchersProductCLM_left_tail_eq_leftBorchersBlock
+          (d := d) (n := n + 1) (m := m) (Nat.succ_pos n) q
+      have hright :=
+        section43TailToBorchersProductCLM_right_tail_eq_rightTailBlock
+          (d := d) (n := n + 1) (m := m) (Nat.succ_pos n) q
+      rw [section43OS24CumulativeTailProduct]
+      rw [hcut]
+      rw [section43VisibleTailProductSchwartz_apply]
+      rw [hleft, hright]
+
+/-- The cumulative-tail product pulled back to flat frequency coordinates. -/
+noncomputable def section43OS24FlatBaseKernel_succRight
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1)) :
+    SchwartzMap (Fin ((n + (m + 1)) * (d + 1)) → ℝ) ℂ :=
+  SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+    (section43CumulativeTailMomentumCLE d (n + (m + 1)))
+    (section43OS24CumulativeTailProduct d n m φ ψ)
+
+@[simp] theorem section43OS24FlatBaseKernel_succRight_apply
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ) :
+    section43OS24FlatBaseKernel_succRight d n m φ ψ ξ =
+      section43OS24CumulativeTailProduct d n m φ ψ
+        (section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ) := by
+  simp [section43OS24FlatBaseKernel_succRight,
+    SchwartzMap.compCLMOfContinuousLinearEquiv_apply]
+
+/-- The visible OS I `(4.24)` scalar on the spectral region. -/
+def section43OS24VisibleKernel_succRight
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    (t : ℝ) (ht : 0 < t)
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ) : ℂ :=
+  let qξ := section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ
+  section43PsiZTimeTest t ht (section43SuccRightEtaCLM d n m ξ) *
+    (star
+      ((section43FrequencyRepresentative (d := d) n φ)
+        (section43LeftBorchersBlock d n (m + 1) (Nat.succ_pos m) qξ)) *
+      (section43FrequencyRepresentative (d := d) (m + 1) ψ)
+        (section43RightTailBlock d n (m + 1) qξ))
+
+/-- Direct Schwartz witness for the OS I `(4.24)` kernel.  Its global values
+include the cutoff extension; only the spectral-region `EqOn` theorem exposes
+the visible formula. -/
+noncomputable def section43OS24KernelWitness_succRight
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    (t : ℝ) (ht : 0 < t) :
+    SchwartzMap (Fin ((n + (m + 1)) * (d + 1)) → ℝ) ℂ :=
+  SchwartzMap.smulLeftCLM ℂ
+    (fun ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ =>
+      section43PsiZTimeTest t ht (section43SuccRightEtaCLM d n m ξ))
+    (section43OS24FlatBaseKernel_succRight d n m φ ψ)
+
+theorem section43OS24KernelWitness_succRight_eqOn_spectralRegion
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    {t : ℝ} (ht : 0 < t) :
+    Set.EqOn
+      (fun ξ => section43OS24KernelWitness_succRight d n m φ ψ t ht ξ)
+      (section43OS24VisibleKernel_succRight d n m φ ψ t ht)
+      (section43WightmanSpectralRegion d (n + (m + 1))) := by
+  intro ξ hξ
+  have hN : 0 < n + (m + 1) := by omega
+  have hq0 :
+      section43CumulativeTailMomentumCLE d (n + (m + 1)) ξ 0 = 0 :=
+    section43WightmanSpectralRegion_cumulativeTail_head_zero
+      (d := d) (N := n + (m + 1)) hN hξ
+  change
+    ((SchwartzMap.smulLeftCLM ℂ
+      (fun ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ =>
+        section43PsiZTimeTest t ht (section43SuccRightEtaCLM d n m ξ))
+      (section43OS24FlatBaseKernel_succRight d n m φ ψ)) ξ) =
+      section43OS24VisibleKernel_succRight d n m φ ψ t ht ξ
+  rw [SchwartzMap.smulLeftCLM_apply_apply
+    (section43PsiZTimeTest_comp_eta_hasTemperateGrowth d n m ht)]
+  rw [section43OS24FlatBaseKernel_succRight_apply]
+  rw [section43OS24CumulativeTailProduct_eq_visible_of_head_zero
+    (d := d) (n := n) (m := m) (φ := φ) (ψ := ψ) hq0]
+  rfl
+
+private theorem exists_section43OS24Kernel_succRight
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    (t : ℝ) (ht : 0 < t) :
+    ∃ KOS : SchwartzMap (Fin ((n + (m + 1)) * (d + 1)) → ℝ) ℂ,
+      Set.EqOn
+        (fun ξ => KOS ξ)
+        (section43OS24VisibleKernel_succRight d n m φ ψ t ht)
+        (section43WightmanSpectralRegion d (n + (m + 1))) :=
+  ⟨section43OS24KernelWitness_succRight d n m φ ψ t ht,
+    section43OS24KernelWitness_succRight_eqOn_spectralRegion d n m φ ψ ht⟩
+
+noncomputable def section43OS24Kernel_succRight
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    (t : ℝ) (ht : 0 < t) :
+    SchwartzMap (Fin ((n + (m + 1)) * (d + 1)) → ℝ) ℂ :=
+  Classical.choose
+    (exists_section43OS24Kernel_succRight d n m φ ψ t ht)
+
+theorem section43OS24Kernel_succRight_eqOn_spectralRegion
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    {t : ℝ} (ht : 0 < t) :
+    Set.EqOn
+      (fun ξ => section43OS24Kernel_succRight d n m φ ψ t ht ξ)
+      (section43OS24VisibleKernel_succRight d n m φ ψ t ht)
+      (section43WightmanSpectralRegion d (n + (m + 1))) :=
+  Classical.choose_spec
+    (exists_section43OS24Kernel_succRight d n m φ ψ t ht)
+
+theorem section43OS24Kernel_succRight_apply_of_mem_spectralRegion
+    (d n m : ℕ) [NeZero d]
+    (φ : SchwartzNPoint d n) (ψ : SchwartzNPoint d (m + 1))
+    {t : ℝ} (ht : 0 < t)
+    (ξ : Fin ((n + (m + 1)) * (d + 1)) → ℝ)
+    (hξ : ξ ∈ section43WightmanSpectralRegion d (n + (m + 1))) :
+    section43OS24Kernel_succRight d n m φ ψ t ht ξ =
+      section43OS24VisibleKernel_succRight d n m φ ψ t ht ξ :=
+  section43OS24Kernel_succRight_eqOn_spectralRegion d n m φ ψ ht hξ
 
 /-- Reindex the right split tail sum into the corresponding full tail sum. -/
 private theorem section43_splitRight_tail_sum_eq_full_tail

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -15152,6 +15152,59 @@ horizontalPhasePairingCLM_fourierTransform
 horizontalPaley_frequency_nonneg_of_mem_dualCone
 ```
 
+Implementation-ready refinement for the first S4 Lean pass, 2026-04-15:
+
+The `exists_section43OS24Kernel_succRight` theorem itself does not yet need the
+horizontal integral-collapse helpers above.  It only needs a production
+definition of the one-variable Paley time test and the linear frequency
+`eta = -lambda/(2*pi)` used to evaluate it.  Add these before the existence
+theorem:
+
+```lean
+noncomputable def section43PsiZTimeTest (t : ℝ) (ht : 0 < t) :
+    SchwartzMap ℝ ℂ :=
+  SCV.schwartzPsiZ (((2 * Real.pi : ℂ) * (t * Complex.I))) ...
+
+noncomputable def section43SuccRightTimeShiftFlatDirection
+    (d n m : ℕ) [NeZero d] :
+    Fin ((n + (m + 1)) * (d + 1)) → ℝ :=
+  castFinCLE (Nat.add_mul n (m + 1) (d + 1)).symm
+    (zeroHeadBlockShift
+      (m := n * (d + 1)) (n := (m + 1) * (d + 1))
+      (section43FlatTimeShiftDirection d (m + 1)))
+
+noncomputable def section43SuccRightEtaCLM
+    (d n m : ℕ) [NeZero d] :
+    (Fin ((n + (m + 1)) * (d + 1)) → ℝ) →L[ℝ] ℝ :=
+  -(1 / (2 * Real.pi)) •
+    sum_i (section43SuccRightTimeShiftFlatDirection d n m i) • proj_i
+```
+
+Then build the kernel directly as:
+
+1. A cumulative-tail product `Kq` by dependent case split on `n`.
+   For `n = 0`, use `section43VisibleProductZeroLeftSchwartz`.
+   For `n = n' + 1`, use `section43TotalMomentumCutoffSchwartz`.
+2. Pull `Kq` back by `section43CumulativeTailMomentumCLE`.
+3. Multiply by
+   `(section43PsiZTimeTest t ht) (section43SuccRightEtaCLM d n m xi)`
+   using `SchwartzMap.smulLeftCLM`; do not attempt to make the one-dimensional
+   projection pullback itself into a Schwartz function.
+
+The `EqOn` proof is pointwise:
+
+1. `hxi : xi in section43WightmanSpectralRegion d (n + (m + 1))` gives
+   `(section43CumulativeTailMomentumCLE ... xi) 0 = 0` by
+   `section43WightmanSpectralRegion_cumulativeTail_head_zero`.
+2. In the `n = 0` branch, `section43LeftBorchersBlock_zero_left` and
+   `section43RightTailBlock_zero_left` identify the visible product.
+3. In the `0 < n` branch,
+   `section43TotalMomentumCutoffSchwartz_one_on_totalMomentum_zero` reduces the
+   cutoff-tail product to `section43VisibleTailProductSchwartz`, and the
+   tail-product apply lemmas identify the left and right OS I `(4.24)` blocks.
+4. The final visible formula is obtained from
+   `SchwartzMap.smulLeftCLM_apply_apply` and the eta apply theorem.
+
 Until these items are filled in, S4 is not implementation-ready.  This is a
 productive blocker, not a wrapper gap: it is the exact Schwartz-extension
 issue needed to turn the spectral-region formula into a legal test function
@@ -15228,7 +15281,21 @@ theorem section43OS24Kernel_succRight_apply_of_mem_spectralRegion
 Proof: this is
 `section43OS24Kernel_succRight_eqOn_spectralRegion d n m φ ψ ht hξ`.
 
-Then S1 and S2 give the support EqOn theorem:
+Production status, 2026-04-15: the S4 kernel witness surface above is now
+implemented and verified in
+`Section43SpectralFactorization.lean`.  The production theorem uses the helper
+function `section43OS24VisibleKernel_succRight` for the visible scalar, rather
+than repeating the full `let qξ`, `let λξ`, `let ηξ` expression in every
+statement.  The pointwise theorem is:
+
+```lean
+theorem section43OS24Kernel_succRight_apply_of_mem_spectralRegion
+    ...
+    section43OS24Kernel_succRight d n m φ ψ t ht ξ =
+      section43OS24VisibleKernel_succRight d n m φ ψ t ht ξ
+```
+
+Next, S1 and S2 give the support EqOn theorem:
 
 ```lean
 private theorem
@@ -15254,15 +15321,22 @@ private theorem
 Proof transcript:
 
 1. Introduce `ξ hξ`; split `hξ` into dual-cone and total-momentum parts.
-2. Apply S1 using the dual-cone part.
-3. Rewrite `base` by S2 using the full spectral-region hypothesis.
-4. Rewrite the target with
+2. Rewrite `hKψZ_eval ξ` using `timeShiftFlatOrbit_apply_phase` to identify
+   the integral with the one-variable oscillatory pairing
+   `section43HorizontalPhasePairingCLM base lam
+     ((SchwartzMap.fourierTransformCLM ℂ) (section43PsiZTimeTest t ht))`.
+3. Apply the direct Fourier identity
+   `section43HorizontalPhasePairingCLM_fourierTransform` to get
+   `base * (section43PsiZTimeTest t ht) (-lam/(2*pi))`.
+4. Rewrite `base` by S2 using the full spectral-region hypothesis.
+5. Rewrite the target with
    `section43OS24Kernel_succRight_apply_of_mem_spectralRegion ... hξ`.
-5. Use `horizontalPaley_frequency_nonneg_of_mem_dualCone` and
-   `SCV.psiZ_eq_exp_of_nonneg` to replace
-   `(section43PsiZTimeTest t ht) ηξ` by
-   `Complex.exp (-(2 * Real.pi * t : ℂ) * (ηξ : ℂ))` on the spectral region.
-6. Close by associativity/commutativity of scalar multiplication only; do not
+6. Use `section43SuccRightEtaCLM_apply` to identify the eta argument with the
+   displayed `-lam/(2*pi)` frequency.  No finite-height `epsilon` factor and no
+   `SCV.psiZ_eq_exp_of_nonneg` rewrite are needed for this EqOn theorem,
+   because the OS24 visible kernel keeps the one-variable Paley test
+   `(section43PsiZTimeTest t ht)` unevaluated.
+7. Close by associativity/commutativity of scalar multiplication only; do not
    unfold the definitions of the left/right blocks.
 
 #### Packet S5: OS scalar recognition by the `bvt_F` Fourier-Laplace shell
@@ -15283,11 +15357,11 @@ restriction / `xiShift` bridge for the chosen continuation `bvt_F`.  Therefore
 Packet S5 must consume a full Fourier-Laplace witness for the same flattened
 distribution `Tflat`, not just the boundary-value equality `hTflat_bv`.
 
-Use the following local structure to keep theorem statements readable without
+Use the following public structure to keep theorem statements readable without
 hiding any data:
 
 ```lean
-private structure section43TflatFourierLaplaceWitness
+structure section43TflatFourierLaplaceWitness
     (OS : OsterwalderSchraderAxioms d) (lgc : OSLinearGrowthCondition d OS)
     (N : ℕ)
     (Tflat : SchwartzMap (Fin (N * (d + 1)) → ℝ) ℂ →L[ℂ] ℂ) where
@@ -15345,6 +15419,26 @@ section43Tflat_fourierLaplaceRep_of_boundaryValue_unique
 which recovers `hTflat_FL` from the boundary-value identity and support.
 Do not prove S5 for an unconstrained `Tflat`; that would leave the OS scalar
 unconnected to the actual analytic continuation.
+
+Production status, 2026-04-15: the witness structure is now public in
+`OSToWightmanBoundaryValueLimits.lean` as
+
+```lean
+section43TflatFourierLaplaceWitness
+```
+
+and the current public supplier is
+
+```lean
+bvt_W_flattened_distribution_hasFourierSupportIn_wightmanSpectralRegion_with_fourierLaplaceWitness
+```
+
+It returns one and the same `Tflat` together with
+`HasFourierSupportIn (section43WightmanSpectralRegion d N) Tflat`, the
+boundary-value identity for `bvt_W`, and the Fourier-Laplace witness for
+`bvt_F`.  Downstream S5 theorems should consume this public packet; they should
+not duplicate the private `bv_implies_fourier_support` proof and should not
+attempt a uniqueness reconstruction from the boundary identity.
 
 S5 is split into four non-wrapper theorems.
 
@@ -15539,6 +15633,24 @@ private theorem
 
 Proof transcript:
 
+Production status, 2026-04-15: the support-ordering theorems are implemented
+and exact-checked in `Section43OS24KernelComparison.lean`:
+
+```lean
+section43OSConjTensorProduct_support_left_reflected_ordered_succRight
+section43OSConjTensorProduct_support_right_ordered_succRight
+section43OSBorchersTimeShiftConfig_strictOrdered_of_osSupport_succRight
+section43OSForwardTubeLift_mem_forwardTube_of_osSupport_succRight
+```
+
+They use `Function.support` to split a nonzero OS tensor product into nonzero
+left and right factors, then move those factors into `tsupport` by
+`subset_tsupport` and apply `f.2`/`g.2`.  The strict-order theorem uses the
+three left/left, left/right, and right/right case split below.  The
+forward-tube membership theorem builds the globally translated real
+configuration `xs`, proves it is Wick-rotated back to the lift, and applies
+`euclidean_ordered_in_forwardTube`.
+
 1. For
    `section43OSConjTensorProduct_support_left_reflected_ordered_succRight`,
    unfold `SchwartzNPoint.osConjTensorProduct` and
@@ -15566,6 +15678,53 @@ Proof transcript:
    is `splitFirst n (m + 1) y 0 0 < 0`, while the first right-tail shifted time
    is `splitLast n (m + 1) y 0 0 + t`, which is positive by right support and
    `ht`.
+
+Lean-ready case split for
+`section43OSBorchersTimeShiftConfig_strictOrdered_of_osSupport_succRight`:
+
+1. Introduce `i j : Fin (n + (m + 1))` and `hij : i < j`.
+2. Split first on `hj_left : j.val < n`.  If true, then
+   `hi_left : i.val < n` follows from `i.val < j.val`.  Set
+   `ii : Fin n := ⟨i.val, hi_left⟩` and
+   `jj : Fin n := ⟨j.val, hj_left⟩`; rewrite
+   `i = Fin.castAdd (m + 1) ii` and
+   `j = Fin.castAdd (m + 1) jj` by `Fin.ext rfl`.  The coordinate normal form
+   reduces the goal to
+   `y (Fin.castAdd (m + 1) (Fin.rev ii)) 0 <
+    y (Fin.castAdd (m + 1) (Fin.rev jj)) 0`.  Prove
+   `Fin.rev jj < Fin.rev ii` with `Fin.rev_lt_iff` from `ii < jj`; apply the
+   left reflected ordered theorem at `Fin.rev jj`, `Fin.rev ii`; unfold
+   `timeReflectionN`, `timeReflection`, and `splitFirst`; close by `nlinarith`.
+3. If `¬ hj_left`, split on `hi_left : i.val < n`.  In the mixed case define
+   `ii : Fin n := ⟨i.val, hi_left⟩` and
+   `jj : Fin (m + 1) := ⟨j.val - n, by omega⟩`; rewrite
+   `i = Fin.castAdd (m + 1) ii` and `j = Fin.natAdd n jj`.
+   The left support theorem gives the left raw time is `< 0`; the right
+   support theorem gives `0 < y (Fin.natAdd n jj) 0`; with `ht`, the shifted
+   right time is positive, and `nlinarith` closes.
+4. In the right/right case define
+   `ii : Fin (m + 1) := ⟨i.val - n, by omega⟩` and
+   `jj : Fin (m + 1) := ⟨j.val - n, by omega⟩`; rewrite both indices as
+   `Fin.natAdd n _`.  From `i < j`, get `ii < jj` by `omega`.  The right
+   support theorem gives strict increase before the shift; the coordinate
+   normal forms add the same `t` to both sides and `nlinarith` closes.
+
+If Lean resists the index rewrites, add these local helpers before the
+strict-order theorem:
+
+```lean
+private theorem section43_eq_castAdd_of_val_lt
+    {n m : ℕ} {i : Fin (n + (m + 1))} (hi : i.val < n) :
+    i = Fin.castAdd (m + 1) (⟨i.val, hi⟩ : Fin n)
+
+private theorem section43_eq_natAdd_of_not_val_lt
+    {n m : ℕ} {i : Fin (n + (m + 1))} (hi : ¬ i.val < n) :
+    i = Fin.natAdd n (⟨i.val - n, by omega⟩ : Fin (m + 1))
+```
+
+Both are `Fin.ext` plus `omega`.  These helpers are not wrappers; they are the
+index-normalization lemmas needed by the strict chronological case split.
+
 6. The global translation makes the first imaginary time `1` and preserves
    every consecutive gap.  Define the real configuration
 
@@ -15625,7 +15784,20 @@ private theorem
           flattenCLEquiv (n + (m + 1)) (d + 1)
             (section43OSBorchersTimeShiftConfig_succRight (d := d) t y) i *
             (ξ i : ℂ))
+```
 
+Production status, 2026-04-15: the concrete raw shell, left-block reversal
+permutation, Borchers-ordered shell, forward-tube lift, left/right
+time-coordinate normal forms, lift-as-Wick-rotation theorem, forward-tube
+membership theorem, complex diagonal translation pairing, total-momentum-zero
+phase-cancellation theorem, and the `multiDimPsiZExt` evaluation theorem below
+are implemented and exact-checked in
+`Section43OS24KernelComparison.lean`.  The left-block reversal is defined via
+`finSumFinEquiv` and `Fin.revPerm`, with compiled simp facts for both
+`Fin.castAdd` and `Fin.natAdd`, so later support proofs should use these
+objects directly rather than re-encoding the chronological permutation.
+
+```lean
 private theorem
     section43OSForwardTubeLift_multiDimPsiZExt_apply_of_spectralRegion_succRight
     (OS : OsterwalderSchraderAxioms d) (lgc : OSLinearGrowthCondition d OS)
@@ -15749,6 +15921,23 @@ Proof transcript:
    `SCV.psiZ_eq_exp_of_nonneg`.
 4. Close by the algebra used in S1: unfold `section43PsiZTimeTest` and `ηξ`
    only at the final step, then `ring_nf`.
+
+Production status, 2026-04-15: the tail-shift sign and Paley-factor theorem
+are implemented and exact-checked in `Section43OS24KernelComparison.lean`:
+
+```lean
+section43SuccRightEtaCLM_nonneg_of_mem_dualCone
+section43SuccRightEtaCLM_nonneg_of_mem_spectralRegion
+section43TailShiftPhase_eq_psiZTimeTest_of_spectralRegion_succRight
+```
+
+The proof uses the public
+`zeroHeadBlockShift_flatTimeShiftDirection_pairing_nonpos_of_mem_dualCone`,
+rewrites the direction by
+`section43SuccRightTimeShiftFlatDirection_eq_flatTimeShiftDirection`, and then
+uses `SCV.psiZ_eq_exp_of_nonneg` at
+`section43SuccRightEtaCLM d n m ξ`.  This fixes the sign of the external
+tail-shift phase before the product factorization theorem.
 
 Then name the full scalar factorization of the Borchers-ordered phase:
 


### PR DESCRIPTION
## Summary

This PR continues the theorem-3 OS route after #64 by adding the Section 4.3 / OS24 support layer needed for the S5 forward-tube lift and spectral-side kernel comparison.

Main additions:

- exposes the flattened Fourier-Laplace witness package from `OSToWightmanBoundaryValueLimits`
- adds `Section43OS24KernelComparison.lean` as a small companion module for OS24/S5 support facts
- proves the translated forward-tube lift on ordered OS support, plus the associated `multiDimPsiZExt` evaluation
- proves the total-momentum-zero phase cancellation and tail-shift normalization lemmas used to align the OS24 kernel with the spectral-side ψZ kernel
- updates the theorem-3 OS-route blueprint with the implemented S5 packet and the next blocker

This deliberately follows the translated-lift route: we construct a global translated forward-tube lift and cancel the translation phase on total-momentum-zero support, rather than relying on the false unshifted absolute-PET statement discussed in issue #62.

## Verification

Fresh checks after merging #64 into `main`:

```text
lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValueLimits.lean
lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/Section43SpectralFactorization.lean
lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/Section43OS24KernelComparison.lean
lake build OSReconstruction.Wightman.Reconstruction.WickRotation.Section43OS24KernelComparison
```

The narrow module build completed successfully with existing warnings only:

```text
Build completed successfully (8461 jobs).
```

`git diff --check` is clean.

## Next Blocker

The remaining OS-route seam is the Borchers-ordered phase integral factorization/Fubini packet: turn the pointwise S5 kernel identity into the distribution-level shell-to-Laplace identification consumed by the theorem-3 positivity frontier.
