### PR TITLE
Add Section 4.3 smooth rapid witness support

### DIFF
--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceCompactDifferentiation.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceCompactDifferentiation.lean
@@ -1,0 +1,599 @@
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceHigherDerivatives
+
+noncomputable section
+
+open scoped Topology FourierTransform LineDeriv
+open Set MeasureTheory
+
+attribute [local instance 101] secondCountableTopologyEither_of_left
+
+namespace OSReconstruction
+
+/-- Membership in the closed ball centered at `0` gives the expected norm
+bound for the Section 4.3 time variable. -/
+theorem norm_le_of_mem_time_closedBall_zero
+    (n : ℕ) (τ : Fin n → ℝ) {R : ℝ}
+    (hτ : τ ∈ Metric.closedBall (0 : Fin n → ℝ) R) :
+    ‖τ‖ ≤ R := by
+  simpa [Metric.mem_closedBall, dist_eq_norm, sub_zero] using hτ
+
+/-- A point in the unit closed ball around `q` has norm at most `‖q‖ + 1`. -/
+theorem norm_nPoint_le_norm_add_one_of_mem_closedBall
+    (d n : ℕ) [NeZero d]
+    (q q' : NPointDomain d n)
+    (hq' : q' ∈ Metric.closedBall q (1 : ℝ)) :
+    ‖q'‖ ≤ ‖q‖ + 1 := by
+  have hdist : dist q' q ≤ (1 : ℝ) := by
+    simpa [Metric.mem_closedBall] using hq'
+  have hsub : ‖q' - q‖ ≤ (1 : ℝ) := by
+    simpa [dist_eq_norm] using hdist
+  have htri : ‖q'‖ ≤ ‖q' - q‖ + ‖q‖ := by
+    calc
+      ‖q'‖ = ‖(q' - q) + q‖ := by
+        simp
+      _ ≤ ‖q' - q‖ + ‖q‖ := norm_add_le _ _
+  linarith
+
+/-- On a compact product of a time ball and a unit `q`-ball, the absolute
+Laplace exponential is uniformly bounded by a scalar depending only on the
+center `q` and the time radius. -/
+theorem norm_exp_neg_section43_timePair_le_local_closedBall
+    (d n : ℕ) [NeZero d]
+    (q q' : NPointDomain d n)
+    (τ : Fin n → ℝ)
+    {R : ℝ} (hR_nonneg : 0 ≤ R)
+    (hτ : τ ∈ Metric.closedBall (0 : Fin n → ℝ) R)
+    (hq' : q' ∈ Metric.closedBall q (1 : ℝ)) :
+    ‖Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) *
+          (section43QTime (d := d) (n := n) q' k : ℂ)))‖ ≤
+      Real.exp
+        (R * ((∑ k : Fin n, section43QTimeCoordOpNorm d n k) *
+          (‖q‖ + 1))) := by
+  rw [Complex.norm_exp]
+  apply Real.exp_le_exp.mpr
+  have hτ_norm : ‖τ‖ ≤ R :=
+    norm_le_of_mem_time_closedBall_zero n τ hτ
+  have hq_norm : ‖q'‖ ≤ ‖q‖ + 1 :=
+    norm_nPoint_le_norm_add_one_of_mem_closedBall d n q q' hq'
+  have hterm :
+      ∀ k : Fin n,
+        |τ k * section43QTime (d := d) (n := n) q' k| ≤
+          R * (section43QTimeCoordOpNorm d n k * (‖q‖ + 1)) := by
+    intro k
+    have hτk : |τ k| ≤ R := by
+      have hcoord : ‖τ k‖ ≤ ‖τ‖ := norm_le_pi_norm τ k
+      have hcoord_abs : |τ k| ≤ ‖τ‖ := by
+        simpa [Real.norm_eq_abs] using hcoord
+      exact hcoord_abs.trans hτ_norm
+    have hcoef_nonneg : 0 ≤ section43QTimeCoordOpNorm d n k := by
+      dsimp [section43QTimeCoordOpNorm]
+      exact norm_nonneg _
+    have hqk :
+        |section43QTime (d := d) (n := n) q' k| ≤
+          section43QTimeCoordOpNorm d n k * (‖q‖ + 1) := by
+      have hbase := abs_section43QTime_coord_le_opNorm d n q' k
+      have hbase' :
+          |section43QTime (d := d) (n := n) q' k| ≤
+            section43QTimeCoordOpNorm d n k * ‖q'‖ := by
+        simpa [section43QTimeCoordOpNorm] using hbase
+      exact hbase'.trans
+        (mul_le_mul_of_nonneg_left hq_norm hcoef_nonneg)
+    calc
+      |τ k * section43QTime (d := d) (n := n) q' k| =
+          |τ k| * |section43QTime (d := d) (n := n) q' k| := by
+            rw [abs_mul]
+      _ ≤ R * (section43QTimeCoordOpNorm d n k * (‖q‖ + 1)) := by
+            exact mul_le_mul hτk hqk (abs_nonneg _) hR_nonneg
+  have hsum_abs :
+      -(∑ k : Fin n,
+          τ k * section43QTime (d := d) (n := n) q' k) ≤
+        ∑ k : Fin n,
+          |τ k * section43QTime (d := d) (n := n) q' k| := by
+    calc
+      -(∑ k : Fin n,
+          τ k * section43QTime (d := d) (n := n) q' k)
+          ≤ |∑ k : Fin n,
+              τ k * section43QTime (d := d) (n := n) q' k| := by
+              exact neg_le_abs _
+      _ ≤ ∑ k : Fin n,
+          |τ k * section43QTime (d := d) (n := n) q' k| := by
+              exact Finset.abs_sum_le_sum_abs _ _
+  have hsum_bound :
+      ∑ k : Fin n,
+          |τ k * section43QTime (d := d) (n := n) q' k| ≤
+        ∑ k : Fin n,
+          R * (section43QTimeCoordOpNorm d n k * (‖q‖ + 1)) := by
+    exact Finset.sum_le_sum fun k _hk => hterm k
+  have hsum_eval :
+      (∑ k : Fin n,
+          R * (section43QTimeCoordOpNorm d n k * (‖q‖ + 1))) =
+        R * ((∑ k : Fin n, section43QTimeCoordOpNorm d n k) *
+          (‖q‖ + 1)) := by
+    rw [← Finset.mul_sum, Finset.sum_mul]
+  have hre :
+      (-(∑ k : Fin n,
+        (τ k : ℂ) *
+          (section43QTime (d := d) (n := n) q' k : ℂ))).re =
+        -(∑ k : Fin n,
+          τ k * section43QTime (d := d) (n := n) q' k) := by
+    simp
+  rw [hre]
+  exact hsum_abs.trans (hsum_bound.trans hsum_eval.le)
+
+/-- In finite-dimensional domain, continuity of a family of continuous
+multilinear maps is equivalent to continuity of all applied scalar families.
+
+This is the multilinear analogue of Mathlib's `continuous_clm_apply`, proved
+by repeatedly currying the leftmost variable. -/
+theorem continuous_cmlm_apply_nPoint
+    (d n r : ℕ) [NeZero d]
+    {X : Type*} [TopologicalSpace X]
+    {L : X →
+      ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ} :
+    Continuous L ↔
+      ∀ m : Fin r → NPointDomain d n, Continuous fun x => L x m := by
+  induction r generalizing X with
+  | zero =>
+      constructor
+      · intro hL m
+        exact
+          (ContinuousMultilinearMap.apply ℝ
+            (fun _ : Fin 0 => NPointDomain d n) ℂ m).continuous.comp hL
+      · intro h
+        let e :=
+          continuousMultilinearCurryFin0 ℝ (NPointDomain d n) ℂ
+        have he : Continuous fun x => e (L x) := by
+          simpa [e] using h (0 : Fin 0 → NPointDomain d n)
+        have hback : Continuous fun x => e.symm (e (L x)) :=
+          e.symm.continuous.comp he
+        simpa [e] using hback
+  | succ r ih =>
+      constructor
+      · intro hL m
+        exact
+          (ContinuousMultilinearMap.apply ℝ
+            (fun _ : Fin (r + 1) => NPointDomain d n) ℂ m).continuous.comp hL
+      · intro h
+        let e :=
+          continuousMultilinearCurryLeftEquiv ℝ
+            (fun _ : Fin (r + 1) => NPointDomain d n) ℂ
+        have hcurry : Continuous fun x => e (L x) := by
+          refine (continuous_clm_apply
+            (𝕜 := ℝ) (E := NPointDomain d n)).2 ?_
+          intro head
+          refine (ih (L := fun x => e (L x) head)).2 ?_
+          intro tail
+          simpa [e, ContinuousMultilinearMap.curryLeft_apply] using
+            h (Fin.cons head tail)
+        have hback : Continuous fun x => e.symm (e (L x)) :=
+          e.symm.continuous.comp hcurry
+        simpa [e] using hback
+
+/-- A fixed derivative word contributes a scalar factor depending continuously
+on the real time variable. -/
+theorem continuous_section43DerivativeWordScalar
+    (d n r : ℕ) [NeZero d]
+    (a : Section43DerivativeWord d n r)
+    (m : Fin r → NPointDomain d n) :
+    Continuous fun τ : Fin n → ℝ =>
+      section43DerivativeWordScalar d n r a τ m := by
+  induction r with
+  | zero =>
+      exact continuous_const
+  | succ r ih =>
+      cases h : a 0 with
+      | time k =>
+          let oldWord : Section43DerivativeWord d n r :=
+            section43DerivativeWordTail d n r a
+          let oldDirections : Fin r → NPointDomain d n :=
+            section43DirectionTail d n r m
+          have hold : Continuous fun τ : Fin n → ℝ =>
+              section43DerivativeWordScalar d n r oldWord τ oldDirections :=
+            ih oldWord oldDirections
+          have hτk : Continuous fun τ : Fin n → ℝ => (τ k : ℂ) :=
+            Complex.continuous_ofReal.comp (continuous_apply k)
+          have hqk : Continuous fun _τ : Fin n → ℝ =>
+              (section43QTime (d := d) (n := n) (m 0) k : ℂ) :=
+            continuous_const
+          simpa [section43DerivativeWordScalar, h, oldWord, oldDirections, mul_assoc]
+            using (hτk.mul (hqk.mul hold)).neg
+      | spatial i =>
+          let oldWord : Section43DerivativeWord d n r :=
+            section43DerivativeWordTail d n r a
+          let oldDirections : Fin r → NPointDomain d n :=
+            section43DirectionTail d n r m
+          have hold : Continuous fun τ : Fin n → ℝ =>
+              section43DerivativeWordScalar d n r oldWord τ oldDirections :=
+            ih oldWord oldDirections
+          have hhead : Continuous fun _τ : Fin n → ℝ =>
+              ((section43QSpatial (d := d) (n := n) (m 0) i : ℝ) : ℂ) :=
+            continuous_const
+          simpa [section43DerivativeWordScalar, h, oldWord, oldDirections]
+            using hhead.mul hold
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Applied all-order pointwise derivatives are continuous in the real time
+variable.  The proof uses the finite derivative-word expansion. -/
+theorem continuous_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (m : Fin r → NPointDomain d n) :
+    Continuous fun τ : Fin n → ℝ =>
+      iteratedFDeriv ℝ r
+        (fun q' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+        q m := by
+  classical
+  let Efun : (Fin n → ℝ) → ℂ := fun τ =>
+    Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) * (section43QTime (d := d) (n := n) q k : ℂ)))
+  have hE : Continuous Efun := by
+    dsimp [Efun]
+    fun_prop
+  have hsum : Continuous fun τ : Fin n → ℝ =>
+      ∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordScalar d n r a τ m *
+          Efun τ *
+          partialFourierSpatial_fun (d := d) (n := n)
+            (section43DerivativeWordInput d n r F a)
+            (τ, section43QSpatial (d := d) (n := n) q) := by
+    refine continuous_finset_sum Finset.univ fun a _ha => ?_
+    have hscalar :=
+      continuous_section43DerivativeWordScalar d n r a m
+    have hP : Continuous fun τ : Fin n → ℝ =>
+        partialFourierSpatial_fun (d := d) (n := n)
+          (section43DerivativeWordInput d n r F a)
+          (τ, section43QSpatial (d := d) (n := n) q) := by
+      let hbase : Continuous
+          (partialFourierSpatial_fun
+            (d := d) (n := n) (section43DerivativeWordInput d n r F a)) :=
+        continuous_partialFourierSpatial_fun
+          (d := d) (n := n) (section43DerivativeWordInput d n r F a)
+      let hpath : Continuous fun τ : Fin n → ℝ =>
+          (τ, section43QSpatial (d := d) (n := n) q) :=
+        continuous_id.prodMk continuous_const
+      simpa using hbase.comp hpath
+    exact (hscalar.mul hE).mul hP
+  convert hsum using 1
+  ext τ
+  rw [section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The CLM-valued all-order pointwise derivative is continuous in the real
+time variable for fixed ambient momentum `q`. -/
+theorem continuous_section43FourierLaplace_timeIntegrand_iteratedFDeriv
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n) :
+    Continuous fun τ : Fin n → ℝ =>
+      iteratedFDeriv ℝ r
+        (fun q' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+        q := by
+  refine (continuous_cmlm_apply_nPoint d n r).2 ?_
+  intro m
+  exact continuous_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply
+    d n r F q m
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Compact local domination for the derivative of the pointwise all-order
+Fourier-Laplace integrand.  This is the all-order analogue of the compiled
+first-derivative local bound, but it uses the finite derivative-word majorant
+instead of a separate joint-continuity compactness argument. -/
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    ∃ bound : (Fin n → ℝ) → ℝ,
+      Integrable bound ∧
+      ∀ᵐ τ, ∀ q' ∈ Metric.closedBall q (1 : ℝ),
+        ‖(iteratedFDeriv ℝ (r + 1)
+          (fun q'' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+            partialFourierSpatial_fun (d := d) (n := n)
+              (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+              (τ, section43QSpatial (d := d) (n := n) q''))
+          q').curryLeft‖ ≤ bound τ := by
+  classical
+  let F : SchwartzNPoint d n := section43DiffPullbackCLM d n ⟨f, hf_ord⟩
+  rcases exists_section43DiffPullback_timeNorm_bound_of_compact_tsupport
+    d n f hf_ord hf_compact with ⟨R, hR_nonneg, hR_supp⟩
+  let Kτ : Set (Fin n → ℝ) := Metric.closedBall (0 : Fin n → ℝ) R
+  choose Cword hCword_nonneg hCword_bound using
+    fun a : Section43DerivativeWord d n (r + 1) =>
+      exists_norm_bound_partialFourierSpatial_fun
+        (d := d) (n := n) (section43DerivativeWordInput d n (r + 1) F a)
+  let Cexp : ℝ :=
+    Real.exp
+      (R * ((∑ k : Fin n, section43QTimeCoordOpNorm d n k) *
+        (‖q‖ + 1)))
+  let Csum : ℝ :=
+    ∑ a : Section43DerivativeWord d n (r + 1),
+      section43DerivativeWordCoeff d n (r + 1) a *
+        R ^ section43DerivativeWordTimeCount d n (r + 1) a *
+        Cword a
+  let C : ℝ := Cexp * Csum
+  refine ⟨Set.indicator Kτ (fun _ => C), ?_, ?_⟩
+  · simpa [Kτ, C] using integrable_indicator_time_closedBall_const n R C
+  · filter_upwards with τ q' hq'
+    by_cases hτ_mem : τ ∈ Kτ
+    · rw [Set.indicator_of_mem hτ_mem]
+      have hτ_norm : ‖τ‖ ≤ R := by
+        simpa [Kτ] using norm_le_of_mem_time_closedBall_zero n τ hτ_mem
+      have hExp :
+          ‖Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ)))‖ ≤ Cexp := by
+        simpa [Cexp, Kτ] using
+          norm_exp_neg_section43_timePair_le_local_closedBall
+            d n q q' τ hR_nonneg hτ_mem hq'
+      have hsum :
+          (∑ a : Section43DerivativeWord d n (r + 1),
+            section43DerivativeWordCoeff d n (r + 1) a *
+              ‖τ‖ ^ section43DerivativeWordTimeCount d n (r + 1) a *
+              ‖partialFourierSpatial_fun (d := d) (n := n)
+                (section43DerivativeWordInput d n (r + 1) F a)
+                (τ, section43QSpatial (d := d) (n := n) q')‖) ≤ Csum := by
+        dsimp [Csum]
+        refine Finset.sum_le_sum ?_
+        intro a _ha
+        let K : ℕ := section43DerivativeWordTimeCount d n (r + 1) a
+        have hcoeff_nonneg :
+            0 ≤ section43DerivativeWordCoeff d n (r + 1) a :=
+          section43DerivativeWordCoeff_nonneg d n (r + 1) a
+        have hpow : ‖τ‖ ^ K ≤ R ^ K := by
+          exact pow_le_pow_left₀ (norm_nonneg τ) hτ_norm K
+        have hP :
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n (r + 1) F a)
+              (τ, section43QSpatial (d := d) (n := n) q')‖ ≤ Cword a :=
+          hCword_bound a (τ, section43QSpatial (d := d) (n := n) q')
+        have hpowP :
+            ‖τ‖ ^ K *
+                ‖partialFourierSpatial_fun (d := d) (n := n)
+                  (section43DerivativeWordInput d n (r + 1) F a)
+                  (τ, section43QSpatial (d := d) (n := n) q')‖ ≤
+              R ^ K * Cword a := by
+          exact mul_le_mul hpow hP (norm_nonneg _) (pow_nonneg hR_nonneg K)
+        have hmul := mul_le_mul_of_nonneg_left hpowP hcoeff_nonneg
+        simpa [K, mul_assoc] using hmul
+      have hsum_nonneg : 0 ≤
+          ∑ a : Section43DerivativeWord d n (r + 1),
+            section43DerivativeWordCoeff d n (r + 1) a *
+              ‖τ‖ ^ section43DerivativeWordTimeCount d n (r + 1) a *
+              ‖partialFourierSpatial_fun (d := d) (n := n)
+                (section43DerivativeWordInput d n (r + 1) F a)
+                (τ, section43QSpatial (d := d) (n := n) q')‖ := by
+        refine Finset.sum_nonneg ?_
+        intro a _ha
+        exact mul_nonneg
+          (mul_nonneg (section43DerivativeWordCoeff_nonneg d n (r + 1) a)
+            (pow_nonneg (norm_nonneg τ) _))
+          (norm_nonneg _)
+      have hmain :=
+        norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words_absExp
+          d n (r + 1) F q' τ
+      have hnorm :
+          ‖(iteratedFDeriv ℝ (r + 1)
+            (fun q'' : NPointDomain d n =>
+              Complex.exp
+                (-(∑ k : Fin n,
+                  (τ k : ℂ) *
+                    (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+              partialFourierSpatial_fun (d := d) (n := n) F
+                (τ, section43QSpatial (d := d) (n := n) q''))
+            q').curryLeft‖ ≤
+            Cexp * Csum := by
+        calc
+          ‖(iteratedFDeriv ℝ (r + 1)
+            (fun q'' : NPointDomain d n =>
+              Complex.exp
+                (-(∑ k : Fin n,
+                  (τ k : ℂ) *
+                    (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+              partialFourierSpatial_fun (d := d) (n := n) F
+                (τ, section43QSpatial (d := d) (n := n) q''))
+            q').curryLeft‖ =
+              ‖iteratedFDeriv ℝ (r + 1)
+                (fun q'' : NPointDomain d n =>
+                  Complex.exp
+                    (-(∑ k : Fin n,
+                      (τ k : ℂ) *
+                        (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+                  partialFourierSpatial_fun (d := d) (n := n) F
+                    (τ, section43QSpatial (d := d) (n := n) q''))
+                q'‖ := by
+                rw [ContinuousMultilinearMap.curryLeft_norm]
+          _ ≤
+              ‖Complex.exp
+                (-(∑ k : Fin n,
+                  (τ k : ℂ) *
+                    (section43QTime (d := d) (n := n) q' k : ℂ)))‖ *
+                ∑ a : Section43DerivativeWord d n (r + 1),
+                  section43DerivativeWordCoeff d n (r + 1) a *
+                    ‖τ‖ ^ section43DerivativeWordTimeCount d n (r + 1) a *
+                    ‖partialFourierSpatial_fun (d := d) (n := n)
+                      (section43DerivativeWordInput d n (r + 1) F a)
+                      (τ, section43QSpatial (d := d) (n := n) q')‖ := hmain
+          _ ≤ Cexp * Csum := by
+                exact mul_le_mul hExp hsum hsum_nonneg (Real.exp_pos _).le
+      simpa [C, F] using hnorm
+    · rw [Set.indicator_of_notMem hτ_mem]
+      have hdist_not : ¬ dist τ (0 : Fin n → ℝ) ≤ R := by
+        simpa [Kτ, Metric.mem_closedBall] using hτ_mem
+      have hlt_dist : R < dist τ (0 : Fin n → ℝ) := lt_of_not_ge hdist_not
+      have hlt : R < ‖τ‖ := by
+        simpa [dist_eq_norm, sub_zero] using hlt_dist
+      have hzero_fun :=
+        section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_timeNorm_gt_bound
+          d n (r + 1) f hf_ord hR_supp τ hlt
+      have hzero_at :
+          iteratedFDeriv ℝ (r + 1)
+            (fun q'' : NPointDomain d n =>
+              Complex.exp
+                (-(∑ k : Fin n,
+                  (τ k : ℂ) *
+                    (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+              partialFourierSpatial_fun (d := d) (n := n)
+                (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+                (τ, section43QSpatial (d := d) (n := n) q''))
+            q' = 0 := by
+        simpa using congrFun hzero_fun q'
+      simp [hzero_at]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Under compact ordered support, the fixed-`q` all-order pointwise derivative
+is Bochner-integrable in the real time variable. -/
+theorem integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    Integrable
+      (fun τ : Fin n → ℝ =>
+        iteratedFDeriv ℝ r
+          (fun q' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q' k : ℂ))) *
+            partialFourierSpatial_fun (d := d) (n := n)
+              (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+              (τ, section43QSpatial (d := d) (n := n) q'))
+          q) := by
+  classical
+  let F : SchwartzNPoint d n := section43DiffPullbackCLM d n ⟨f, hf_ord⟩
+  have hmeas : AEStronglyMeasurable
+      (fun τ : Fin n → ℝ =>
+        iteratedFDeriv ℝ r
+          (fun q' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q' k : ℂ))) *
+            partialFourierSpatial_fun (d := d) (n := n) F
+              (τ, section43QSpatial (d := d) (n := n) q'))
+          q) :=
+    (continuous_section43FourierLaplace_timeIntegrand_iteratedFDeriv
+      d n r F q).aestronglyMeasurable
+  cases r with
+  | zero =>
+      let e :=
+        continuousMultilinearCurryFin0 ℝ (NPointDomain d n) ℂ
+      have hbase :
+          Integrable
+            (fun τ : Fin n → ℝ =>
+              Complex.exp
+                (-(∑ k : Fin n,
+                  (τ k : ℂ) *
+                    (section43QTime (d := d) (n := n) q k : ℂ))) *
+              partialFourierSpatial_fun (d := d) (n := n)
+                (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+                (τ, section43QSpatial (d := d) (n := n) q)) :=
+        integrable_section43FourierLaplace_timeIntegrand_of_compact
+          d n f hf_ord hf_compact q
+      have hcomp :
+          Integrable
+            (fun τ : Fin n → ℝ =>
+              e.symm
+                (Complex.exp
+                  (-(∑ k : Fin n,
+                    (τ k : ℂ) *
+                      (section43QTime (d := d) (n := n) q k : ℂ))) *
+                partialFourierSpatial_fun (d := d) (n := n)
+                  (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+                  (τ, section43QSpatial (d := d) (n := n) q))) :=
+        (e.symm : ℂ →L[ℝ]
+          ContinuousMultilinearMap ℝ (fun _ : Fin 0 => NPointDomain d n) ℂ).integrable_comp hbase
+      convert hcomp using 1
+  | succ r =>
+      rcases
+        section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+          d n r f hf_ord hf_compact q with
+        ⟨bound, hbound_int, hbound⟩
+      have hq_self : q ∈ Metric.closedBall q (1 : ℝ) := by
+        simp [Metric.mem_closedBall]
+      refine Integrable.mono' hbound_int ?_ ?_
+      · simpa [F] using hmeas
+      · exact hbound.mono fun τ hτ => by
+          have hτq := hτ q hq_self
+          simpa [F, ContinuousMultilinearMap.curryLeft_norm] using hτq
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The curry-left pointwise derivative appearing in the dominated derivative
+theorem is aestrongly measurable in the real time variable. -/
+theorem aestronglyMeasurable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    AEStronglyMeasurable
+      (fun τ : Fin n → ℝ =>
+        (iteratedFDeriv ℝ (r + 1)
+          (fun q' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q' k : ℂ))) *
+            partialFourierSpatial_fun (d := d) (n := n)
+              (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+              (τ, section43QSpatial (d := d) (n := n) q'))
+          q).curryLeft) := by
+  let F : SchwartzNPoint d n := section43DiffPullbackCLM d n ⟨f, hf_ord⟩
+  let e :=
+    continuousMultilinearCurryLeftEquiv ℝ
+      (fun _ : Fin (r + 1) => NPointDomain d n) ℂ
+  have hint :
+      Integrable
+        (fun τ : Fin n → ℝ =>
+          iteratedFDeriv ℝ (r + 1)
+            (fun q' : NPointDomain d n =>
+              Complex.exp
+                (-(∑ k : Fin n,
+                  (τ k : ℂ) *
+                    (section43QTime (d := d) (n := n) q' k : ℂ))) *
+              partialFourierSpatial_fun (d := d) (n := n) F
+                (τ, section43QSpatial (d := d) (n := n) q'))
+            q) := by
+    simpa [F] using
+      integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact
+        d n (r + 1) f hf_ord hf_compact q
+  have hmeas : AEStronglyMeasurable fun τ : Fin n → ℝ =>
+      e (iteratedFDeriv ℝ (r + 1)
+        (fun q' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+        q) :=
+    e.continuous.comp_aestronglyMeasurable hint.aestronglyMeasurable
+  simpa [F, e] using hmeas
+
+end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceCompactDifferentiation.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceCompactDifferentiation.lean
@@ -596,4 +596,323 @@ theorem aestronglyMeasurable_section43FourierLaplace_timeIntegrand_iteratedFDeri
     e.continuous.comp_aestronglyMeasurable hint.aestronglyMeasurable
   simpa [F, e] using hmeas
 
+set_option maxHeartbeats 220000 in
+set_option backward.isDefEq.respectTransparency false in
+/-- Under compact ordered support, the integrated all-order derivative
+candidate has derivative given by the curry-left of the next integrated
+candidate. -/
+theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    HasFDerivAt
+      (fun q' : NPointDomain d n =>
+        section43FourierLaplaceIntegral_iteratedFDerivCandidate
+          d n r f hf_ord q')
+      ((section43FourierLaplaceIntegral_iteratedFDerivCandidate
+        d n (r + 1) f hf_ord q).curryLeft)
+      q := by
+  classical
+  let F : SchwartzNPoint d n := section43DiffPullbackCLM d n ⟨f, hf_ord⟩
+  let Fint : NPointDomain d n → (Fin n → ℝ) →
+      ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ :=
+    fun q' τ =>
+      iteratedFDeriv ℝ r
+        (fun q'' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q''))
+        q'
+  let Fderiv : NPointDomain d n → (Fin n → ℝ) →
+      NPointDomain d n →L[ℝ]
+        ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ :=
+    fun q' τ =>
+      (iteratedFDeriv ℝ (r + 1)
+        (fun q'' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q''))
+        q').curryLeft
+  rcases
+    section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+      d n r f hf_ord hf_compact q with
+    ⟨bound, hbound_int, hbound⟩
+  have hs : Metric.closedBall q (1 : ℝ) ∈ 𝓝 q :=
+    Metric.closedBall_mem_nhds q zero_lt_one
+  have hF_meas : ∀ᶠ q' in 𝓝 q, AEStronglyMeasurable (Fint q') := by
+    exact Filter.Eventually.of_forall fun q' =>
+      (integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact
+        d n r f hf_ord hf_compact q').aestronglyMeasurable
+  have hF_int : Integrable (Fint q) := by
+    simpa [Fint, F] using
+      integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact
+        d n r f hf_ord hf_compact q
+  have hbound' : ∀ᵐ τ : Fin n → ℝ, ∀ q' ∈ Metric.closedBall q (1 : ℝ),
+      ‖Fderiv q' τ‖ ≤ bound τ := by
+    simpa [Fderiv, F] using hbound
+  have hq_self : q ∈ Metric.closedBall q (1 : ℝ) := by
+    simp [Metric.mem_closedBall]
+  let Phi : (Fin n → ℝ) →
+      ContinuousMultilinearMap ℝ
+        (fun _ : Fin (r + 1) => NPointDomain d n) ℂ :=
+    fun τ =>
+      iteratedFDeriv ℝ (r + 1)
+        (fun q'' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q''))
+        q
+  have hnext_int :
+      @Integrable
+        (ContinuousMultilinearMap ℝ
+          (fun _ : Fin (r + 1) => NPointDomain d n) ℂ)
+        PseudoMetricSpace.toUniformSpace.toTopologicalSpace
+        SeminormedAddGroup.toContinuousENorm
+        (Fin n → ℝ) _ Phi volume := by
+    simpa [F] using
+      integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact
+        d n (r + 1) f hf_ord hf_compact q
+  have hcurry_lipschitz :
+      LipschitzWith 1
+        (fun L : ContinuousMultilinearMap ℝ
+            (fun _ : Fin (r + 1) => NPointDomain d n) ℂ =>
+          L.curryLeft) := by
+    refine LipschitzWith.of_dist_le_mul ?_
+    intro L M
+    simp only [NNReal.coe_one, one_mul]
+    rw [dist_eq_norm, dist_eq_norm]
+    have hsub : L.curryLeft - M.curryLeft = (L - M).curryLeft := by
+      ext v mtail
+      simp [ContinuousMultilinearMap.curryLeft_apply]
+    rw [hsub, ContinuousMultilinearMap.curryLeft_norm]
+  have hFderiv_int :
+      @Integrable
+        (NPointDomain d n →L[ℝ]
+          ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ)
+        PseudoMetricSpace.toUniformSpace.toTopologicalSpace
+        SeminormedAddGroup.toContinuousENorm
+        (Fin n → ℝ) _ (Fderiv q) volume := by
+    refine Integrable.mono
+      (f := Fderiv q)
+      (g := Phi)
+      hnext_int ?_ ?_
+    · have hmeas :
+          AEStronglyMeasurable
+            (fun τ : Fin n → ℝ => (Phi τ).curryLeft) :=
+          hcurry_lipschitz.continuous.comp_aestronglyMeasurable
+            hnext_int.aestronglyMeasurable
+      simpa [Fderiv, Phi] using hmeas
+    · filter_upwards with τ
+      simp [Fderiv, Phi, ContinuousMultilinearMap.curryLeft_norm]
+  have hFderiv_meas := hFderiv_int.aestronglyMeasurable
+  have hdiff : ∀ᵐ τ : Fin n → ℝ, ∀ q' ∈ Metric.closedBall q (1 : ℝ),
+      HasFDerivAt (Fint · τ) (Fderiv q' τ) q' := by
+    filter_upwards with τ q' _hq'
+    simpa [Fint, Fderiv, F] using
+      hasFDerivAt_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft
+        d n r F q' τ
+  have hmain :=
+    hasFDerivAt_integral_of_dominated_of_fderiv_le
+      (𝕜 := ℝ) (μ := volume)
+      (F := Fint) (F' := Fderiv) (x₀ := q)
+      (s := Metric.closedBall q (1 : ℝ)) (bound := bound)
+      hs hF_meas hF_int hFderiv_meas hbound' hbound_int hdiff
+  have hderivIntegral :
+      (∫ τ : Fin n → ℝ, Fderiv q τ) =
+        ((∫ τ : Fin n → ℝ, Phi τ).curryLeft) := by
+    letI : SeminormedAddCommGroup
+        (ContinuousMultilinearMap ℝ
+          (fun _ : Fin (r + 1) => NPointDomain d n) ℂ) :=
+      NormedAddCommGroup.toSeminormedAddCommGroup
+    letI : SeminormedAddCommGroup
+        (NPointDomain d n →L[ℝ]
+          ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ) :=
+      NormedAddCommGroup.toSeminormedAddCommGroup
+    let curryLI :
+        ContinuousMultilinearMap ℝ
+            (fun _ : Fin (r + 1) => NPointDomain d n) ℂ →ₗᵢ[ℝ]
+          (NPointDomain d n →L[ℝ]
+            ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ) :=
+      { toLinearMap :=
+          { toFun := fun L => L.curryLeft
+            map_add' := by
+              intro L M
+              rfl
+            map_smul' := by
+              intro c L
+              rfl }
+        norm_map' := by
+          intro L
+          exact ContinuousMultilinearMap.curryLeft_norm L }
+    haveI : CompleteSpace
+        (ContinuousMultilinearMap ℝ
+          (fun _ : Fin (r + 1) => NPointDomain d n) ℂ) := inferInstance
+    change (∫ τ : Fin n → ℝ, curryLI (Phi τ)) =
+      curryLI (∫ τ : Fin n → ℝ, Phi τ)
+    exact
+      (ContinuousLinearMap.integral_comp_comm
+          (𝕜 := ℝ)
+          (E := ContinuousMultilinearMap ℝ
+            (fun _ : Fin (r + 1) => NPointDomain d n) ℂ)
+          (Fₗ := NPointDomain d n →L[ℝ]
+            ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ)
+          (X := Fin n → ℝ)
+          (μ := volume)
+          curryLI.toContinuousLinearMap hnext_int)
+  rw [hderivIntegral] at hmain
+  simpa [section43FourierLaplaceIntegral_iteratedFDerivCandidate,
+    Fint, Fderiv, F] using hmain
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Under compact ordered support, the iterated derivatives of the
+Fourier-Laplace integral are the integrated pointwise derivative candidates. -/
+theorem section43FourierLaplaceIntegral_iteratedFDeriv_eq_candidate_of_compact_orderedSupport
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q')
+      q =
+      section43FourierLaplaceIntegral_iteratedFDerivCandidate
+        d n r f hf_ord q := by
+  classical
+  let G : NPointDomain d n → ℂ := fun q' =>
+    section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q'
+  induction r generalizing q with
+  | zero =>
+      ext m
+      have hint :
+          Integrable
+            (fun τ : Fin n → ℝ =>
+              iteratedFDeriv ℝ 0
+                (fun q' : NPointDomain d n =>
+                  Complex.exp
+                    (-(∑ k : Fin n,
+                      (τ k : ℂ) *
+                        (section43QTime (d := d) (n := n) q' k : ℂ))) *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+                    (τ, section43QSpatial (d := d) (n := n) q'))
+                q) := by
+        simpa using
+          integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact
+            d n 0 f hf_ord hf_compact q
+      change
+        section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q =
+          (∫ τ : Fin n → ℝ,
+            iteratedFDeriv ℝ 0
+              (fun q' : NPointDomain d n =>
+                Complex.exp
+                  (-(∑ k : Fin n,
+                    (τ k : ℂ) *
+                      (section43QTime (d := d) (n := n) q' k : ℂ))) *
+                partialFourierSpatial_fun (d := d) (n := n)
+                  (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+                  (τ, section43QSpatial (d := d) (n := n) q'))
+              q) m
+      rw [ContinuousMultilinearMap.integral_apply hint m]
+      simp [section43FourierLaplaceIntegral, iteratedFDeriv_zero_apply]
+  | succ r ih =>
+      have hfun :
+          iteratedFDeriv ℝ r G =
+          fun q' : NPointDomain d n =>
+            section43FourierLaplaceIntegral_iteratedFDerivCandidate
+              d n r f hf_ord q' := by
+        funext q'
+        simpa [G] using ih q'
+      have hfd :
+          fderiv ℝ (iteratedFDeriv ℝ r G) q =
+            (section43FourierLaplaceIntegral_iteratedFDerivCandidate
+              d n (r + 1) f hf_ord q).curryLeft := by
+        have hderiv :=
+          section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport
+            d n r f hf_ord hf_compact q
+        rw [hfun]
+        exact hderiv.fderiv
+      rw [iteratedFDeriv_succ_eq_comp_left, Function.comp_apply, hfd]
+      exact ContinuousMultilinearMap.uncurry_curryLeft _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Under compact ordered support, the Section 4.3 Fourier-Laplace integral is
+ambient smooth in the positive-energy variable. -/
+theorem section43FourierLaplaceIntegral_contDiff_of_compact_orderedSupport
+    (d n : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ)) :
+    ContDiff ℝ (↑(⊤ : ℕ∞))
+      (fun q : NPointDomain d n =>
+        section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q) := by
+  classical
+  let G : NPointDomain d n → ℂ := fun q =>
+    section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q
+  change ContDiff ℝ (↑(⊤ : ℕ∞)) G
+  refine contDiff_of_differentiable_iteratedFDeriv
+    (𝕜 := ℝ) (E := NPointDomain d n) (F := ℂ) (f := G) (n := (⊤ : ℕ∞)) ?_
+  intro r _hr
+  have hfun :
+      iteratedFDeriv ℝ r G =
+      fun q : NPointDomain d n =>
+        section43FourierLaplaceIntegral_iteratedFDerivCandidate
+          d n r f hf_ord q := by
+    funext q
+    simpa [G] using
+      section43FourierLaplaceIntegral_iteratedFDeriv_eq_candidate_of_compact_orderedSupport
+        d n r f hf_ord hf_compact q
+  rw [hfun]
+  intro q
+  exact
+    (section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport
+      d n r f hf_ord hf_compact q).differentiableAt
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Rapid decay of the actual all-order derivatives of the Section 4.3
+Fourier-Laplace integral on the positive-energy half-space. -/
+theorem section43FourierLaplaceIntegral_iteratedFDeriv_rapid_on_positiveEnergy
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    {δ : ℝ} (hδ_pos : 0 < δ)
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)}) :
+    ∀ s : ℕ, ∃ C : ℝ, 0 ≤ C ∧
+      ∀ q ∈ section43PositiveEnergyRegion d n,
+        (1 + ‖q‖) ^ s *
+          ‖iteratedFDeriv ℝ r
+            (fun q' : NPointDomain d n =>
+              section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q')
+            q‖ ≤ C := by
+  intro s
+  rcases
+    section43FourierLaplaceIntegral_iteratedFDerivCandidate_rapid_on_positiveEnergy
+      d n r f hf_ord hδ_pos hδ_supp s with
+    ⟨C, hC_nonneg, hC_bound⟩
+  refine ⟨C, hC_nonneg, ?_⟩
+  intro q hq
+  rw [section43FourierLaplaceIntegral_iteratedFDeriv_eq_candidate_of_compact_orderedSupport
+    d n r f hf_ord hf_compact q]
+  exact hC_bound q hq
+
 end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceHigherDerivatives.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceHigherDerivatives.lean
@@ -572,4 +572,623 @@ theorem section43FourierLaplace_timeIntegrandFDerivCLM_apply_eq_sum_atoms
                     (τ, section43QSpatial (d := d) (n := n) q) := by
           rw [← hsplit]
 
+/-- The pointwise Section 4.3 Fourier-Laplace time integrand is smooth in the
+positive-energy variable `q`, for fixed real time parameter `τ`.  This is the
+regularity input needed to pass from the CLM-valued `iteratedFDeriv` recursion
+to an applied scalar derivative after freezing the old directions. -/
+theorem contDiff_section43FourierLaplace_timeIntegrand_q
+    (d n : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (τ : Fin n → ℝ) :
+    ContDiff ℝ (⊤ : ℕ∞)
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q')) := by
+  classical
+  have hEarg : ContDiff ℝ (⊤ : ℕ∞) (fun q' : NPointDomain d n =>
+      -(∑ k : Fin n,
+        (τ k : ℂ) *
+          (section43QTime (d := d) (n := n) q' k : ℂ))) := by
+    apply ContDiff.neg
+    apply ContDiff.sum
+    intro k _hk
+    have hreal : ContDiff ℝ (⊤ : ℕ∞) (fun q' : NPointDomain d n =>
+        section43QTime (d := d) (n := n) q' k) := by
+      let L : NPointDomain d n →L[ℝ] ℝ :=
+        (ContinuousLinearMap.proj (R := ℝ) (ι := Fin n) (φ := fun _ => ℝ) k).comp
+          (section43QTimeCLM d n)
+      simpa [L] using L.contDiff
+    have hcomplex : ContDiff ℝ (⊤ : ℕ∞) (fun q' : NPointDomain d n =>
+        (section43QTime (d := d) (n := n) q' k : ℂ)) := by
+      exact Complex.ofRealCLM.contDiff.comp hreal
+    exact contDiff_const.mul hcomplex
+  have hE : ContDiff ℝ (⊤ : ℕ∞) (fun q' : NPointDomain d n =>
+      Complex.exp
+        (-(∑ k : Fin n,
+          (τ k : ℂ) *
+            (section43QTime (d := d) (n := n) q' k : ℂ)))) :=
+    Complex.contDiff_exp.comp hEarg
+  have hP : ContDiff ℝ (⊤ : ℕ∞) (fun q' : NPointDomain d n =>
+      partialFourierSpatial_fun (d := d) (n := n) F
+        (τ, section43QSpatial (d := d) (n := n) q')) := by
+    let hbase : ContDiff ℝ (⊤ : ℕ∞)
+        (partialFourierSpatial_fun (d := d) (n := n) F) :=
+      contDiff_partialFourierSpatial_fun_joint (d := d) (n := n) F
+    have hspatial : ContDiff ℝ (⊤ : ℕ∞) (fun q' : NPointDomain d n =>
+        section43QSpatial (d := d) (n := n) q') := by
+      simpa using (section43QSpatialCLM d n).contDiff
+    let hpath : ContDiff ℝ (⊤ : ℕ∞) (fun q' : NPointDomain d n =>
+        (τ, section43QSpatial (d := d) (n := n) q')) :=
+      (contDiff_const :
+        ContDiff ℝ (⊤ : ℕ∞) (fun _ : NPointDomain d n => τ)).prodMk hspatial
+    simpa using hbase.comp hpath
+  exact hE.mul hP
+
+/-- Differentiating a fixed old-word summand only differentiates the basic
+Fourier-Laplace integrand; the old word scalar is constant in `q`. -/
+private theorem hasFDerivAt_section43FourierLaplace_timeIntegrand_wordTerm
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (a : Section43DerivativeWord d n r)
+    (τ : Fin n → ℝ)
+    (m : Fin r → NPointDomain d n)
+    (q : NPointDomain d n) :
+    HasFDerivAt
+      (fun q' : NPointDomain d n =>
+        section43DerivativeWordScalar d n r a τ m *
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n)
+            (section43DerivativeWordInput d n r F a)
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      (section43DerivativeWordScalar d n r a τ m •
+        section43FourierLaplace_timeIntegrandFDerivCLM d n
+          (section43DerivativeWordInput d n r F a) q τ)
+      q := by
+  let c : ℂ := section43DerivativeWordScalar d n r a τ m
+  let F' : SchwartzNPoint d n := section43DerivativeWordInput d n r F a
+  simpa [c, F', mul_assoc] using
+    (hasFDerivAt_section43FourierLaplace_timeIntegrand d n F' q τ).const_mul c
+
+/-- Expanding the first derivative of every old-word summand and reindexing by
+prepending the new derivative atom gives the next word layer. -/
+theorem section43FourierLaplace_sum_words_fderivCLM_apply_eq_sum_cons
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q v : NPointDomain d n)
+    (τ : Fin n → ℝ)
+    (mtail : Fin r → NPointDomain d n) :
+    (∑ a : Section43DerivativeWord d n r,
+      section43DerivativeWordScalar d n r a τ mtail *
+        section43FourierLaplace_timeIntegrandFDerivCLM d n
+          (section43DerivativeWordInput d n r F a) q τ v) =
+    ∑ a : Section43DerivativeWord d n (r + 1),
+      section43DerivativeWordScalar d n (r + 1) a τ (Fin.cons v mtail) *
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q k : ℂ))) *
+        partialFourierSpatial_fun (d := d) (n := n)
+          (section43DerivativeWordInput d n (r + 1) F a)
+          (τ, section43QSpatial (d := d) (n := n) q) := by
+  classical
+  let E : ℂ :=
+    Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) * (section43QTime (d := d) (n := n) q k : ℂ)))
+  calc
+    (∑ a : Section43DerivativeWord d n r,
+      section43DerivativeWordScalar d n r a τ mtail *
+        section43FourierLaplace_timeIntegrandFDerivCLM d n
+          (section43DerivativeWordInput d n r F a) q τ v) =
+      ∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordScalar d n r a τ mtail *
+          (∑ head : Section43DerivativeAtom d n,
+            match head with
+            | Section43DerivativeAtom.time k =>
+                (-((τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) v k : ℂ))) * E *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43DerivativeWordInput d n r F a)
+                    (τ, section43QSpatial (d := d) (n := n) q)
+            | Section43DerivativeAtom.spatial i =>
+                ((section43QSpatial (d := d) (n := n) v i : ℝ) : ℂ) * E *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43SpatialMultiplierTransport d n
+                      (section43DerivativeWordInput d n r F a) i)
+                    (τ, section43QSpatial (d := d) (n := n) q)) := by
+        refine Finset.sum_congr rfl ?_
+        intro a _ha
+        rw [section43FourierLaplace_timeIntegrandFDerivCLM_apply_eq_sum_atoms]
+    _ = ∑ a : Section43DerivativeWord d n r,
+        ∑ head : Section43DerivativeAtom d n,
+          section43DerivativeWordScalar d n r a τ mtail *
+            (match head with
+            | Section43DerivativeAtom.time k =>
+                (-((τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) v k : ℂ))) * E *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43DerivativeWordInput d n r F a)
+                    (τ, section43QSpatial (d := d) (n := n) q)
+            | Section43DerivativeAtom.spatial i =>
+                ((section43QSpatial (d := d) (n := n) v i : ℝ) : ℂ) * E *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43SpatialMultiplierTransport d n
+                      (section43DerivativeWordInput d n r F a) i)
+                    (τ, section43QSpatial (d := d) (n := n) q)) := by
+        simp [Finset.mul_sum]
+    _ = ∑ head : Section43DerivativeAtom d n,
+        ∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordScalar d n r a τ mtail *
+            (match head with
+            | Section43DerivativeAtom.time k =>
+                (-((τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) v k : ℂ))) * E *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43DerivativeWordInput d n r F a)
+                    (τ, section43QSpatial (d := d) (n := n) q)
+            | Section43DerivativeAtom.spatial i =>
+                ((section43QSpatial (d := d) (n := n) v i : ℝ) : ℂ) * E *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43SpatialMultiplierTransport d n
+                      (section43DerivativeWordInput d n r F a) i)
+                    (τ, section43QSpatial (d := d) (n := n) q)) := by
+        rw [Finset.sum_comm]
+    _ = ∑ head : Section43DerivativeAtom d n,
+        ∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordScalar d n (r + 1)
+            (section43DerivativeWordCons d n r head a) τ (Fin.cons v mtail) *
+            E *
+            partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n (r + 1) F
+                (section43DerivativeWordCons d n r head a))
+              (τ, section43QSpatial (d := d) (n := n) q) := by
+        refine Finset.sum_congr rfl ?_
+        intro head _hhead
+        refine Finset.sum_congr rfl ?_
+        intro a _ha
+        cases head with
+        | time k =>
+            simp [E, mul_assoc, mul_left_comm, mul_comm]
+        | spatial i =>
+            simp [E, mul_assoc, mul_comm]
+    _ = ∑ a : Section43DerivativeWord d n (r + 1),
+      section43DerivativeWordScalar d n (r + 1) a τ (Fin.cons v mtail) *
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q k : ℂ))) *
+        partialFourierSpatial_fun (d := d) (n := n)
+          (section43DerivativeWordInput d n (r + 1) F a)
+          (τ, section43QSpatial (d := d) (n := n) q) := by
+        rw [section43DerivativeWord_sum_cons]
+
+/-- Pointwise all-order finite-word expansion for the Section 4.3
+Fourier-Laplace time integrand.  Each derivative slot either differentiates the
+Laplace exponential, producing a `time` atom, or differentiates the spatial
+Fourier argument, producing a `spatial` atom and transporting the input
+Schwartz function by the corresponding coordinate multiplier. -/
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (τ : Fin n → ℝ)
+    (m : Fin r → NPointDomain d n) :
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q m =
+      ∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordScalar d n r a τ m *
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n)
+            (section43DerivativeWordInput d n r F a)
+            (τ, section43QSpatial (d := d) (n := n) q) := by
+  classical
+  induction r generalizing q with
+  | zero =>
+      simp [section43DerivativeWordScalar, section43DerivativeWordInput]
+  | succ r ih =>
+      let G : NPointDomain d n → ℂ := fun q' =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q')
+      let v : NPointDomain d n := m 0
+      let mtail : Fin r → NPointDomain d n := section43DirectionTail d n r m
+      have hm : Fin.cons v mtail = m := by
+        change Fin.cons (m 0) (Fin.tail m) = m
+        exact Fin.cons_self_tail m
+      have hGsmooth : ContDiff ℝ (⊤ : ℕ∞) G := by
+        simpa [G] using contDiff_section43FourierLaplace_timeIntegrand_q d n F τ
+      have hGdiff : DifferentiableAt ℝ (iteratedFDeriv ℝ r G) q := by
+        exact hGsmooth.contDiffAt.differentiableAt_iteratedFDeriv
+          (WithTop.coe_lt_coe.2 (ENat.coe_lt_top r))
+      have happly :
+          (fderiv ℝ (fun q' : NPointDomain d n => (iteratedFDeriv ℝ r G q') mtail) q) v =
+            (fderiv ℝ (iteratedFDeriv ℝ r G) q) v mtail := by
+        simpa using
+          (fderiv_continuousMultilinear_apply_const_apply
+            (𝕜 := ℝ) (c := fun q' : NPointDomain d n => iteratedFDeriv ℝ r G q')
+            (x := q) hGdiff mtail v)
+      have hfun :
+          (fun q' : NPointDomain d n => (iteratedFDeriv ℝ r G q') mtail) =
+            fun q' : NPointDomain d n =>
+              ∑ a : Section43DerivativeWord d n r,
+                section43DerivativeWordScalar d n r a τ mtail *
+                  Complex.exp
+                    (-(∑ k : Fin n,
+                      (τ k : ℂ) *
+                        (section43QTime (d := d) (n := n) q' k : ℂ))) *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43DerivativeWordInput d n r F a)
+                    (τ, section43QSpatial (d := d) (n := n) q') := by
+        funext q'
+        simpa [G] using ih q' mtail
+      have hsumDeriv :
+          HasFDerivAt
+            (fun q' : NPointDomain d n =>
+              ∑ a : Section43DerivativeWord d n r,
+                section43DerivativeWordScalar d n r a τ mtail *
+                  Complex.exp
+                    (-(∑ k : Fin n,
+                      (τ k : ℂ) *
+                        (section43QTime (d := d) (n := n) q' k : ℂ))) *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43DerivativeWordInput d n r F a)
+                    (τ, section43QSpatial (d := d) (n := n) q'))
+            (∑ a : Section43DerivativeWord d n r,
+              section43DerivativeWordScalar d n r a τ mtail •
+                section43FourierLaplace_timeIntegrandFDerivCLM d n
+                  (section43DerivativeWordInput d n r F a) q τ)
+            q := by
+        apply HasFDerivAt.fun_sum
+        intro a _ha
+        exact hasFDerivAt_section43FourierLaplace_timeIntegrand_wordTerm
+          d n r F a τ mtail q
+      have hfderiv_sum_apply :
+          (fderiv ℝ
+            (fun q' : NPointDomain d n =>
+              ∑ a : Section43DerivativeWord d n r,
+                section43DerivativeWordScalar d n r a τ mtail *
+                  Complex.exp
+                    (-(∑ k : Fin n,
+                      (τ k : ℂ) *
+                        (section43QTime (d := d) (n := n) q' k : ℂ))) *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43DerivativeWordInput d n r F a)
+                    (τ, section43QSpatial (d := d) (n := n) q')) q) v =
+            ∑ a : Section43DerivativeWord d n r,
+              section43DerivativeWordScalar d n r a τ mtail *
+                section43FourierLaplace_timeIntegrandFDerivCLM d n
+                  (section43DerivativeWordInput d n r F a) q τ v := by
+        rw [hsumDeriv.fderiv]
+        simp [ContinuousLinearMap.sum_apply, ContinuousLinearMap.smul_apply, smul_eq_mul]
+      rw [← hm]
+      calc
+        iteratedFDeriv ℝ (r + 1) G q (Fin.cons v mtail) =
+            (fderiv ℝ (iteratedFDeriv ℝ r G) q) v mtail := by
+              rfl
+        _ = (fderiv ℝ (fun q' : NPointDomain d n => (iteratedFDeriv ℝ r G q') mtail) q) v := by
+              rw [← happly]
+        _ = (fderiv ℝ
+              (fun q' : NPointDomain d n =>
+                ∑ a : Section43DerivativeWord d n r,
+                  section43DerivativeWordScalar d n r a τ mtail *
+                    Complex.exp
+                      (-(∑ k : Fin n,
+                        (τ k : ℂ) *
+                          (section43QTime (d := d) (n := n) q' k : ℂ))) *
+                    partialFourierSpatial_fun (d := d) (n := n)
+                      (section43DerivativeWordInput d n r F a)
+                      (τ, section43QSpatial (d := d) (n := n) q')) q) v := by
+              rw [hfun]
+        _ = ∑ a : Section43DerivativeWord d n r,
+              section43DerivativeWordScalar d n r a τ mtail *
+                section43FourierLaplace_timeIntegrandFDerivCLM d n
+                  (section43DerivativeWordInput d n r F a) q τ v := hfderiv_sum_apply
+        _ = ∑ a : Section43DerivativeWord d n (r + 1),
+              section43DerivativeWordScalar d n (r + 1) a τ (Fin.cons v mtail) *
+                Complex.exp
+                  (-(∑ k : Fin n,
+                    (τ k : ℂ) *
+                      (section43QTime (d := d) (n := n) q k : ℂ))) *
+                partialFourierSpatial_fun (d := d) (n := n)
+                  (section43DerivativeWordInput d n (r + 1) F a)
+                  (τ, section43QSpatial (d := d) (n := n) q) := by
+              exact section43FourierLaplace_sum_words_fderivCLM_apply_eq_sum_cons
+                d n r F q v τ mtail
+
+/-- Positive-energy pointwise norm bound for the all-order finite-word
+expansion, applied to a fixed tuple of derivative directions. -/
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    {δ : ℝ}
+    (q : NPointDomain d n) (hq : q ∈ section43PositiveEnergyRegion d n)
+    (τ : Fin n → ℝ)
+    (hτ_margin : ∀ k : Fin n, δ ≤ τ k)
+    (m : Fin r → NPointDomain d n) :
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q m‖ ≤
+      Real.exp (-(δ * ∑ k : Fin n,
+        section43QTime (d := d) (n := n) q k)) *
+        (∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖) *
+        ∏ j : Fin r, ‖m j‖ := by
+  classical
+  let E : ℂ :=
+    Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) * (section43QTime (d := d) (n := n) q k : ℂ)))
+  let A : ℝ :=
+    Real.exp (-(δ * ∑ k : Fin n, section43QTime (d := d) (n := n) q k))
+  let dirProd : ℝ := ∏ j : Fin r, ‖m j‖
+  let P : Section43DerivativeWord d n r → ℂ := fun a =>
+    partialFourierSpatial_fun (d := d) (n := n)
+      (section43DerivativeWordInput d n r F a)
+      (τ, section43QSpatial (d := d) (n := n) q)
+  have hEbound : ‖E‖ ≤ A := by
+    simpa [E, A] using
+      norm_exp_neg_section43_timePair_le_exp_neg_margin_sum
+        d n q τ hq hτ_margin
+  have hmain :
+      ‖∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordScalar d n r a τ m * E * P a‖ ≤
+        ∑ a : Section43DerivativeWord d n r,
+          A *
+            (section43DerivativeWordCoeff d n r a *
+              ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+            dirProd := by
+    calc
+      ‖∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordScalar d n r a τ m * E * P a‖ ≤
+          ∑ a : Section43DerivativeWord d n r,
+            ‖section43DerivativeWordScalar d n r a τ m * E * P a‖ := by
+            exact norm_sum_le _ _
+      _ ≤ ∑ a : Section43DerivativeWord d n r,
+          A *
+            (section43DerivativeWordCoeff d n r a *
+              ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+            dirProd := by
+          refine Finset.sum_le_sum ?_
+          intro a _ha
+          have hscalar := section43DerivativeWordScalar_norm_le d n r a τ m
+          have hupper_nonneg :
+              0 ≤ section43DerivativeWordCoeff d n r a *
+                ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * dirProd := by
+            exact mul_nonneg
+              (mul_nonneg (section43DerivativeWordCoeff_nonneg d n r a)
+                (pow_nonneg (norm_nonneg τ) _))
+              (Finset.prod_nonneg fun j _hj => norm_nonneg (m j))
+          have hSE :
+              ‖section43DerivativeWordScalar d n r a τ m‖ * ‖E‖ ≤
+                (section43DerivativeWordCoeff d n r a *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * dirProd) * A := by
+            exact mul_le_mul hscalar hEbound (norm_nonneg E) hupper_nonneg
+          have hP_nonneg : 0 ≤ ‖P a‖ := norm_nonneg _
+          calc
+            ‖section43DerivativeWordScalar d n r a τ m * E * P a‖ =
+                ‖section43DerivativeWordScalar d n r a τ m‖ * ‖E‖ * ‖P a‖ := by
+                  simp [mul_assoc]
+            _ ≤ ((section43DerivativeWordCoeff d n r a *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * dirProd) * A) *
+                  ‖P a‖ := by
+                  exact mul_le_mul_of_nonneg_right hSE hP_nonneg
+            _ = A *
+                (section43DerivativeWordCoeff d n r a *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+                dirProd := by
+                  ring
+  calc
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q m‖ =
+        ‖∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordScalar d n r a τ m * E * P a‖ := by
+          rw [section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words]
+    _ ≤ ∑ a : Section43DerivativeWord d n r,
+          A *
+            (section43DerivativeWordCoeff d n r a *
+              ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+            dirProd := hmain
+    _ = A *
+        (∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+        dirProd := by
+          rw [← Finset.sum_mul]
+          congr 1
+          rw [Finset.mul_sum]
+    _ = Real.exp (-(δ * ∑ k : Fin n,
+        section43QTime (d := d) (n := n) q k)) *
+        (∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖) *
+        ∏ j : Fin r, ‖m j‖ := by
+          simp [A, P, dirProd]
+
+/-- Below the ordered-support time margin, the pointwise Fourier-Laplace time
+integrand for the OS-I difference-coordinate pullback is identically zero as a
+function of the positive-energy variable `q`. -/
+theorem section43FourierLaplace_timeIntegrand_eq_zero_of_exists_time_lt_margin
+    (d n : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ}
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)})
+    (τ : Fin n → ℝ)
+    (hτ : ∃ i : Fin n, τ i < δ) :
+    (fun q' : NPointDomain d n =>
+      Complex.exp
+        (-(∑ k : Fin n,
+          (τ k : ℂ) *
+            (section43QTime (d := d) (n := n) q' k : ℂ))) *
+      partialFourierSpatial_fun (d := d) (n := n)
+        (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+        (τ, section43QSpatial (d := d) (n := n) q')) =
+      fun _ => 0 := by
+  funext q'
+  have hP_zero :
+      partialFourierSpatial_fun (d := d) (n := n)
+        (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+        (τ, section43QSpatial (d := d) (n := n) q') = 0 := by
+    exact partialFourierSpatial_section43DiffPullback_eq_zero_of_exists_time_lt_margin
+      d n f hf_ord hδ_supp τ (section43QSpatial (d := d) (n := n) q') hτ
+  simp [hP_zero]
+
+/-- Below the ordered-support time margin, all pointwise iterated derivatives
+of the Fourier-Laplace time integrand vanish.  The proof goes through the
+zero-function identity for the original integrand, avoiding any transported-word
+support claim. -/
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_exists_time_lt_margin
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ}
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)})
+    (τ : Fin n → ℝ)
+    (hτ : ∃ i : Fin n, τ i < δ) :
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+        partialFourierSpatial_fun (d := d) (n := n)
+          (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+          (τ, section43QSpatial (d := d) (n := n) q')) =
+      0 := by
+  rw [section43FourierLaplace_timeIntegrand_eq_zero_of_exists_time_lt_margin
+    d n f hf_ord hδ_supp τ hτ]
+  simp
+
+/-- Pointwise operator-norm bound for the all-order Fourier-Laplace integrand
+derivative.  The proof splits on the lower-margin branch; above the margin it
+packages the applied word bound with `ContinuousMultilinearMap.opNorm_le_bound`. -/
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ}
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)})
+    (q : NPointDomain d n) (hq : q ∈ section43PositiveEnergyRegion d n)
+    (τ : Fin n → ℝ) :
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n)
+            (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q‖ ≤
+      Real.exp (-(δ * ∑ k : Fin n,
+        section43QTime (d := d) (n := n) q k)) *
+        ∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r
+                (section43DiffPullbackCLM d n ⟨f, hf_ord⟩) a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖ := by
+  classical
+  let F : SchwartzNPoint d n := section43DiffPullbackCLM d n ⟨f, hf_ord⟩
+  let A : ℝ :=
+    Real.exp (-(δ * ∑ k : Fin n, section43QTime (d := d) (n := n) q k))
+  let S : ℝ :=
+    ∑ a : Section43DerivativeWord d n r,
+      section43DerivativeWordCoeff d n r a *
+        ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+        ‖partialFourierSpatial_fun (d := d) (n := n)
+          (section43DerivativeWordInput d n r F a)
+          (τ, section43QSpatial (d := d) (n := n) q)‖
+  have hS_nonneg : 0 ≤ S := by
+    dsimp [S]
+    refine Finset.sum_nonneg ?_
+    intro a _ha
+    exact mul_nonneg
+      (mul_nonneg (section43DerivativeWordCoeff_nonneg d n r a)
+        (pow_nonneg (norm_nonneg τ) _))
+      (norm_nonneg _)
+  have hM_nonneg : 0 ≤ A * S := mul_nonneg (Real.exp_pos _).le hS_nonneg
+  by_cases hlow : ∃ i : Fin n, τ i < δ
+  · have hzero :=
+      section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_exists_time_lt_margin
+        d n r f hf_ord hδ_supp τ hlow
+    rw [hzero]
+    simpa [A, S, F] using hM_nonneg
+  · have hτ_margin : ∀ i : Fin n, δ ≤ τ i := by
+      intro i
+      exact le_of_not_gt fun hi => hlow ⟨i, hi⟩
+    have hop :
+        ‖iteratedFDeriv ℝ r
+          (fun q' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q' k : ℂ))) *
+              partialFourierSpatial_fun (d := d) (n := n) F
+                (τ, section43QSpatial (d := d) (n := n) q'))
+          q‖ ≤ A * S := by
+      refine ContinuousMultilinearMap.opNorm_le_bound hM_nonneg ?_
+      intro m
+      have happly :=
+        norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words
+          d n r F q hq τ hτ_margin m
+      simpa [A, S, F] using happly
+    simpa [A, S, F] using hop
+
 end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceHigherDerivatives.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceHigherDerivatives.lean
@@ -1182,7 +1182,7 @@ theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
                   (section43QTime (d := d) (n := n) q' k : ℂ))) *
               partialFourierSpatial_fun (d := d) (n := n) F
                 (τ, section43QSpatial (d := d) (n := n) q'))
-          q‖ ≤ A * S := by
+      q‖ ≤ A * S := by
       refine ContinuousMultilinearMap.opNorm_le_bound hM_nonneg ?_
       intro m
       have happly :=
@@ -1190,6 +1190,301 @@ theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
           d n r F q hq τ hτ_margin m
       simpa [A, S, F] using happly
     simpa [A, S, F] using hop
+
+/-- Pointwise norm bound for the all-order finite-word expansion without any
+positive-energy or time-margin assumptions.  The exponential is left as its
+actual norm; this is the compact-slab variant needed for dominated
+differentiation. -/
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words_absExp
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (τ : Fin n → ℝ)
+    (m : Fin r → NPointDomain d n) :
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q m‖ ≤
+      ‖Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q k : ℂ)))‖ *
+        (∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖) *
+        ∏ j : Fin r, ‖m j‖ := by
+  classical
+  let E : ℂ :=
+    Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) * (section43QTime (d := d) (n := n) q k : ℂ)))
+  let dirProd : ℝ := ∏ j : Fin r, ‖m j‖
+  let P : Section43DerivativeWord d n r → ℂ := fun a =>
+    partialFourierSpatial_fun (d := d) (n := n)
+      (section43DerivativeWordInput d n r F a)
+      (τ, section43QSpatial (d := d) (n := n) q)
+  have hmain :
+      ‖∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordScalar d n r a τ m * E * P a‖ ≤
+        ∑ a : Section43DerivativeWord d n r,
+          ‖E‖ *
+            (section43DerivativeWordCoeff d n r a *
+              ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+            dirProd := by
+    calc
+      ‖∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordScalar d n r a τ m * E * P a‖ ≤
+          ∑ a : Section43DerivativeWord d n r,
+            ‖section43DerivativeWordScalar d n r a τ m * E * P a‖ := by
+            exact norm_sum_le _ _
+      _ ≤ ∑ a : Section43DerivativeWord d n r,
+          ‖E‖ *
+            (section43DerivativeWordCoeff d n r a *
+              ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+            dirProd := by
+          refine Finset.sum_le_sum ?_
+          intro a _ha
+          have hscalar := section43DerivativeWordScalar_norm_le d n r a τ m
+          have hSE :
+              ‖section43DerivativeWordScalar d n r a τ m‖ * ‖E‖ ≤
+                (section43DerivativeWordCoeff d n r a *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * dirProd) * ‖E‖ := by
+            exact mul_le_mul_of_nonneg_right hscalar (norm_nonneg E)
+          have hP_nonneg : 0 ≤ ‖P a‖ := norm_nonneg _
+          calc
+            ‖section43DerivativeWordScalar d n r a τ m * E * P a‖ =
+                ‖section43DerivativeWordScalar d n r a τ m‖ * ‖E‖ * ‖P a‖ := by
+                  simp [mul_assoc]
+            _ ≤ ((section43DerivativeWordCoeff d n r a *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * dirProd) * ‖E‖) *
+                  ‖P a‖ := by
+                  exact mul_le_mul_of_nonneg_right hSE hP_nonneg
+            _ = ‖E‖ *
+                (section43DerivativeWordCoeff d n r a *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+                dirProd := by
+                  ring
+  calc
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q m‖ =
+        ‖∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordScalar d n r a τ m * E * P a‖ := by
+          rw [section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words]
+    _ ≤ ∑ a : Section43DerivativeWord d n r,
+          ‖E‖ *
+            (section43DerivativeWordCoeff d n r a *
+              ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+            dirProd := hmain
+    _ = ‖E‖ *
+        (∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a * ‖P a‖) *
+        dirProd := by
+          rw [← Finset.sum_mul]
+          congr 1
+          rw [Finset.mul_sum]
+    _ =
+      ‖Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q k : ℂ)))‖ *
+        (∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖) *
+        ∏ j : Fin r, ‖m j‖ := by
+          simp [E, P, dirProd]
+
+/-- Operator-norm form of the no-margin finite-word bound. -/
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words_absExp
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (τ : Fin n → ℝ) :
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q‖ ≤
+      ‖Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q k : ℂ)))‖ *
+        ∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖ := by
+  classical
+  let E : ℂ :=
+    Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) * (section43QTime (d := d) (n := n) q k : ℂ)))
+  let S : ℝ :=
+    ∑ a : Section43DerivativeWord d n r,
+      section43DerivativeWordCoeff d n r a *
+        ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+        ‖partialFourierSpatial_fun (d := d) (n := n)
+          (section43DerivativeWordInput d n r F a)
+          (τ, section43QSpatial (d := d) (n := n) q)‖
+  have hS_nonneg : 0 ≤ S := by
+    dsimp [S]
+    refine Finset.sum_nonneg ?_
+    intro a _ha
+    exact mul_nonneg
+      (mul_nonneg (section43DerivativeWordCoeff_nonneg d n r a)
+        (pow_nonneg (norm_nonneg τ) _))
+      (norm_nonneg _)
+  have hM_nonneg : 0 ≤ ‖E‖ * S := mul_nonneg (norm_nonneg E) hS_nonneg
+  have hop :
+      ‖iteratedFDeriv ℝ r
+        (fun q' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+        q‖ ≤ ‖E‖ * S := by
+    refine ContinuousMultilinearMap.opNorm_le_bound hM_nonneg ?_
+    intro m
+    have happly :=
+      norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words_absExp
+        d n r F q τ m
+    simpa [E, S] using happly
+  simpa [E, S] using hop
+
+/-- Above the compact-support time slab, the pointwise Fourier-Laplace time
+integrand is identically zero as a function of `q`. -/
+theorem section43FourierLaplace_timeIntegrand_eq_zero_of_timeNorm_gt_bound
+    (d n : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {R : ℝ}
+    (hR_supp :
+      ∀ ξ ∈ tsupport
+        (((section43DiffPullbackCLM d n ⟨f, hf_ord⟩ : SchwartzNPoint d n) :
+          NPointDomain d n → ℂ)),
+        ‖section43QTime (d := d) (n := n) ξ‖ ≤ R)
+    (τ : Fin n → ℝ)
+    (hτ : R < ‖τ‖) :
+    (fun q' : NPointDomain d n =>
+      Complex.exp
+        (-(∑ k : Fin n,
+          (τ k : ℂ) *
+            (section43QTime (d := d) (n := n) q' k : ℂ))) *
+      partialFourierSpatial_fun (d := d) (n := n)
+        (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+        (τ, section43QSpatial (d := d) (n := n) q')) =
+      fun _ => 0 := by
+  funext q'
+  have hP_zero :
+      partialFourierSpatial_fun (d := d) (n := n)
+        (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+        (τ, section43QSpatial (d := d) (n := n) q') = 0 := by
+    exact partialFourierSpatial_section43DiffPullback_eq_zero_of_timeNorm_gt_bound
+      d n f hf_ord hR_supp τ (section43QSpatial (d := d) (n := n) q') hτ
+  simp [hP_zero]
+
+/-- Above the compact-support time slab, all pointwise iterated derivatives of
+the Fourier-Laplace time integrand vanish. -/
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_timeNorm_gt_bound
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {R : ℝ}
+    (hR_supp :
+      ∀ ξ ∈ tsupport
+        (((section43DiffPullbackCLM d n ⟨f, hf_ord⟩ : SchwartzNPoint d n) :
+          NPointDomain d n → ℂ)),
+        ‖section43QTime (d := d) (n := n) ξ‖ ≤ R)
+    (τ : Fin n → ℝ)
+    (hτ : R < ‖τ‖) :
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+        partialFourierSpatial_fun (d := d) (n := n)
+          (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+          (τ, section43QSpatial (d := d) (n := n) q')) =
+      0 := by
+  rw [section43FourierLaplace_timeIntegrand_eq_zero_of_timeNorm_gt_bound
+    d n f hf_ord hR_supp τ hτ]
+  simp
+
+/-- Pointwise derivative of the pointwise `r`-th derivative.  The derivative is
+the left-curry of the `(r+1)`-linear map, matching the
+`iteratedFDeriv_succ_apply_left` convention. -/
+theorem hasFDerivAt_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (τ : Fin n → ℝ) :
+    HasFDerivAt
+      (fun q' : NPointDomain d n =>
+        iteratedFDeriv ℝ r
+          (fun q'' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+            partialFourierSpatial_fun (d := d) (n := n) F
+              (τ, section43QSpatial (d := d) (n := n) q''))
+          q')
+      ((iteratedFDeriv ℝ (r + 1)
+        (fun q'' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q''))
+        q).curryLeft)
+      q := by
+  let G : NPointDomain d n → ℂ := fun q' =>
+    Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) *
+          (section43QTime (d := d) (n := n) q' k : ℂ))) *
+    partialFourierSpatial_fun (d := d) (n := n) F
+      (τ, section43QSpatial (d := d) (n := n) q')
+  have hGsmooth : ContDiff ℝ (⊤ : ℕ∞) G := by
+    simpa [G] using contDiff_section43FourierLaplace_timeIntegrand_q d n F τ
+  have hdiff : DifferentiableAt ℝ (iteratedFDeriv ℝ r G) q := by
+    exact hGsmooth.contDiffAt.differentiableAt_iteratedFDeriv
+      (WithTop.coe_lt_coe.2 (ENat.coe_lt_top r))
+  have hderiv_eq :
+      fderiv ℝ (iteratedFDeriv ℝ r G) q =
+        (iteratedFDeriv ℝ (r + 1) G q).curryLeft := by
+    ext v mtail
+    rfl
+  simpa [G, hderiv_eq] using hdiff.hasFDerivAt
 
 set_option backward.isDefEq.respectTransparency false in
 /-- All-order derivative candidate for the Section 4.3 Fourier-Laplace

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceHigherDerivatives.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceHigherDerivatives.lean
@@ -1191,4 +1191,368 @@ theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
       simpa [A, S, F] using happly
     simpa [A, S, F] using hop
 
+set_option backward.isDefEq.respectTransparency false in
+/-- All-order derivative candidate for the Section 4.3 Fourier-Laplace
+integral, defined in the same Bochner-integral category as the already
+compiled first-derivative candidate. -/
+noncomputable def section43FourierLaplaceIntegral_iteratedFDerivCandidate
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (q : NPointDomain d n) :
+    ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ :=
+  ∫ τ : Fin n → ℝ,
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+        partialFourierSpatial_fun (d := d) (n := n)
+          (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+          (τ, section43QSpatial (d := d) (n := n) q'))
+      q
+
+/-- Real finite-word majorant for the norm of the pointwise all-order
+Fourier-Laplace integrand derivative. -/
+noncomputable def section43FourierLaplace_iteratedFDerivWordMajorant
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (ξ : EuclideanSpace ℝ (Fin n × Fin d))
+    (τ : Fin n → ℝ) : ℝ :=
+  ∑ a : Section43DerivativeWord d n r,
+    section43DerivativeWordCoeff d n r a *
+      ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+        ‖partialFourierSpatial_fun (d := d) (n := n)
+          (section43DerivativeWordInput d n r F a) (τ, ξ)‖
+
+/-- The integrated finite-word majorant, with each time moment integrated
+before the finite word sum is assembled. -/
+noncomputable def section43FourierLaplace_iteratedFDerivWordMajorantIntegral
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (ξ : EuclideanSpace ℝ (Fin n × Fin d)) : ℝ :=
+  ∑ a : Section43DerivativeWord d n r,
+    section43DerivativeWordCoeff d n r a *
+      ∫ τ : Fin n → ℝ,
+        ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+          ‖partialFourierSpatial_fun (d := d) (n := n)
+            (section43DerivativeWordInput d n r F a) (τ, ξ)‖
+
+/-- Integrability of the finite-word majorant follows word-by-word from the
+compiled time-moment integrability theorem for partial spatial Fourier
+transforms. -/
+theorem integrable_section43FourierLaplace_iteratedFDerivWordMajorant
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (ξ : EuclideanSpace ℝ (Fin n × Fin d)) :
+    Integrable
+      (section43FourierLaplace_iteratedFDerivWordMajorant d n r F ξ)
+      (volume : Measure (Fin n → ℝ)) := by
+  classical
+  change Integrable
+    (fun τ : Fin n → ℝ =>
+      ∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordCoeff d n r a *
+          ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a) (τ, ξ)‖)
+    (volume : Measure (Fin n → ℝ))
+  refine integrable_finset_sum _ ?_
+  intro a _ha
+  have hbase :
+      Integrable
+        (fun τ : Fin n → ℝ =>
+          ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a) (τ, ξ)‖)
+        (volume : Measure (Fin n → ℝ)) :=
+    integrable_timeMoment_norm_partialFourierSpatial_timeSlice
+      (d := d) (n := n) (section43DerivativeWordInput d n r F a)
+      (section43DerivativeWordTimeCount d n r a) ξ
+  simpa [mul_assoc] using
+    hbase.const_mul (section43DerivativeWordCoeff d n r a)
+
+/-- The integral of the finite-word majorant is the finite sum of the word
+time-moment integrals. -/
+theorem integral_section43FourierLaplace_iteratedFDerivWordMajorant
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (ξ : EuclideanSpace ℝ (Fin n × Fin d)) :
+    (∫ τ : Fin n → ℝ,
+      section43FourierLaplace_iteratedFDerivWordMajorant d n r F ξ τ) =
+      section43FourierLaplace_iteratedFDerivWordMajorantIntegral d n r F ξ := by
+  classical
+  dsimp [section43FourierLaplace_iteratedFDerivWordMajorant,
+    section43FourierLaplace_iteratedFDerivWordMajorantIntegral]
+  rw [MeasureTheory.integral_finset_sum]
+  · refine Finset.sum_congr rfl ?_
+    intro a _ha
+    calc
+      (∫ τ : Fin n → ℝ,
+        section43DerivativeWordCoeff d n r a *
+          ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a) (τ, ξ)‖) =
+          ∫ τ : Fin n → ℝ,
+            section43DerivativeWordCoeff d n r a *
+              (‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+                ‖partialFourierSpatial_fun (d := d) (n := n)
+                  (section43DerivativeWordInput d n r F a) (τ, ξ)‖) := by
+            apply MeasureTheory.integral_congr_ae
+            filter_upwards with τ
+            ring
+      _ = section43DerivativeWordCoeff d n r a *
+          ∫ τ : Fin n → ℝ,
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+              ‖partialFourierSpatial_fun (d := d) (n := n)
+                (section43DerivativeWordInput d n r F a) (τ, ξ)‖ := by
+            rw [MeasureTheory.integral_const_mul]
+  · intro a _ha
+    have hbase :
+        Integrable
+          (fun τ : Fin n → ℝ =>
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+              ‖partialFourierSpatial_fun (d := d) (n := n)
+                (section43DerivativeWordInput d n r F a) (τ, ξ)‖)
+          (volume : Measure (Fin n → ℝ)) :=
+      integrable_timeMoment_norm_partialFourierSpatial_timeSlice
+        (d := d) (n := n) (section43DerivativeWordInput d n r F a)
+        (section43DerivativeWordTimeCount d n r a) ξ
+    simpa [mul_assoc] using
+      hbase.const_mul (section43DerivativeWordCoeff d n r a)
+
+/-- Spatial rapid decay of the integrated finite-word majorant.  Each word is
+handled by the compiled time-moment rapid theorem, then the finite word
+constants are summed. -/
+theorem section43FourierLaplace_iteratedFDerivWordMajorantIntegral_spatialRapid
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (s : ℕ) :
+    ∃ C : ℝ, 0 ≤ C ∧
+      ∀ ξ : EuclideanSpace ℝ (Fin n × Fin d),
+        (1 + ‖ξ‖) ^ s *
+          section43FourierLaplace_iteratedFDerivWordMajorantIntegral
+            d n r F ξ ≤ C := by
+  classical
+  choose Cword hCword_nonneg hCword_bound using
+    fun a : Section43DerivativeWord d n r =>
+      section43PartialFourier_timeMomentIntegral_spatialRapid
+        (d := d) (n := n)
+        (section43DerivativeWordInput d n r F a)
+        (section43DerivativeWordTimeCount d n r a) s
+  let C : ℝ :=
+    ∑ a : Section43DerivativeWord d n r,
+      section43DerivativeWordCoeff d n r a * Cword a
+  refine ⟨C, ?_, ?_⟩
+  · dsimp [C]
+    refine Finset.sum_nonneg ?_
+    intro a _ha
+    exact mul_nonneg (section43DerivativeWordCoeff_nonneg d n r a)
+      (hCword_nonneg a)
+  intro ξ
+  let W : ℝ := (1 + ‖ξ‖) ^ s
+  let I : Section43DerivativeWord d n r → ℝ := fun a =>
+    ∫ τ : Fin n → ℝ,
+      ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+        ‖partialFourierSpatial_fun (d := d) (n := n)
+          (section43DerivativeWordInput d n r F a) (τ, ξ)‖
+  calc
+    W *
+        section43FourierLaplace_iteratedFDerivWordMajorantIntegral d n r F ξ =
+        W * ∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a * I a := by
+          simp [W, I, section43FourierLaplace_iteratedFDerivWordMajorantIntegral]
+    _ =
+        ∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a * (W * I a) := by
+          rw [Finset.mul_sum]
+          refine Finset.sum_congr rfl ?_
+          intro a _ha
+          ring
+    _ ≤ ∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordCoeff d n r a * Cword a := by
+          refine Finset.sum_le_sum ?_
+          intro a _ha
+          exact mul_le_mul_of_nonneg_left
+            (by simpa [W, I] using hCword_bound a ξ)
+            (section43DerivativeWordCoeff_nonneg d n r a)
+    _ = C := by
+          simp [C]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The integrated all-order derivative candidate is bounded by the
+exponentially damped integrated finite-word majorant. -/
+theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_norm_le_exp_margin_word_integrals
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ}
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)})
+    (q : NPointDomain d n)
+    (hq : q ∈ section43PositiveEnergyRegion d n) :
+    let F : SchwartzNPoint d n := section43DiffPullbackCLM d n ⟨f, hf_ord⟩
+    let E : ℝ :=
+      Real.exp (-(δ * ∑ k : Fin n,
+        section43QTime (d := d) (n := n) q k))
+    let ξ : EuclideanSpace ℝ (Fin n × Fin d) :=
+      section43QSpatial (d := d) (n := n) q
+    ‖section43FourierLaplaceIntegral_iteratedFDerivCandidate
+      d n r f hf_ord q‖ ≤
+      E *
+        section43FourierLaplace_iteratedFDerivWordMajorantIntegral
+          d n r F ξ := by
+  intro F E ξ
+  let G : (Fin n → ℝ) →
+      ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ :=
+    fun τ =>
+      iteratedFDeriv ℝ r
+        (fun q' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+        q
+  let Jfun : (Fin n → ℝ) → ℝ :=
+    section43FourierLaplace_iteratedFDerivWordMajorant d n r F ξ
+  have hJ_int :
+      Integrable Jfun (volume : Measure (Fin n → ℝ)) := by
+    simpa [Jfun, F, ξ] using
+      integrable_section43FourierLaplace_iteratedFDerivWordMajorant
+        d n r F ξ
+  have hEJ_int :
+      Integrable (fun τ : Fin n → ℝ => E * Jfun τ)
+        (volume : Measure (Fin n → ℝ)) :=
+    hJ_int.const_mul E
+  have hpoint : ∀ τ : Fin n → ℝ, ‖G τ‖ ≤ E * Jfun τ := by
+    intro τ
+    have hbound :=
+      norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
+        d n r f hf_ord hδ_supp q hq τ
+    simpa [G, Jfun, F, E, ξ,
+      section43FourierLaplace_iteratedFDerivWordMajorant] using hbound
+  calc
+    ‖section43FourierLaplaceIntegral_iteratedFDerivCandidate
+        d n r f hf_ord q‖ =
+        ‖∫ τ : Fin n → ℝ, G τ‖ := by
+          simp [section43FourierLaplaceIntegral_iteratedFDerivCandidate, G, F]
+    _ ≤ ∫ τ : Fin n → ℝ, ‖G τ‖ :=
+        MeasureTheory.norm_integral_le_integral_norm _
+    _ ≤ ∫ τ : Fin n → ℝ, E * Jfun τ := by
+        exact MeasureTheory.integral_mono_of_nonneg
+          (Filter.Eventually.of_forall fun τ => norm_nonneg (G τ))
+          hEJ_int
+          (Filter.Eventually.of_forall hpoint)
+    _ = E * ∫ τ : Fin n → ℝ, Jfun τ := by
+        rw [MeasureTheory.integral_const_mul]
+    _ = E *
+        section43FourierLaplace_iteratedFDerivWordMajorantIntegral d n r F ξ := by
+        rw [integral_section43FourierLaplace_iteratedFDerivWordMajorant]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Rapid decay of the all-order derivative candidate on the positive-energy
+half-space. -/
+theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_rapid_on_positiveEnergy
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ} (hδ_pos : 0 < δ)
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)}) :
+    ∀ s : ℕ, ∃ C : ℝ, 0 ≤ C ∧
+      ∀ q ∈ section43PositiveEnergyRegion d n,
+        (1 + ‖q‖) ^ s *
+          ‖section43FourierLaplaceIntegral_iteratedFDerivCandidate
+            d n r f hf_ord q‖ ≤ C := by
+  intro s
+  let F : SchwartzNPoint d n := section43DiffPullbackCLM d n ⟨f, hf_ord⟩
+  rcases section43FourierLaplace_iteratedFDerivWordMajorantIntegral_spatialRapid
+      (d := d) (n := n) r F s with
+    ⟨Csp, hCsp_nonneg, hCsp_bound⟩
+  rcases exp_margin_sum_controls_positiveEnergy_time_polynomial
+      (d := d) (n := n) hδ_pos s with
+    ⟨Ct, hCt_nonneg, hCt_bound⟩
+  let A : ℝ :=
+    1 + 2 * ‖(nPointTimeSpatialCLE (d := d) n).symm.toContinuousLinearMap‖
+  let C : ℝ := A ^ s * Ct * Csp
+  have hA_nonneg : 0 ≤ A := by
+    dsimp [A]
+    positivity
+  refine ⟨C, mul_nonneg (mul_nonneg (pow_nonneg hA_nonneg s) hCt_nonneg) hCsp_nonneg, ?_⟩
+  intro q hq
+  let t : Fin n → ℝ := section43QTime (d := d) (n := n) q
+  let ξ : EuclideanSpace ℝ (Fin n × Fin d) :=
+    section43QSpatial (d := d) (n := n) q
+  let E : ℝ := Real.exp (-(δ * ∑ k : Fin n, t k))
+  let J : ℝ :=
+    section43FourierLaplace_iteratedFDerivWordMajorantIntegral d n r F ξ
+  have hJ_nonneg : 0 ≤ J := by
+    dsimp [J, section43FourierLaplace_iteratedFDerivWordMajorantIntegral]
+    refine Finset.sum_nonneg ?_
+    intro a _ha
+    exact mul_nonneg (section43DerivativeWordCoeff_nonneg d n r a)
+      (integral_nonneg fun τ =>
+        mul_nonneg (pow_nonneg (norm_nonneg τ) _)
+          (norm_nonneg _))
+  have hspatial :
+      (1 + ‖ξ‖) ^ s * J ≤ Csp := by
+    simpa [J, F, ξ] using hCsp_bound ξ
+  have htime :
+      (1 + ‖t‖) ^ s * E ≤ Ct := by
+    simpa [t, E] using hCt_bound q hq
+  have hscalar :
+      ‖section43FourierLaplaceIntegral_iteratedFDerivCandidate
+        d n r f hf_ord q‖ ≤ E * J := by
+    simpa [E, J, F, t, ξ] using
+      section43FourierLaplaceIntegral_iteratedFDerivCandidate_norm_le_exp_margin_word_integrals
+        d n r f hf_ord hδ_supp q hq
+  have hnorm :
+      1 + ‖q‖ ≤ A * (1 + ‖t‖) * (1 + ‖ξ‖) := by
+    simpa [A, t, ξ] using
+      one_add_norm_le_section43_time_spatial_product d n q
+  have hpow_norm :
+      (1 + ‖q‖) ^ s ≤ (A * (1 + ‖t‖) * (1 + ‖ξ‖)) ^ s := by
+    exact pow_le_pow_left₀ (by positivity) hnorm s
+  have htime_nonneg : 0 ≤ (1 + ‖t‖) ^ s * E := by
+    exact mul_nonneg (pow_nonneg (by positivity) s) (Real.exp_pos _).le
+  have hspatial_nonneg : 0 ≤ (1 + ‖ξ‖) ^ s * J := by
+    exact mul_nonneg (pow_nonneg (by positivity) s) hJ_nonneg
+  have hterm_prod :
+      ((1 + ‖t‖) ^ s * E) * ((1 + ‖ξ‖) ^ s * J) ≤ Ct * Csp := by
+    calc
+      ((1 + ‖t‖) ^ s * E) * ((1 + ‖ξ‖) ^ s * J)
+          ≤ Ct * ((1 + ‖ξ‖) ^ s * J) := by
+            exact mul_le_mul_of_nonneg_right htime hspatial_nonneg
+      _ ≤ Ct * Csp := by
+            exact mul_le_mul_of_nonneg_left hspatial hCt_nonneg
+  calc
+    (1 + ‖q‖) ^ s *
+        ‖section43FourierLaplaceIntegral_iteratedFDerivCandidate
+          d n r f hf_ord q‖
+        ≤ (A * (1 + ‖t‖) * (1 + ‖ξ‖)) ^ s *
+            ‖section43FourierLaplaceIntegral_iteratedFDerivCandidate
+              d n r f hf_ord q‖ := by
+          exact mul_le_mul_of_nonneg_right hpow_norm (norm_nonneg _)
+    _ ≤ (A * (1 + ‖t‖) * (1 + ‖ξ‖)) ^ s * (E * J) := by
+          exact mul_le_mul_of_nonneg_left hscalar (pow_nonneg (by positivity) s)
+    _ = A ^ s * (((1 + ‖t‖) ^ s * E) * ((1 + ‖ξ‖) ^ s * J)) := by
+          rw [mul_pow, mul_pow]
+          ring
+    _ ≤ A ^ s * (Ct * Csp) := by
+          exact mul_le_mul_of_nonneg_left hterm_prod (pow_nonneg hA_nonneg s)
+    _ = C := by
+          simp [C, mul_assoc]
+
 end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceHigherDerivatives.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceHigherDerivatives.lean
@@ -1,0 +1,575 @@
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceWitness
+
+noncomputable section
+
+open scoped Topology FourierTransform LineDeriv
+open Set MeasureTheory
+
+namespace OSReconstruction
+
+/-- A single derivative slot in the Section 4.3 Fourier-Laplace integrand.
+
+`time k` means the derivative hits the Laplace exponential and contributes the
+time-coordinate scalar from the direction.  `spatial i` means the derivative
+hits the spatial Fourier argument and contributes the `i`th spatial-coordinate
+scalar from the direction. -/
+inductive Section43DerivativeAtom (d n : ℕ) where
+  | time (k : Fin n)
+  | spatial (i : Fin n × Fin d)
+  deriving DecidableEq, Fintype
+
+/-- A length-`r` derivative word records which factor each derivative slot hits.
+The slot order follows `iteratedFDeriv_succ_apply_left`: index `0` is the
+newest derivative direction when passing from `r` to `r + 1`. -/
+abbrev Section43DerivativeWord (d n r : ℕ) :=
+  Fin r → Section43DerivativeAtom d n
+
+/-- The derivative atom type is the finite disjoint union of time-coordinate
+atoms and spatial-coordinate atoms. -/
+def section43DerivativeAtomEquivSum (d n : ℕ) :
+    Section43DerivativeAtom d n ≃ (Fin n) ⊕ (Fin n × Fin d) where
+  toFun
+    | Section43DerivativeAtom.time k => Sum.inl k
+    | Section43DerivativeAtom.spatial i => Sum.inr i
+  invFun
+    | Sum.inl k => Section43DerivativeAtom.time k
+    | Sum.inr i => Section43DerivativeAtom.spatial i
+  left_inv := by
+    intro a
+    cases a <;> rfl
+  right_inv := by
+    intro a
+    cases a <;> rfl
+
+/-- Split a finite sum over derivative atoms into its time and spatial pieces. -/
+theorem section43DerivativeAtom_sum
+    (d n : ℕ) {M : Type*} [AddCommMonoid M]
+    (f : Fin n → M) (g : Fin n × Fin d → M) :
+    (∑ a : Section43DerivativeAtom d n,
+      match a with
+      | Section43DerivativeAtom.time k => f k
+      | Section43DerivativeAtom.spatial i => g i) =
+    (∑ k : Fin n, f k) + ∑ i : Fin n × Fin d, g i := by
+  classical
+  let e := section43DerivativeAtomEquivSum d n
+  calc
+    (∑ a : Section43DerivativeAtom d n,
+      match a with
+      | Section43DerivativeAtom.time k => f k
+      | Section43DerivativeAtom.spatial i => g i) =
+        ∑ s : (Fin n) ⊕ (Fin n × Fin d),
+          match s with
+          | Sum.inl k => f k
+          | Sum.inr i => g i := by
+          refine Fintype.sum_equiv e _ _ ?_
+          intro a
+          cases a <;> rfl
+    _ = (∑ k : Fin n, f k) + ∑ i : Fin n × Fin d, g i := by
+          rw [Fintype.sum_sum_type]
+
+/-- Prepend one derivative atom to a word. -/
+def section43DerivativeWordCons
+    (d n r : ℕ)
+    (head : Section43DerivativeAtom d n)
+    (tail : Section43DerivativeWord d n r) :
+    Section43DerivativeWord d n (r + 1) :=
+  Fin.cons head tail
+
+@[simp] theorem section43DerivativeWordCons_zero
+    (d n r : ℕ)
+    (head : Section43DerivativeAtom d n)
+    (tail : Section43DerivativeWord d n r) :
+    section43DerivativeWordCons d n r head tail 0 = head := by
+  rfl
+
+@[simp] theorem section43DerivativeWordCons_succ
+    (d n r : ℕ)
+    (head : Section43DerivativeAtom d n)
+    (tail : Section43DerivativeWord d n r)
+    (j : Fin r) :
+    section43DerivativeWordCons d n r head tail j.succ = tail j := by
+  rfl
+
+/-- A nonempty derivative word is equivalently its newest atom together with
+the remaining tail word. -/
+def section43DerivativeWordEquivCons (d n r : ℕ) :
+    Section43DerivativeWord d n (r + 1) ≃
+      Section43DerivativeAtom d n × Section43DerivativeWord d n r where
+  toFun a := (a 0, fun j => a j.succ)
+  invFun p := section43DerivativeWordCons d n r p.1 p.2
+  left_inv := by
+    intro a
+    funext j
+    refine Fin.cases ?zero ?succ j
+    · rfl
+    · intro i
+      rfl
+  right_inv := by
+    intro p
+    cases p with
+    | mk head tail =>
+        rfl
+
+/-- Reindex a finite sum over nonempty derivative words by newest atom and
+tail word. -/
+theorem section43DerivativeWord_sum_cons
+    (d n r : ℕ) {M : Type*} [AddCommMonoid M]
+    (f : Section43DerivativeWord d n (r + 1) → M) :
+    (∑ a : Section43DerivativeWord d n (r + 1), f a) =
+      ∑ head : Section43DerivativeAtom d n,
+        ∑ tail : Section43DerivativeWord d n r,
+          f (section43DerivativeWordCons d n r head tail) := by
+  classical
+  let e := section43DerivativeWordEquivCons d n r
+  calc
+    (∑ a : Section43DerivativeWord d n (r + 1), f a) =
+        ∑ p : Section43DerivativeAtom d n × Section43DerivativeWord d n r,
+          f (section43DerivativeWordCons d n r p.1 p.2) := by
+          refine Fintype.sum_equiv e _ _ ?_
+          intro a
+          exact congrArg f (e.left_inv a).symm
+    _ = ∑ head : Section43DerivativeAtom d n,
+        ∑ tail : Section43DerivativeWord d n r,
+          f (section43DerivativeWordCons d n r head tail) := by
+          rw [Fintype.sum_prod_type]
+
+/-- Drop the newest derivative slot from a nonempty derivative word. -/
+def section43DerivativeWordTail
+    (d n r : ℕ)
+    (a : Section43DerivativeWord d n (r + 1)) :
+    Section43DerivativeWord d n r :=
+  fun j => a j.succ
+
+@[simp] theorem section43DerivativeWordTail_cons
+    (d n r : ℕ)
+    (head : Section43DerivativeAtom d n)
+    (tail : Section43DerivativeWord d n r) :
+    section43DerivativeWordTail d n r
+      (section43DerivativeWordCons d n r head tail) = tail := by
+  rfl
+
+/-- Drop the newest direction from a nonempty direction tuple. -/
+def section43DirectionTail
+    (d n r : ℕ) [NeZero d]
+    (m : Fin (r + 1) → NPointDomain d n) :
+    Fin r → NPointDomain d n :=
+  fun j => m j.succ
+
+@[simp] theorem section43DirectionTail_cons
+    (d n r : ℕ) [NeZero d]
+    (head : NPointDomain d n)
+    (tail : Fin r → NPointDomain d n) :
+    section43DirectionTail d n r (Fin.cons head tail) = tail := by
+  rfl
+
+/-- Number of time atoms in a derivative word.  This is the exponent of the
+time-moment weight `‖τ‖ ^ K` consumed by the partial-Fourier rapid theorem. -/
+def section43DerivativeWordTimeCount
+    (d n : ℕ) : (r : ℕ) → Section43DerivativeWord d n r → ℕ
+  | 0, _ => 0
+  | r + 1, a =>
+      let old := section43DerivativeWordTimeCount d n r
+        (section43DerivativeWordTail d n r a)
+      match a 0 with
+      | Section43DerivativeAtom.time _ => old + 1
+      | Section43DerivativeAtom.spatial _ => old
+
+@[simp] theorem section43DerivativeWordTimeCount_cons_time
+    (d n r : ℕ) (k : Fin n)
+    (tail : Section43DerivativeWord d n r) :
+    section43DerivativeWordTimeCount d n (r + 1)
+      (section43DerivativeWordCons d n r
+        (Section43DerivativeAtom.time k) tail) =
+      section43DerivativeWordTimeCount d n r tail + 1 := by
+  rfl
+
+@[simp] theorem section43DerivativeWordTimeCount_cons_spatial
+    (d n r : ℕ) (i : Fin n × Fin d)
+    (tail : Section43DerivativeWord d n r) :
+    section43DerivativeWordTimeCount d n (r + 1)
+      (section43DerivativeWordCons d n r
+        (Section43DerivativeAtom.spatial i) tail) =
+      section43DerivativeWordTimeCount d n r tail := by
+  rfl
+
+/-- The transported Schwartz input attached to a derivative word.  Spatial atoms
+apply the already compiled coordinate multiplier transport; time atoms leave the
+input unchanged. -/
+noncomputable def section43DerivativeWordInput
+    (d n : ℕ) [NeZero d] :
+    (r : ℕ) → SchwartzNPoint d n → Section43DerivativeWord d n r → SchwartzNPoint d n
+  | 0, F, _ => F
+  | r + 1, F, a =>
+      let old := section43DerivativeWordInput d n r F
+        (section43DerivativeWordTail d n r a)
+      match a 0 with
+      | Section43DerivativeAtom.time _ => old
+      | Section43DerivativeAtom.spatial i =>
+          section43SpatialMultiplierTransport d n old i
+
+@[simp] theorem section43DerivativeWordInput_cons_time
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n) (k : Fin n)
+    (tail : Section43DerivativeWord d n r) :
+    section43DerivativeWordInput d n (r + 1) F
+      (section43DerivativeWordCons d n r
+        (Section43DerivativeAtom.time k) tail) =
+      section43DerivativeWordInput d n r F tail := by
+  rfl
+
+@[simp] theorem section43DerivativeWordInput_cons_spatial
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n) (i : Fin n × Fin d)
+    (tail : Section43DerivativeWord d n r) :
+    section43DerivativeWordInput d n (r + 1) F
+      (section43DerivativeWordCons d n r
+        (Section43DerivativeAtom.spatial i) tail) =
+      section43SpatialMultiplierTransport d n
+        (section43DerivativeWordInput d n r F tail) i := by
+  rfl
+
+/-- Nonnegative scalar coefficient controlling the coordinate factors in a
+derivative word. -/
+noncomputable def section43DerivativeWordCoeff
+    (d n : ℕ) [NeZero d] :
+    (r : ℕ) → Section43DerivativeWord d n r → ℝ
+  | 0, _ => 1
+  | r + 1, a =>
+      let old := section43DerivativeWordCoeff d n r
+        (section43DerivativeWordTail d n r a)
+      match a 0 with
+      | Section43DerivativeAtom.time k =>
+          section43QTimeCoordOpNorm d n k * old
+      | Section43DerivativeAtom.spatial i =>
+          section43QSpatialCoordOpNorm d n i * old
+
+@[simp] theorem section43DerivativeWordCoeff_cons_time
+    (d n r : ℕ) [NeZero d] (k : Fin n)
+    (tail : Section43DerivativeWord d n r) :
+    section43DerivativeWordCoeff d n (r + 1)
+      (section43DerivativeWordCons d n r
+        (Section43DerivativeAtom.time k) tail) =
+      section43QTimeCoordOpNorm d n k *
+        section43DerivativeWordCoeff d n r tail := by
+  rfl
+
+@[simp] theorem section43DerivativeWordCoeff_cons_spatial
+    (d n r : ℕ) [NeZero d] (i : Fin n × Fin d)
+    (tail : Section43DerivativeWord d n r) :
+    section43DerivativeWordCoeff d n (r + 1)
+      (section43DerivativeWordCons d n r
+        (Section43DerivativeAtom.spatial i) tail) =
+      section43QSpatialCoordOpNorm d n i *
+        section43DerivativeWordCoeff d n r tail := by
+  rfl
+
+/-- Scalar factor carried by a derivative word after evaluating it on the
+direction tuple `m`. -/
+noncomputable def section43DerivativeWordScalar
+    (d n : ℕ) [NeZero d] :
+    (r : ℕ) → Section43DerivativeWord d n r →
+      (Fin n → ℝ) → (Fin r → NPointDomain d n) → ℂ
+  | 0, _a, _τ, _m => 1
+  | r + 1, a, τ, m =>
+      let old := section43DerivativeWordScalar d n r
+        (section43DerivativeWordTail d n r a) τ
+        (section43DirectionTail d n r m)
+      match a 0 with
+      | Section43DerivativeAtom.time k =>
+          (-((τ k : ℂ) *
+            (section43QTime (d := d) (n := n) (m 0) k : ℂ))) * old
+      | Section43DerivativeAtom.spatial i =>
+          ((section43QSpatial (d := d) (n := n) (m 0) i : ℝ) : ℂ) * old
+
+@[simp] theorem section43DerivativeWordScalar_cons_time
+    (d n r : ℕ) [NeZero d]
+    (k : Fin n) (tail : Section43DerivativeWord d n r)
+    (τ : Fin n → ℝ) (head : NPointDomain d n)
+    (directions : Fin r → NPointDomain d n) :
+    section43DerivativeWordScalar d n (r + 1)
+      (section43DerivativeWordCons d n r
+        (Section43DerivativeAtom.time k) tail)
+      τ (Fin.cons head directions) =
+      (-((τ k : ℂ) *
+        (section43QTime (d := d) (n := n) head k : ℂ))) *
+        section43DerivativeWordScalar d n r tail τ directions := by
+  rfl
+
+@[simp] theorem section43DerivativeWordScalar_cons_spatial
+    (d n r : ℕ) [NeZero d]
+    (i : Fin n × Fin d) (tail : Section43DerivativeWord d n r)
+    (τ : Fin n → ℝ) (head : NPointDomain d n)
+    (directions : Fin r → NPointDomain d n) :
+    section43DerivativeWordScalar d n (r + 1)
+      (section43DerivativeWordCons d n r
+        (Section43DerivativeAtom.spatial i) tail)
+      τ (Fin.cons head directions) =
+      ((section43QSpatial (d := d) (n := n) head i : ℝ) : ℂ) *
+        section43DerivativeWordScalar d n r tail τ directions := by
+  rfl
+
+theorem section43DerivativeWordCoeff_nonneg
+    (d n r : ℕ) [NeZero d]
+    (a : Section43DerivativeWord d n r) :
+    0 ≤ section43DerivativeWordCoeff d n r a := by
+  induction r with
+  | zero =>
+      simp [section43DerivativeWordCoeff]
+  | succ r ih =>
+      cases h : a 0 with
+      | time k =>
+          have hold :
+              0 ≤ section43DerivativeWordCoeff d n r
+                (section43DerivativeWordTail d n r a) :=
+            ih (section43DerivativeWordTail d n r a)
+          simp [section43DerivativeWordCoeff, h,
+            section43QTimeCoordOpNorm,
+            mul_nonneg (norm_nonneg _) hold]
+      | spatial i =>
+          have hold :
+              0 ≤ section43DerivativeWordCoeff d n r
+                (section43DerivativeWordTail d n r a) :=
+            ih (section43DerivativeWordTail d n r a)
+          simp [section43DerivativeWordCoeff, h,
+            section43QSpatialCoordOpNorm,
+            mul_nonneg (norm_nonneg _) hold]
+
+/-- Norm bound for the scalar carried by a derivative word.  Time atoms
+contribute one power of `‖τ‖`; every atom contributes the corresponding
+coordinate-projection operator norm and one direction norm. -/
+theorem section43DerivativeWordScalar_norm_le
+    (d n r : ℕ) [NeZero d]
+    (a : Section43DerivativeWord d n r)
+    (τ : Fin n → ℝ) (m : Fin r → NPointDomain d n) :
+    ‖section43DerivativeWordScalar d n r a τ m‖ ≤
+      section43DerivativeWordCoeff d n r a *
+        ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+          ∏ j : Fin r, ‖m j‖ := by
+  induction r with
+  | zero =>
+      simp [section43DerivativeWordScalar, section43DerivativeWordCoeff,
+        section43DerivativeWordTimeCount]
+  | succ r ih =>
+      cases h : a 0 with
+      | time k =>
+          let oldWord : Section43DerivativeWord d n r :=
+            section43DerivativeWordTail d n r a
+          let oldDirections : Fin r → NPointDomain d n :=
+            section43DirectionTail d n r m
+          let head : ℂ :=
+            -((τ k : ℂ) *
+              (section43QTime (d := d) (n := n) (m 0) k : ℂ))
+          let oldScalar : ℂ :=
+            section43DerivativeWordScalar d n r oldWord τ oldDirections
+          have hhead :
+              ‖head‖ ≤ section43QTimeCoordOpNorm d n k * ‖τ‖ * ‖m 0‖ := by
+            have hm := abs_section43QTime_coord_le_opNorm d n (m 0) k
+            have hτk : |τ k| ≤ ‖τ‖ := by
+              simpa [Real.norm_eq_abs] using norm_le_pi_norm τ k
+            calc
+              ‖head‖ =
+                  |τ k| * |section43QTime (d := d) (n := n) (m 0) k| := by
+                    simp [head, Complex.norm_real, Real.norm_eq_abs]
+              _ ≤ ‖τ‖ *
+                    (section43QTimeCoordOpNorm d n k * ‖m 0‖) := by
+                    exact mul_le_mul hτk hm (abs_nonneg _)
+                      (norm_nonneg _)
+              _ = section43QTimeCoordOpNorm d n k * ‖τ‖ * ‖m 0‖ := by
+                    ring
+          have hold :
+              ‖oldScalar‖ ≤
+                section43DerivativeWordCoeff d n r oldWord *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n r oldWord *
+                    ∏ j : Fin r, ‖oldDirections j‖ := by
+            simpa [oldScalar, oldWord, oldDirections] using
+              ih oldWord oldDirections
+          have hhead_nonneg :
+              0 ≤ section43QTimeCoordOpNorm d n k * ‖τ‖ * ‖m 0‖ := by
+            exact mul_nonneg
+              (mul_nonneg (norm_nonneg _) (norm_nonneg _))
+              (norm_nonneg _)
+          have hmul :
+              ‖head‖ * ‖oldScalar‖ ≤
+                (section43QTimeCoordOpNorm d n k * ‖τ‖ * ‖m 0‖) *
+                  (section43DerivativeWordCoeff d n r oldWord *
+                    ‖τ‖ ^ section43DerivativeWordTimeCount d n r oldWord *
+                      ∏ j : Fin r, ‖oldDirections j‖) := by
+            exact mul_le_mul hhead hold (norm_nonneg _) hhead_nonneg
+          calc
+            ‖section43DerivativeWordScalar d n (r + 1) a τ m‖ =
+                ‖head‖ * ‖oldScalar‖ := by
+                  simp [section43DerivativeWordScalar, h, head, oldScalar,
+                    oldWord, oldDirections]
+            _ ≤
+                (section43QTimeCoordOpNorm d n k * ‖τ‖ * ‖m 0‖) *
+                  (section43DerivativeWordCoeff d n r oldWord *
+                    ‖τ‖ ^ section43DerivativeWordTimeCount d n r oldWord *
+                      ∏ j : Fin r, ‖oldDirections j‖) := hmul
+            _ =
+                section43DerivativeWordCoeff d n (r + 1) a *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n (r + 1) a *
+                    ∏ j : Fin (r + 1), ‖m j‖ := by
+                  simp [section43DerivativeWordCoeff,
+                    section43DerivativeWordTimeCount, h, oldWord,
+                    oldDirections, section43DirectionTail,
+                    Fin.prod_univ_succ, pow_succ]
+                  ring
+      | spatial i =>
+          let oldWord : Section43DerivativeWord d n r :=
+            section43DerivativeWordTail d n r a
+          let oldDirections : Fin r → NPointDomain d n :=
+            section43DirectionTail d n r m
+          let head : ℂ :=
+            ((section43QSpatial (d := d) (n := n) (m 0) i : ℝ) : ℂ)
+          let oldScalar : ℂ :=
+            section43DerivativeWordScalar d n r oldWord τ oldDirections
+          have hhead :
+              ‖head‖ ≤ section43QSpatialCoordOpNorm d n i * ‖m 0‖ := by
+            have hm := abs_section43QSpatial_coord_le_opNorm d n (m 0) i
+            simpa [head, Complex.norm_real, Real.norm_eq_abs] using hm
+          have hold :
+              ‖oldScalar‖ ≤
+                section43DerivativeWordCoeff d n r oldWord *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n r oldWord *
+                    ∏ j : Fin r, ‖oldDirections j‖ := by
+            simpa [oldScalar, oldWord, oldDirections] using
+              ih oldWord oldDirections
+          have hhead_nonneg :
+              0 ≤ section43QSpatialCoordOpNorm d n i * ‖m 0‖ := by
+            exact mul_nonneg (norm_nonneg _) (norm_nonneg _)
+          have hmul :
+              ‖head‖ * ‖oldScalar‖ ≤
+                (section43QSpatialCoordOpNorm d n i * ‖m 0‖) *
+                  (section43DerivativeWordCoeff d n r oldWord *
+                    ‖τ‖ ^ section43DerivativeWordTimeCount d n r oldWord *
+                      ∏ j : Fin r, ‖oldDirections j‖) := by
+            exact mul_le_mul hhead hold (norm_nonneg _) hhead_nonneg
+          calc
+            ‖section43DerivativeWordScalar d n (r + 1) a τ m‖ =
+                ‖head‖ * ‖oldScalar‖ := by
+                  simp [section43DerivativeWordScalar, h, head, oldScalar,
+                    oldWord, oldDirections]
+            _ ≤
+                (section43QSpatialCoordOpNorm d n i * ‖m 0‖) *
+                  (section43DerivativeWordCoeff d n r oldWord *
+                    ‖τ‖ ^ section43DerivativeWordTimeCount d n r oldWord *
+                      ∏ j : Fin r, ‖oldDirections j‖) := hmul
+            _ =
+                section43DerivativeWordCoeff d n (r + 1) a *
+                  ‖τ‖ ^ section43DerivativeWordTimeCount d n (r + 1) a *
+                    ∏ j : Fin (r + 1), ‖m j‖ := by
+                  simp [section43DerivativeWordCoeff,
+                    section43DerivativeWordTimeCount, h, oldWord,
+                    oldDirections, section43DirectionTail,
+                    Fin.prod_univ_succ]
+                  ring
+
+/-- The first derivative is the one-letter instance of the finite word
+expansion: time atoms come from differentiating the exponential, and spatial
+atoms come from differentiating the spatial Fourier argument. -/
+theorem section43FourierLaplace_timeIntegrandFDerivCLM_apply_eq_sum_atoms
+    (d n : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q m : NPointDomain d n)
+    (τ : Fin n → ℝ) :
+    section43FourierLaplace_timeIntegrandFDerivCLM d n F q τ m =
+      ∑ a : Section43DerivativeAtom d n,
+        match a with
+        | Section43DerivativeAtom.time k =>
+            (-((τ k : ℂ) *
+              (section43QTime (d := d) (n := n) m k : ℂ))) *
+              Complex.exp
+                (-(∑ j : Fin n,
+                  (τ j : ℂ) *
+                    (section43QTime (d := d) (n := n) q j : ℂ))) *
+                partialFourierSpatial_fun (d := d) (n := n) F
+                  (τ, section43QSpatial (d := d) (n := n) q)
+        | Section43DerivativeAtom.spatial i =>
+            ((section43QSpatial (d := d) (n := n) m i : ℝ) : ℂ) *
+              Complex.exp
+                (-(∑ j : Fin n,
+                  (τ j : ℂ) *
+                    (section43QTime (d := d) (n := n) q j : ℂ))) *
+                partialFourierSpatial_fun (d := d) (n := n)
+                  (section43SpatialMultiplierTransport d n F i)
+                  (τ, section43QSpatial (d := d) (n := n) q) := by
+  classical
+  let E : ℂ :=
+    Complex.exp
+      (-(∑ j : Fin n,
+        (τ j : ℂ) * (section43QTime (d := d) (n := n) q j : ℂ)))
+  let ξ : EuclideanSpace ℝ (Fin n × Fin d) :=
+    section43QSpatial (d := d) (n := n) q
+  let P : ℂ :=
+    partialFourierSpatial_fun (d := d) (n := n) F (τ, ξ)
+  let timeTerm : Fin n → ℂ := fun k =>
+    (-((τ k : ℂ) *
+      (section43QTime (d := d) (n := n) m k : ℂ))) * E * P
+  let spatialTerm : Fin n × Fin d → ℂ := fun i =>
+    ((section43QSpatial (d := d) (n := n) m i : ℝ) : ℂ) * E *
+      partialFourierSpatial_fun (d := d) (n := n)
+        (section43SpatialMultiplierTransport d n F i) (τ, ξ)
+  have hspatial :
+      (fderiv ℝ
+        (fun ξ' : EuclideanSpace ℝ (Fin n × Fin d) =>
+          partialFourierSpatial_fun (d := d) (n := n) F (τ, ξ'))
+        ξ)
+        (section43QSpatial (d := d) (n := n) m) =
+        ∑ i : Fin n × Fin d,
+          ((section43QSpatial (d := d) (n := n) m i : ℝ) : ℂ) *
+            partialFourierSpatial_fun (d := d) (n := n)
+              (section43SpatialMultiplierTransport d n F i) (τ, ξ) := by
+    simpa [ξ] using
+      fderiv_partialFourierSpatial_fun_spatial_apply_eq_sum_multiplierTransport
+        d n F τ ξ (section43QSpatial (d := d) (n := n) m)
+  have hsplit :
+      (∑ a : Section43DerivativeAtom d n,
+        match a with
+        | Section43DerivativeAtom.time k => timeTerm k
+        | Section43DerivativeAtom.spatial i => spatialTerm i) =
+      (∑ k : Fin n, timeTerm k) + ∑ i : Fin n × Fin d, spatialTerm i := by
+    exact section43DerivativeAtom_sum d n timeTerm spatialTerm
+  calc
+    section43FourierLaplace_timeIntegrandFDerivCLM d n F q τ m =
+        (∑ k : Fin n,
+          (section43QTime (d := d) (n := n) m k : ℝ) •
+            (-(τ k : ℂ) * E * P)) +
+          E •
+            (fderiv ℝ
+              (fun ξ' : EuclideanSpace ℝ (Fin n × Fin d) =>
+                partialFourierSpatial_fun (d := d) (n := n) F (τ, ξ'))
+              ξ)
+              (section43QSpatial (d := d) (n := n) m) := by
+          simp [section43FourierLaplace_timeIntegrandFDerivCLM_apply, E, P, ξ]
+    _ = (∑ k : Fin n, timeTerm k) + ∑ i : Fin n × Fin d, spatialTerm i := by
+          congr 1
+          · refine Finset.sum_congr rfl ?_
+            intro k _hk
+            simp [timeTerm, Complex.real_smul, mul_assoc, mul_left_comm]
+          · rw [hspatial]
+            simp [spatialTerm, smul_eq_mul, Finset.mul_sum,
+              mul_assoc, mul_left_comm]
+    _ =
+        ∑ a : Section43DerivativeAtom d n,
+          match a with
+          | Section43DerivativeAtom.time k =>
+              (-((τ k : ℂ) *
+                (section43QTime (d := d) (n := n) m k : ℂ))) *
+                Complex.exp
+                  (-(∑ j : Fin n,
+                    (τ j : ℂ) *
+                      (section43QTime (d := d) (n := n) q j : ℂ))) *
+                  partialFourierSpatial_fun (d := d) (n := n) F
+                    (τ, section43QSpatial (d := d) (n := n) q)
+          | Section43DerivativeAtom.spatial i =>
+              ((section43QSpatial (d := d) (n := n) m i : ℝ) : ℂ) *
+                Complex.exp
+                  (-(∑ j : Fin n,
+                    (τ j : ℂ) *
+                      (section43QTime (d := d) (n := n) q j : ℂ))) *
+                  partialFourierSpatial_fun (d := d) (n := n)
+                    (section43SpatialMultiplierTransport d n F i)
+                    (τ, section43QSpatial (d := d) (n := n) q) := by
+          rw [← hsplit]
+
+end OSReconstruction

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -20430,14 +20430,328 @@ Implementation readiness checkpoint:
   `section43FourierLaplaceIntegral_iteratedFDerivCandidate_rapid_on_positiveEnergy`.
   Exact file check and narrow module build both terminated successfully on
   2026-04-17.
-- Ready next: under `hf_compact`, identify the candidate with actual
-  `iteratedFDeriv` by an all-order dominated differentiation theorem using
-  compact upper time-slab support.
+- Compiled now in `Section43FourierLaplaceHigherDerivatives.lean` and
+  exact-file checked on 2026-04-17:
+  `norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words_absExp`,
+  `norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words_absExp`,
+  `section43FourierLaplace_timeIntegrand_eq_zero_of_timeNorm_gt_bound`,
+  `section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_timeNorm_gt_bound`,
+  and
+  `hasFDerivAt_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft`.
+- Ready next: prove
+  `section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact`,
+  the compact upper-slab local domination theorem.
+- Then ready: apply `hasFDerivAt_integral_of_dominated_of_fderiv_le` to
+  identify the derivative of the integrated candidate with the next candidate.
+- Then ready: identify the candidate with actual `iteratedFDeriv` by
+  induction.
 - Then ready: derive the actual derivative rapid theorem from that
   identification and the compiled candidate rapid theorem.
 - Not ready to implement yet: the positive-half-space Schwartz extension
   theorem; it should be documented separately after the all-order witness
   packet is compiled.
+
+The all-order candidate-identification theorem should be proved in the
+following smaller theorem order.  Do **not** jump straight to
+`ContDiff ℝ ⊤`; the local domination theorem is the real seam.
+
+First add the no-margin pointwise norm estimates.  These are the compact-slab
+analogues of the positive-energy word bounds, but with the exponential left as
+its actual norm:
+
+```lean
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words_absExp
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (τ : Fin n → ℝ)
+    (m : Fin r → NPointDomain d n) :
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q m‖ ≤
+      ‖Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q k : ℂ)))‖ *
+        (∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖) *
+        ∏ j : Fin r, ‖m j‖
+
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words_absExp
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (τ : Fin n → ℝ) :
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q‖ ≤
+      ‖Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q k : ℂ)))‖ *
+        ∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖
+```
+
+Proof transcript:
+
+1. Repeat the compiled positive-energy proof, but do not use
+   `norm_exp_neg_section43_timePair_le_exp_neg_margin_sum`.
+2. Rewrite by
+   `section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words`.
+3. Use `norm_sum_le`, `norm_mul`, and
+   `section43DerivativeWordScalar_norm_le`.
+4. Pull out the common factors
+   `‖Complex.exp ...‖` and `∏ j, ‖m j‖`.
+5. Convert the applied theorem to the operator-norm theorem with
+   `ContinuousMultilinearMap.opNorm_le_bound`.
+
+Second add the upper-slab all-order zero theorem.  This is exactly the
+upper-slab version of the already compiled lower-margin theorem:
+
+```lean
+theorem section43FourierLaplace_timeIntegrand_eq_zero_of_timeNorm_gt_bound
+    (d n : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {R : ℝ}
+    (hR_supp :
+      ∀ ξ ∈ tsupport
+        (((section43DiffPullbackCLM d n ⟨f, hf_ord⟩ : SchwartzNPoint d n) :
+          NPointDomain d n → ℂ)),
+        ‖section43QTime (d := d) (n := n) ξ‖ ≤ R)
+    (τ : Fin n → ℝ)
+    (hτ : R < ‖τ‖) :
+    (fun q' : NPointDomain d n =>
+      Complex.exp
+        (-(∑ k : Fin n,
+          (τ k : ℂ) *
+            (section43QTime (d := d) (n := n) q' k : ℂ))) *
+      partialFourierSpatial_fun (d := d) (n := n)
+        (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+        (τ, section43QSpatial (d := d) (n := n) q')) =
+      fun _ => 0
+
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_timeNorm_gt_bound
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {R : ℝ}
+    (hR_supp :
+      ∀ ξ ∈ tsupport
+        (((section43DiffPullbackCLM d n ⟨f, hf_ord⟩ : SchwartzNPoint d n) :
+          NPointDomain d n → ℂ)),
+        ‖section43QTime (d := d) (n := n) ξ‖ ≤ R)
+    (τ : Fin n → ℝ)
+    (hτ : R < ‖τ‖) :
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+        partialFourierSpatial_fun (d := d) (n := n)
+          (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+          (τ, section43QSpatial (d := d) (n := n) q')) =
+      0
+```
+
+Proof transcript: use
+`partialFourierSpatial_section43DiffPullback_eq_zero_of_timeNorm_gt_bound`
+for every `q'`, `funext` the original integrand to the zero function, then
+`rw` and `simp` all iterated derivatives of `0`.
+
+Third prove the pointwise derivative of the pointwise `r`-th derivative.  The
+derivative target must be the left-curry of the `(r+1)`-linear map, because
+Mathlib's `iteratedFDeriv_succ_apply_left` convention puts the newest
+direction in slot `0`:
+
+```lean
+theorem hasFDerivAt_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (τ : Fin n → ℝ) :
+    HasFDerivAt
+      (fun q' : NPointDomain d n =>
+        iteratedFDeriv ℝ r
+          (fun q'' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+            partialFourierSpatial_fun (d := d) (n := n) F
+              (τ, section43QSpatial (d := d) (n := n) q''))
+          q')
+      ((iteratedFDeriv ℝ (r + 1)
+        (fun q'' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q''))
+        q).curryLeft)
+      q
+```
+
+Proof transcript:
+
+1. Let `G τ q` be the scalar pointwise integrand.
+2. From `contDiff_section43FourierLaplace_timeIntegrand_q`, get
+   `DifferentiableAt ℝ (iteratedFDeriv ℝ r G) q` by
+   `ContDiffAt.differentiableAt_iteratedFDeriv`.
+3. The derivative supplied by `hdiff.hasFDerivAt` is
+   `fderiv ℝ (iteratedFDeriv ℝ r G) q`.
+4. Prove
+   `fderiv ℝ (iteratedFDeriv ℝ r G) q =
+    (iteratedFDeriv ℝ (r + 1) G q).curryLeft`
+   by extensionality in `v` and `mtail`; the application equality is
+   definitional from the `iteratedFDeriv` successor convention and
+   `ContinuousMultilinearMap.curryLeft_apply`.
+
+Fourth prove compact local domination for the candidate derivative:
+
+```lean
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    ∃ bound : (Fin n → ℝ) → ℝ,
+      Integrable bound ∧
+      ∀ᵐ τ, ∀ q' ∈ Metric.closedBall q (1 : ℝ),
+        ‖(iteratedFDeriv ℝ (r + 1)
+          (fun q'' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q'' k : ℂ))) *
+            partialFourierSpatial_fun (d := d) (n := n)
+              (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+              (τ, section43QSpatial (d := d) (n := n) q''))
+          q').curryLeft‖ ≤ bound τ
+```
+
+Proof transcript:
+
+1. Choose `R ≥ 0` from
+   `exists_section43DiffPullback_timeNorm_bound_of_compact_tsupport`.
+2. Let `Kτ = Metric.closedBall (0 : Fin n → ℝ) R`.
+3. Off `Kτ`, the derivative is zero by the upper-slab all-order zero theorem,
+   so the bound can be zero there.
+4. On `Kτ` and `Metric.closedBall q 1`, use the no-margin operator norm
+   estimate for order `r + 1` plus `ContinuousMultilinearMap.curryLeft_norm`.
+5. Bound the exponential uniformly on the product by
+   `Complex.norm_exp`, `Finset.abs_sum_le_sum_abs`,
+   `abs_section43QTime_coord_le_opNorm`, `‖q'‖ ≤ ‖q‖ + 1`, `‖τ‖ ≤ R`, and
+   monotonicity of `Real.exp`.
+6. For each word `a`, choose a global constant from
+   `exists_norm_bound_partialFourierSpatial_fun` for
+   `section43DerivativeWordInput d n (r + 1)
+      (section43DiffPullbackCLM d n ⟨f, hf_ord⟩) a`.
+7. Use `‖τ‖ ^ K ≤ R ^ K` on `Kτ` and the nonnegativity of word
+   coefficients to build a single constant
+   `C = Cexp * ∑ a, coeff(a) * R ^ timeCount(a) * Cword(a)`.
+8. Take `bound = Set.indicator Kτ (fun _ => C)`.  Integrability is exactly
+   `integrable_indicator_time_closedBall_const`.
+
+Fifth apply Mathlib's dominated parametric integral theorem to the
+CLM-valued candidate:
+
+```lean
+theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    HasFDerivAt
+      (fun q' : NPointDomain d n =>
+        section43FourierLaplaceIntegral_iteratedFDerivCandidate
+          d n r f hf_ord q')
+      ((section43FourierLaplaceIntegral_iteratedFDerivCandidate
+          d n (r + 1) f hf_ord q).curryLeft)
+      q
+```
+
+Proof transcript:
+
+1. Use
+   `hasFDerivAt_integral_of_dominated_of_fderiv_le` with codomain
+   `ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ`.
+2. The parameter set is `Metric.closedBall q 1`, which is in `𝓝 q`.
+3. Fixed-`q'` measurability/integrability follows from the compact local
+   bound and fixed-`τ` continuity of the pointwise `iteratedFDeriv`; if Lean
+   requests an explicit fixed-`q'` integrability theorem, prove it from the
+   same upper-slab indicator bound with `q = q'`.
+4. The pointwise `HasFDerivAt` hypothesis is
+   `hasFDerivAt_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft`.
+5. The dominated bound is
+   `section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact`.
+6. Simplify the resulting derivative integral to
+   `(section43FourierLaplaceIntegral_iteratedFDerivCandidate
+      d n (r + 1) f hf_ord q).curryLeft` using
+   Bochner integral compatibility with the continuous linear map
+   `ContinuousMultilinearMap.curryLeft`, i.e. the linear isometry
+   `continuousMultilinearCurryLeftEquiv`.
+
+Finally identify the actual iterated derivative by induction:
+
+```lean
+theorem section43FourierLaplaceIntegral_iteratedFDeriv_eq_candidate_of_compact_orderedSupport
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q')
+      q =
+      section43FourierLaplaceIntegral_iteratedFDerivCandidate
+        d n r f hf_ord q
+```
+
+Proof transcript:
+
+1. Base `r = 0`: ext the zero-linear maps on `m : Fin 0 → NPointDomain d n`.
+   The left side evaluates to the Fourier-Laplace integral and the right side
+   evaluates to the Bochner integral of the zero-th pointwise derivative; close
+   by the definition of `section43FourierLaplaceIntegral` and integral
+   compatibility with fixed zero-linear-map evaluation.
+2. Step `r → r+1`: use the induction hypothesis as a function equality for
+   `q'`, differentiate it at `q`, and use
+   `section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport`.
+3. Convert the resulting curried derivative equality back to an
+   `(r+1)`-linear map by applying `.uncurryLeft`; this is exactly
+   `ContinuousMultilinearMap.uncurry_curryLeft`.
 
 There is one important implementation correction before the derivative theorem:
 the `smoothOn` field should not be attacked by a custom closed-half-space

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -20438,11 +20438,33 @@ Implementation readiness checkpoint:
   `section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_timeNorm_gt_bound`,
   and
   `hasFDerivAt_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft`.
-- Ready next: prove
-  `section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact`,
-  the compact upper-slab local domination theorem.
-- Then ready: apply `hasFDerivAt_integral_of_dominated_of_fderiv_le` to
-  identify the derivative of the integrated candidate with the next candidate.
+- Compiled now in
+  `Section43FourierLaplaceCompactDifferentiation.lean` and exact-file checked
+  on 2026-04-17:
+  `norm_le_of_mem_time_closedBall_zero`,
+  `norm_nPoint_le_norm_add_one_of_mem_closedBall`,
+  `norm_exp_neg_section43_timePair_le_local_closedBall`, and
+  `section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact`.
+- Compiled now in
+  `Section43FourierLaplaceCompactDifferentiation.lean` and exact-file checked
+  on 2026-04-17:
+  `continuous_cmlm_apply_nPoint`,
+  `continuous_section43DerivativeWordScalar`,
+  `continuous_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply`,
+  `continuous_section43FourierLaplace_timeIntegrand_iteratedFDeriv`,
+  `integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact`,
+  and
+  `aestronglyMeasurable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft`.
+- Ready next: align the CMLM codomain topology/normed-space instance surface
+  for `hasFDerivAt_integral_of_dominated_of_fderiv_le`.  The first attempt
+  showed the honest remaining Lean seam: the theorem expects the normed /
+  pseudometric topology on
+  `ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ`, while
+  direct continuity lemmas naturally produce `AEStronglyMeasurable` under the
+  bundled CMLM topology.  Close this with a small topology-transport lemma, not
+  with heartbeat increases or wrapper reductions.
+- Then apply `hasFDerivAt_integral_of_dominated_of_fderiv_le` to identify the
+  derivative of the integrated candidate with the next candidate.
 - Then ready: identify the candidate with actual `iteratedFDeriv` by
   induction.
 - Then ready: derive the actual derivative rapid theorem from that
@@ -20635,6 +20657,21 @@ Proof transcript:
 Fourth prove compact local domination for the candidate derivative:
 
 ```lean
+theorem norm_exp_neg_section43_timePair_le_local_closedBall
+    (d n : ℕ) [NeZero d]
+    (q q' : NPointDomain d n)
+    (τ : Fin n → ℝ)
+    {R : ℝ} (hR_nonneg : 0 ≤ R)
+    (hτ : τ ∈ Metric.closedBall (0 : Fin n → ℝ) R)
+    (hq' : q' ∈ Metric.closedBall q (1 : ℝ)) :
+    ‖Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) *
+          (section43QTime (d := d) (n := n) q' k : ℂ)))‖ ≤
+      Real.exp
+        (R * ((∑ k : Fin n, section43QTimeCoordOpNorm d n k) *
+          (‖q‖ + 1)))
+
 theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft_local_bound_of_compact
     (d n r : ℕ) [NeZero d]
     (f : SchwartzNPoint d n)
@@ -20662,21 +20699,38 @@ Proof transcript:
 1. Choose `R ≥ 0` from
    `exists_section43DiffPullback_timeNorm_bound_of_compact_tsupport`.
 2. Let `Kτ = Metric.closedBall (0 : Fin n → ℝ) R`.
-3. Off `Kτ`, the derivative is zero by the upper-slab all-order zero theorem,
+3. Prove the local exponential bound:
+   - From `hτ : τ ∈ Kτ`, obtain `‖τ‖ ≤ R` by rewriting
+     `Metric.mem_closedBall`, `dist_eq_norm`, and `sub_zero`.
+   - From `hq' : q' ∈ Metric.closedBall q 1`, obtain
+     `‖q'‖ ≤ ‖q‖ + 1` by combining
+     `‖q'‖ = ‖(q' - q) + q‖`, `norm_add_le`, and
+     `dist q' q ≤ 1`.
+   - For each `k`, combine `norm_le_pi_norm τ k` and
+     `abs_section43QTime_coord_le_opNorm d n q' k` to prove
+     `|τ k * section43QTime q' k| ≤
+      R * (section43QTimeCoordOpNorm d n k * (‖q‖ + 1))`.
+   - Use `Complex.norm_exp`, compute the real part of the exponent by `simp`,
+     bound `-(∑ k, τ k * section43QTime q' k)` by
+     `∑ k, |τ k * section43QTime q' k|` via
+     `neg_le_abs` and `Finset.abs_sum_le_sum_abs`, and finish with
+     `Real.exp_le_exp`.
+   - Rewrite the final finite sum as
+     `R * ((∑ k, section43QTimeCoordOpNorm d n k) * (‖q‖ + 1))`
+     using distributivity and commutativity.
+4. Off `Kτ`, the derivative is zero by the upper-slab all-order zero theorem,
    so the bound can be zero there.
-4. On `Kτ` and `Metric.closedBall q 1`, use the no-margin operator norm
+5. On `Kτ` and `Metric.closedBall q 1`, use the no-margin operator norm
    estimate for order `r + 1` plus `ContinuousMultilinearMap.curryLeft_norm`.
-5. Bound the exponential uniformly on the product by
-   `Complex.norm_exp`, `Finset.abs_sum_le_sum_abs`,
-   `abs_section43QTime_coord_le_opNorm`, `‖q'‖ ≤ ‖q‖ + 1`, `‖τ‖ ≤ R`, and
-   monotonicity of `Real.exp`.
 6. For each word `a`, choose a global constant from
    `exists_norm_bound_partialFourierSpatial_fun` for
    `section43DerivativeWordInput d n (r + 1)
       (section43DiffPullbackCLM d n ⟨f, hf_ord⟩) a`.
 7. Use `‖τ‖ ^ K ≤ R ^ K` on `Kτ` and the nonnegativity of word
    coefficients to build a single constant
-   `C = Cexp * ∑ a, coeff(a) * R ^ timeCount(a) * Cword(a)`.
+   `C = Cexp * ∑ a, coeff(a) * R ^ timeCount(a) * Cword(a)`, where
+   `Cexp =
+    Real.exp (R * ((∑ k, section43QTimeCoordOpNorm d n k) * (‖q‖ + 1)))`.
 8. Take `bound = Set.indicator Kτ (fun _ => C)`.  Integrability is exactly
    `integrable_indicator_time_closedBall_const`.
 
@@ -20705,11 +20759,107 @@ Proof transcript:
 1. Use
    `hasFDerivAt_integral_of_dominated_of_fderiv_le` with codomain
    `ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ`.
-2. The parameter set is `Metric.closedBall q 1`, which is in `𝓝 q`.
-3. Fixed-`q'` measurability/integrability follows from the compact local
-   bound and fixed-`τ` continuity of the pointwise `iteratedFDeriv`; if Lean
-   requests an explicit fixed-`q'` integrability theorem, prove it from the
-   same upper-slab indicator bound with `q = q'`.
+2. Before this theorem, compile the fixed-`q` hypothesis packet:
+
+```lean
+theorem continuous_section43FourierLaplace_timeIntegrand_iteratedFDeriv
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n) :
+    Continuous fun τ : Fin n → ℝ =>
+      iteratedFDeriv ℝ r
+        (fun q' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+        q
+
+theorem integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    Integrable fun τ : Fin n → ℝ =>
+      iteratedFDeriv ℝ r
+        (fun q' : NPointDomain d n =>
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n)
+            (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+            (τ, section43QSpatial (d := d) (n := n) q'))
+        q
+
+theorem aestronglyMeasurable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    AEStronglyMeasurable
+      (fun τ : Fin n → ℝ =>
+        (iteratedFDeriv ℝ (r + 1)
+          (fun q' : NPointDomain d n =>
+            Complex.exp
+              (-(∑ k : Fin n,
+                (τ k : ℂ) *
+                  (section43QTime (d := d) (n := n) q' k : ℂ))) *
+            partialFourierSpatial_fun (d := d) (n := n)
+              (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+              (τ, section43QSpatial (d := d) (n := n) q'))
+          q).curryLeft)
+```
+
+Proof transcript for the continuity packet:
+
+1. Prove a finite-dimensional application criterion for CMLM-valued maps,
+   by induction on `r`, using `continuous_clm_apply` for the curry-left
+   representation and `continuousMultilinearCurryFin0` for the zero-arity
+   endpoint:
+   `Continuous (fun x => L x) ↔ ∀ m, Continuous (fun x => L x m)`.
+2. For each direction tuple `m`, rewrite the applied function by
+   `section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words`.
+3. Each finite-word scalar is continuous in `τ` by induction on the word
+   length; time atoms contribute the coordinate `τ k`, while spatial atoms
+   are independent of `τ`.
+4. Each partial-Fourier word term is continuous in `τ` by
+   `continuous_partialFourierSpatial_fun` composed with
+   `τ ↦ (τ, section43QSpatial q)`.
+5. Finite sums and products give applied continuity, hence CMLM-valued
+   continuity.
+6. Integrability follows from the compiled local domination theorem with
+   center `q`, together with the continuity/aestrong-measurability theorem
+   and `Integrable.mono'`/the dominated-bound integrability.
+7. The curry-left derivative measurability theorem uses the order `r + 1`
+   integrability theorem and then composes its `AEStronglyMeasurable` field
+   with the continuous curry-left linear isometry.  This is why the compiled
+   theorem includes the compact-support hypothesis.
+
+Remaining topology-transport seam before the dominated-integral theorem:
+
+1. Add a small lemma that restates the compiled `AEStronglyMeasurable` facts
+   for CMLM-valued maps using the exact codomain topology inferred by
+   `hasFDerivAt_integral_of_dominated_of_fderiv_le`.
+2. The point is not new mathematics: it is an instance/topology alignment
+   between `ContinuousMultilinearMap.instTopologicalSpace` and the
+   pseudometric topology coming from the operator norm.
+3. Do not use `set_option maxHeartbeats 0`; if a finite local synth-heartbeat
+   option appears necessary, first try explicit local instances or an
+   equality/identity transport lemma and document the exact statement.
+4. Once this transport compiles, the previously attempted `HasFDerivAt` proof
+   should be reintroduced with the same ingredients already compiled:
+   local bound, `hF_meas`, `hF_int`, `hF'_meas`, pointwise curry-left
+   derivative, and the integral-application extensionality proof for the
+   derivative integral.
+
+3. The parameter set is `Metric.closedBall q 1`, which is in `𝓝 q`.
 4. The pointwise `HasFDerivAt` hypothesis is
    `hasFDerivAt_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft`.
 5. The dominated bound is

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -20016,6 +20016,15 @@ Proof transcript:
 4. Pull the common factors
    `Real.exp (...)` and `∏ j, ‖m j‖` outside the finite sum.
 
+Compiled status, 2026-04-17: the pointwise finite-word expansion and applied
+positive-energy norm bound are implemented and exact-file checked in
+`Section43FourierLaplaceHigherDerivatives.lean`:
+
+```lean
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words
+```
+
 For the lower-margin branch, do not prove that every transported word
 vanishes.  Prove instead that the original integrand is identically zero as a
 function of `q`, and therefore all of its iterated derivatives are zero:
@@ -20095,6 +20104,15 @@ theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
               (section43DerivativeWordInput d n r
                 (section43DiffPullbackCLM d n ⟨f, hf_ord⟩) a)
               (τ, section43QSpatial (d := d) (n := n) q)‖
+```
+
+Compiled status, 2026-04-17: the lower-margin all-order zero theorem and the
+operator-norm word bound are implemented and exact-file checked in
+`Section43FourierLaplaceHigherDerivatives.lean`:
+
+```lean
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_exists_time_lt_margin
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
 ```
 
 The integrated rapid estimate should be implemented first for the finite-word
@@ -20263,18 +20281,24 @@ Implementation readiness checkpoint:
   the cons/tail simp lemmas for word scalar/input/count/coeff, and the
   one-letter expansion theorem
   `section43FourierLaplace_timeIntegrandFDerivCLM_apply_eq_sum_atoms`.
-- Ready next: prove the pointwise finite-word expansion and its applied norm
-  corollary.
+- Compiled now in `Section43FourierLaplaceHigherDerivatives.lean`:
+  `contDiff_section43FourierLaplace_timeIntegrand_q`,
+  `section43FourierLaplace_sum_words_fderivCLM_apply_eq_sum_cons`,
+  `section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words`,
+  `norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words`,
+  `section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_exists_time_lt_margin`,
+  and
+  `norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words`.
+- Ready next: prove the integrated finite-word candidate rapid estimate.
 - Implementation caution for the next theorem: the induction step naturally
   differentiates the CLM-valued map
   `q ↦ iteratedFDeriv ℝ r G q`, while the desired statement is applied to
   directions.  The clean Lean route is either to formulate an intermediate
   CLM-valued finite-word candidate, or to use the constant-application
   derivative theorem to pass from the CLM-valued derivative to the applied
-  scalar function.  Do not fake this with an applied-only rewrite that loses
-  the derivative-of-application obligation.
-- Then ready: prove the lower-margin all-order zero theorem and the
-  operator-norm word bound.
+  scalar function.  This is now handled in the compiled proof by
+  `fderiv_continuousMultilinear_apply_const_apply`, after proving smoothness
+  of the pointwise integrand.
 - Then ready: prove the integrated candidate rapid theorem by finite
   summation of `section43PartialFourier_timeMomentIntegral_spatialRapid`.
 - Then ready: under `hf_compact`, identify the candidate with actual

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -19522,8 +19522,9 @@ finite sum of partial-Fourier transforms of transported Schwartz inputs.
 
 #### First-Derivative Rapid Packet
 
-The next production target should be the first-derivative rapid estimate for
-the compiled CLM-valued derivative candidate:
+This packet is now compiled and is retained here as the `r = 1` model for the
+all-order word induction.  The first-derivative rapid estimate for the compiled
+CLM-valued derivative candidate is:
 
 ```lean
 theorem section43FourierLaplaceIntegral_fderivCandidate_rapid_on_positiveEnergy
@@ -19542,12 +19543,16 @@ theorem section43FourierLaplaceIntegral_fderivCandidate_rapid_on_positiveEnergy
         ‖section43FourierLaplaceIntegral_fderivCandidate d n f hf_ord q‖ ≤ C
 ```
 
+Compiled status, 2026-04-17: this theorem is implemented and exact-file
+checked in `Section43FourierLaplaceWitness.lean`.
+
 This theorem is the `k = 1` rapid field, because the compiled ambient
 first-derivative theorem identifies the derivative of
 `section43FourierLaplaceIntegral` with
 `section43FourierLaplaceIntegral_fderivCandidate`.
 
-The proof should be split into the following Lean lemmas.
+The proof was split into the following Lean lemmas; the same decomposition is
+the template for the all-order word package.
 
 1. Lower-margin derivative vanishing:
 
@@ -19803,56 +19808,480 @@ packet.
 #### Higher-Derivative Smooth/Rapid Induction
 
 For `ContDiffOn ℝ ⊤` and the full rapid field, do not try to write each order
-by hand.  The implementation should introduce an inductive finite-term
-description of derivatives of the integrand.
+by hand and do not introduce another first-derivative wrapper.  The compiled
+first derivative and C¹ package are the base case.  The remaining proof must
+encode the finite algebra of all higher derivatives of the same integrand.
+
+The correct finite algebra is a word expansion, not the earlier coarse
+`timeDegree/spatialInput/coeff` sketch.  The word records exactly which factor
+each derivative slot hits.
 
 Recommended data shape:
 
 ```lean
-structure Section43DerivativeTerm (d n : ℕ) [NeZero d] where
-  timeDegree : ℕ
-  spatialInput : SchwartzNPoint d n
-  coeff : ℝ
+inductive Section43DerivativeAtom (d n : ℕ) where
+  | time (k : Fin n)
+  | spatial (i : Fin n × Fin d)
+  deriving DecidableEq, Fintype
+
+abbrev Section43DerivativeWord (d n r : ℕ) :=
+  Fin r → Section43DerivativeAtom d n
 ```
 
-The semantic term represented by
-`T : Section43DerivativeTerm d n` is
+For a derivative order `r`, a word
+`a : Section43DerivativeWord d n r` is read against directions
+`m : Fin r → NPointDomain d n`.  Its scalar and transported input are defined
+recursively by adding the newest derivative slot on the left, matching
+`iteratedFDeriv_succ_apply_left`.
+
+Base word:
 
 ```text
-q, τ ↦ coeff *
-  polynomial_in(τ, section43QTime directions) of degree ≤ timeDegree *
-  exp(-∑ τ_i q_i^0) *
-  partialFourierSpatial_fun T.spatialInput (τ, section43QSpatial q)
+wordScalar 0 empty τ m = 1
+wordInput  0 empty F     = F
+timeCount  0 empty       = 0
 ```
 
-For a fixed derivative order `k`, the `k`th derivative is a finite sum of such
-terms, multilinear in the `k` direction variables.  Differentiating once more
-does only two things:
+Step, with newest direction `v` and old word `a`:
 
-1. hit the exponential factor, increasing `timeDegree` by one and keeping the
-   same `spatialInput`;
-2. hit the spatial momentum argument, replacing `spatialInput` by one of the
-   finitely many spatial-coordinate transport Schwartz inputs.
+```text
+prepend (time k):
+  wordScalar := (-(τ k : ℂ) * (section43QTime v k : ℂ)) * oldScalar
+  wordInput  := oldInput
+  timeCount  := oldTimeCount + 1
 
-This induction gives three reusable theorem families:
+prepend (spatial i):
+  wordScalar := ((section43QSpatial v i : ℝ) : ℂ) * oldScalar
+  wordInput  := section43SpatialMultiplierTransport d n oldInput i
+  timeCount  := oldTimeCount
+```
+
+The implementation can realize this either as recursive definitions over
+`r`, using `Fin.cons`/`Fin.tail`, or as list definitions plus a length-indexed
+conversion.  The recursion-over-`r` version is preferred because the induction
+step aligns directly with `iteratedFDeriv_succ_apply_left`:
 
 ```lean
-theorem section43FourierLaplace_integrand_iteratedFDeriv_finiteExpansion
-    ...
+-- Pseudocode only; names should be stabilized in Lean when implemented.
+noncomputable def section43DerivativeWordScalar
+    (d n r : ℕ) [NeZero d]
+    (a : Section43DerivativeWord d n r)
+    (τ : Fin n → ℝ) (m : Fin r → NPointDomain d n) : ℂ := ...
 
-theorem section43FourierLaplace_integrand_iteratedFDeriv_dominated
-    ...
+noncomputable def section43DerivativeWordInput
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (a : Section43DerivativeWord d n r) : SchwartzNPoint d n := ...
 
-theorem section43FourierLaplaceIntegral_iteratedFDeriv_rapid_on_positiveEnergy
-    ...
+def section43DerivativeWordTimeCount
+    (d n r : ℕ)
+    (a : Section43DerivativeWord d n r) : ℕ := ...
 ```
 
-The domination theorem consumes exactly the compiled moment estimate
-`section43PartialFourier_timeMomentIntegral_spatialRapid`, with
-`K = timeDegree`, and the same positive-energy exponential bound.  This is the
-right proof-doc criterion for implementation readiness: each generated term
-must reduce to one call to the moment rapid theorem plus finite sums/products
-of constants.
+The first implementation theorem should be the pointwise applied
+`iteratedFDeriv` expansion for the integrand
+
+```text
+G_F(q, τ) =
+  exp(-∑ k, (τ k : ℂ) * (section43QTime q k : ℂ)) *
+    partialFourierSpatial_fun F (τ, section43QSpatial q).
+```
+
+Exact theorem shape:
+
+```lean
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_eq_sum_words
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (q : NPointDomain d n)
+    (τ : Fin n → ℝ)
+    (m : Fin r → NPointDomain d n) :
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q m =
+      ∑ a : Section43DerivativeWord d n r,
+        section43DerivativeWordScalar d n r a τ m *
+          Complex.exp
+            (-(∑ k : Fin n,
+              (τ k : ℂ) *
+                (section43QTime (d := d) (n := n) q k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n)
+            (section43DerivativeWordInput d n r F a)
+            (τ, section43QSpatial (d := d) (n := n) q)
+```
+
+Proof transcript:
+
+1. Base `r = 0`: `iteratedFDeriv ℝ 0` is the original function, and the only
+   word is the empty word.
+2. Step from `r` to `r + 1`: rewrite the left side using
+   `iteratedFDeriv_succ_apply_left`, so the new direction is
+   `v : NPointDomain d n` and the old directions are
+   `u : Fin r → NPointDomain d n`.
+3. Rewrite the inductive hypothesis for the `r`-th derivative as a finite sum
+   over old words.
+4. Differentiate each summand with `HasFDerivAt.mul`.
+5. If the derivative hits the exponential, prepend `time k`.  The derivative
+   of the exponent is the already compiled linear expression using
+   `section43QTimeCLM`; after evaluation on `v`, the scalar contribution is
+   `-(τ k : ℂ) * (section43QTime v k : ℂ)`.
+6. If the derivative hits the spatial partial-Fourier factor, use the compiled
+   coordinate expansion
+   `fderiv_partialFourierSpatial_fun_spatial_apply_eq_sum_multiplierTransport`
+   with `section43QSpatial v`.  Each coordinate `i` prepends `spatial i` and
+   replaces the old input by
+   `section43SpatialMultiplierTransport d n oldInput i`.
+7. Reindex the finite sum over
+   `Option (Fin n) ⊕ (Fin n × Fin d)` into
+   `Section43DerivativeWord d n (r + 1)` by the two constructors
+   `time` and `spatial`.  In Lean this should be expressed as two `Finset.sum`
+   pieces and then folded into the `Fintype` sum over words.
+
+The corresponding scalar norm theorem is the second implementation theorem:
+
+```lean
+theorem section43DerivativeWordScalar_norm_le
+    (d n r : ℕ) [NeZero d]
+    (a : Section43DerivativeWord d n r)
+    (τ : Fin n → ℝ) (m : Fin r → NPointDomain d n) :
+    ‖section43DerivativeWordScalar d n r a τ m‖ ≤
+      section43DerivativeWordCoeff d n r a *
+        ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+        ∏ j : Fin r, ‖m j‖
+```
+
+Here `section43DerivativeWordCoeff` is a nonnegative finite product of the
+already compiled coordinate projection operator norms:
+
+```text
+time k    contributes section43QTimeCoordOpNorm d n k
+spatial i contributes section43QSpatialCoordOpNorm d n i
+```
+
+Proof transcript:
+
+1. Induct over the same word recursion.
+2. For a time atom, use
+   `abs_section43QTime_coord_le_opNorm` and `|τ k| ≤ ‖τ‖`.
+3. For a spatial atom, use
+   `abs_section43QSpatial_coord_le_opNorm`.
+4. Use `norm_mul`, finite-product associativity, and
+   `pow_succ` in the time case.
+
+The applied pointwise derivative bound follows by combining the expansion and
+the scalar norm theorem:
+
+```lean
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_apply_le_sum_words
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    {δ : ℝ}
+    (q : NPointDomain d n) (hq : q ∈ section43PositiveEnergyRegion d n)
+    (τ : Fin n → ℝ)
+    (hτ_margin : ∀ k : Fin n, δ ≤ τ k)
+    (m : Fin r → NPointDomain d n) :
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n) F
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q m‖ ≤
+      Real.exp (-(δ * ∑ k : Fin n,
+        section43QTime (d := d) (n := n) q k)) *
+        (∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r F a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖) *
+        ∏ j : Fin r, ‖m j‖
+```
+
+Proof transcript:
+
+1. Rewrite by the finite-word expansion.
+2. Use `norm_sum_le`, `norm_mul`, and the scalar norm theorem.
+3. Bound the exponential by
+   `norm_exp_neg_section43_timePair_le_exp_neg_margin_sum` using
+   `hτ_margin` and `hq`.
+4. Pull the common factors
+   `Real.exp (...)` and `∏ j, ‖m j‖` outside the finite sum.
+
+For the lower-margin branch, do not prove that every transported word
+vanishes.  Prove instead that the original integrand is identically zero as a
+function of `q`, and therefore all of its iterated derivatives are zero:
+
+```lean
+theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_exists_time_lt_margin
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ}
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)})
+    (τ : Fin n → ℝ)
+    (hτ : ∃ i : Fin n, τ i < δ) :
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n)
+            (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      =
+      0
+```
+
+Proof transcript:
+
+1. For every `q'`, the compiled lower-margin support theorem gives
+   `partialFourierSpatial_fun ... (τ, section43QSpatial q') = 0`.
+2. Hence the whole integrand function is definitionally equal to the zero
+   function by `funext`.
+3. Rewrite the `iteratedFDeriv` of that function to the derivative of `0`,
+   then close by simp.  This avoids any support claim about transported word
+   inputs.
+
+Combining the above-margin and lower-margin branches gives the CLM/operator
+norm estimate.  The applied estimate has the factor
+`∏ j, ‖m j‖`; use `ContinuousMultilinearMap.opNorm_le_bound` to remove the
+directions:
+
+```lean
+theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ}
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)})
+    (q : NPointDomain d n) (hq : q ∈ section43PositiveEnergyRegion d n)
+    (τ : Fin n → ℝ) :
+    ‖iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+          partialFourierSpatial_fun (d := d) (n := n)
+            (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+            (τ, section43QSpatial (d := d) (n := n) q'))
+      q‖ ≤
+      Real.exp (-(δ * ∑ k : Fin n,
+        section43QTime (d := d) (n := n) q k)) *
+        ∑ a : Section43DerivativeWord d n r,
+          section43DerivativeWordCoeff d n r a *
+            ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+            ‖partialFourierSpatial_fun (d := d) (n := n)
+              (section43DerivativeWordInput d n r
+                (section43DiffPullbackCLM d n ⟨f, hf_ord⟩) a)
+              (τ, section43QSpatial (d := d) (n := n) q)‖
+```
+
+The integrated rapid estimate should be implemented first for the finite-word
+candidate.  This theorem does not need compact support, because it only bounds
+the already-defined Bochner integrals of the word majorants:
+
+```lean
+noncomputable def section43FourierLaplaceIntegral_iteratedFDerivCandidate
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (q : NPointDomain d n) :
+    ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ :=
+  -- Bochner integral of the pointwise `iteratedFDeriv`, or the equivalent
+  -- finite sum of word integrals.
+  ...
+
+theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_rapid_on_positiveEnergy
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ} (hδ_pos : 0 < δ)
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)}) :
+    ∀ s : ℕ, ∃ C : ℝ, 0 ≤ C ∧
+      ∀ q ∈ section43PositiveEnergyRegion d n,
+        (1 + ‖q‖) ^ s *
+          ‖section43FourierLaplaceIntegral_iteratedFDerivCandidate
+            d n r f hf_ord q‖ ≤ C
+```
+
+Proof transcript:
+
+1. Apply `norm_integral_le_integral_norm` to the integrated candidate, or
+   unfold the finite word-sum candidate and use `norm_sum_le`.
+2. Apply the operator-norm word bound.
+3. Use `one_add_norm_le_section43_time_spatial_product` exactly as in the
+   zero- and first-derivative rapid proofs to split `(1 + ‖q‖)^s` into time
+   and spatial weights.
+4. Use `exp_margin_sum_controls_positiveEnergy_time_polynomial` for the time
+   weight and exponential margin.
+5. For each word `a`, apply
+   `section43PartialFourier_timeMomentIntegral_spatialRapid` to the Schwartz
+   input `section43DerivativeWordInput ... a` with
+   `K = section43DerivativeWordTimeCount ... a`.
+6. Sum the finitely many word constants.  This is exactly why the word
+   expansion is the right implementation surface: every generated term
+   consumes one call to the compiled moment theorem.
+
+Only after the compact-support smoothness theorem identifies the candidate
+with the actual derivative should production state the actual
+`iteratedFDeriv` rapid theorem:
+
+```lean
+theorem section43FourierLaplaceIntegral_iteratedFDeriv_rapid_on_positiveEnergy
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    {δ : ℝ} (hδ_pos : 0 < δ)
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)}) :
+    ∀ s : ℕ, ∃ C : ℝ, 0 ≤ C ∧
+      ∀ q ∈ section43PositiveEnergyRegion d n,
+        (1 + ‖q‖) ^ s *
+          ‖iteratedFDeriv ℝ r
+            (fun q' : NPointDomain d n =>
+              section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q')
+            q‖ ≤ C
+```
+
+Proof transcript:
+
+1. Use the all-order compact-support dominated integral theorem below to
+   identify `iteratedFDeriv` of the integral with
+   `section43FourierLaplaceIntegral_iteratedFDerivCandidate`.
+2. Close by the candidate rapid theorem.
+
+The smoothness proof under compact support is a separate all-order dominated
+integral theorem.  It should use compact `τ`-slab domination, not the
+positive-energy exponential damping:
+
+```lean
+theorem section43FourierLaplaceIntegral_contDiff_of_compact_orderedSupport
+    (d n : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ)) :
+    ContDiff ℝ ⊤
+      (fun q : NPointDomain d n =>
+        section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q)
+```
+
+Implementation transcript:
+
+1. For each finite order `r`, define the integrated derivative candidate as
+   the Bochner integral of the pointwise `iteratedFDeriv` CLM, or equivalently
+   as the finite sum of the word integrals from the expansion.
+2. Prove fixed-`q` integrability from compact upper-slab support:
+   the existing upper-slab support theorem gives compact support in `τ`, and
+   the finite-word expansion is continuous on the compact product.
+3. Prove local domination on `Metric.closedBall q 1`: on the compact product
+   `Metric.closedBall q 1 ×ˢ Metric.closedBall 0 R`, joint continuity of each
+   word term gives a finite bound, and outside the `τ`-slab the original
+   integrand and all its derivatives vanish because the integrand is
+   identically zero.
+4. Apply Mathlib's dominated differentiation theorem at each finite order,
+   inducting with `contDiff_succ_iff_fderiv_apply` or the corresponding
+   finite-dimensional `ContDiff` theorem already used elsewhere in the repo.
+5. Upgrade finite-order smoothness to `ContDiff ℝ ⊤` by introducing the
+   arbitrary finite order at the start of the proof.
+
+After the previous two theorem families are compiled, the positive-energy
+witness packet becomes implementation-ready:
+
+```lean
+structure Section43PositiveEnergySchwartzWitness
+    (d n : ℕ) [NeZero d] (F : NPointDomain d n → ℂ) where
+  smoothOn :
+    ContDiffOn ℝ ⊤ F (section43PositiveEnergyRegion d n)
+  rapid :
+    ∀ k l : ℕ, ∃ C : ℝ,
+      ∀ q ∈ section43PositiveEnergyRegion d n,
+        ‖q‖ ^ k *
+          ‖iteratedFDerivWithin ℝ l F
+            (section43PositiveEnergyRegion d n) q‖ ≤ C
+```
+
+The bridge from ambient theorems to this structure is:
+
+1. `smoothOn` follows from
+   `section43FourierLaplaceIntegral_contDiff_of_compact_orderedSupport` by
+   `.contDiffOn`.
+2. The `rapid` field follows from
+   `section43FourierLaplaceIntegral_iteratedFDeriv_rapid_on_positiveEnergy`;
+   if Lean keeps the field in `iteratedFDerivWithin` form, use the ambient
+   smoothness theorem plus the positive-energy set restriction theorem to
+   rewrite `iteratedFDerivWithin` to ambient `iteratedFDeriv` on the region.
+3. Only after this structure is populated should the general
+   positive-half-space Schwartz extension theorem be used to obtain an ambient
+   `SchwartzNPoint`.
+
+Implementation readiness checkpoint:
+
+- Compiled now in `Section43FourierLaplaceHigherDerivatives.lean`:
+  `Section43DerivativeAtom`, `Section43DerivativeWord`,
+  `section43DerivativeWordScalar`, `section43DerivativeWordInput`,
+  `section43DerivativeWordTimeCount`, `section43DerivativeWordCoeff`,
+  `section43DerivativeWordCoeff_nonneg`,
+  `section43DerivativeWordScalar_norm_le`,
+  `section43DerivativeAtomEquivSum`,
+  `section43DerivativeAtom_sum`,
+  `section43DerivativeWordCons`,
+  `section43DerivativeWordEquivCons`,
+  `section43DerivativeWord_sum_cons`,
+  the cons/tail simp lemmas for word scalar/input/count/coeff, and the
+  one-letter expansion theorem
+  `section43FourierLaplace_timeIntegrandFDerivCLM_apply_eq_sum_atoms`.
+- Ready next: prove the pointwise finite-word expansion and its applied norm
+  corollary.
+- Implementation caution for the next theorem: the induction step naturally
+  differentiates the CLM-valued map
+  `q ↦ iteratedFDeriv ℝ r G q`, while the desired statement is applied to
+  directions.  The clean Lean route is either to formulate an intermediate
+  CLM-valued finite-word candidate, or to use the constant-application
+  derivative theorem to pass from the CLM-valued derivative to the applied
+  scalar function.  Do not fake this with an applied-only rewrite that loses
+  the derivative-of-application obligation.
+- Then ready: prove the lower-margin all-order zero theorem and the
+  operator-norm word bound.
+- Then ready: prove the integrated candidate rapid theorem by finite
+  summation of `section43PartialFourier_timeMomentIntegral_spatialRapid`.
+- Then ready: under `hf_compact`, identify the candidate with actual
+  `iteratedFDeriv` and derive the actual derivative rapid theorem.
+- Not ready to implement yet: the positive-half-space Schwartz extension
+  theorem; it should be documented separately after the all-order witness
+  packet is compiled.
 
 There is one important implementation correction before the derivative theorem:
 the `smoothOn` field should not be attacked by a custom closed-half-space

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -20115,9 +20115,13 @@ theorem section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_exists_t
 theorem norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words
 ```
 
-The integrated rapid estimate should be implemented first for the finite-word
-candidate.  This theorem does not need compact support, because it only bounds
-the already-defined Bochner integrals of the word majorants:
+The integrated rapid estimate should be implemented first for the
+Bochner-integral candidate.  There is no longer an "either/or" implementation
+choice here: the candidate is the CLM-valued Bochner integral of the pointwise
+`iteratedFDeriv`, while the finite-word expansion is used only to build a real
+majorant for its norm.  This keeps the candidate in the same category as the
+first-derivative candidate already compiled in
+`Section43FourierLaplaceWitness.lean`.
 
 ```lean
 noncomputable def section43FourierLaplaceIntegral_iteratedFDerivCandidate
@@ -20127,9 +20131,137 @@ noncomputable def section43FourierLaplaceIntegral_iteratedFDerivCandidate
       tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
     (q : NPointDomain d n) :
     ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ :=
-  -- Bochner integral of the pointwise `iteratedFDeriv`, or the equivalent
-  -- finite sum of word integrals.
-  ...
+  ∫ τ : Fin n → ℝ,
+    iteratedFDeriv ℝ r
+      (fun q' : NPointDomain d n =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) *
+              (section43QTime (d := d) (n := n) q' k : ℂ))) *
+        partialFourierSpatial_fun (d := d) (n := n)
+          (section43DiffPullbackCLM d n ⟨f, hf_ord⟩)
+          (τ, section43QSpatial (d := d) (n := n) q'))
+      q
+```
+
+The real finite-word majorant for fixed spatial momentum `ξ` is:
+
+```lean
+noncomputable def section43FourierLaplace_iteratedFDerivWordMajorant
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (ξ : EuclideanSpace ℝ (Fin n × Fin d))
+    (τ : Fin n → ℝ) : ℝ :=
+  ∑ a : Section43DerivativeWord d n r,
+    section43DerivativeWordCoeff d n r a *
+      ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+        ‖partialFourierSpatial_fun (d := d) (n := n)
+          (section43DerivativeWordInput d n r F a) (τ, ξ)‖
+
+noncomputable def section43FourierLaplace_iteratedFDerivWordMajorantIntegral
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (ξ : EuclideanSpace ℝ (Fin n × Fin d)) : ℝ :=
+  ∑ a : Section43DerivativeWord d n r,
+    section43DerivativeWordCoeff d n r a *
+      ∫ τ : Fin n → ℝ,
+        ‖τ‖ ^ section43DerivativeWordTimeCount d n r a *
+          ‖partialFourierSpatial_fun (d := d) (n := n)
+            (section43DerivativeWordInput d n r F a) (τ, ξ)‖
+```
+
+The immediate Lean package before the rapid theorem is:
+
+```lean
+theorem integrable_section43FourierLaplace_iteratedFDerivWordMajorant
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (ξ : EuclideanSpace ℝ (Fin n × Fin d)) :
+    Integrable
+      (section43FourierLaplace_iteratedFDerivWordMajorant d n r F ξ)
+      (volume : Measure (Fin n → ℝ))
+
+theorem integral_section43FourierLaplace_iteratedFDerivWordMajorant
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (ξ : EuclideanSpace ℝ (Fin n × Fin d)) :
+    (∫ τ : Fin n → ℝ,
+      section43FourierLaplace_iteratedFDerivWordMajorant d n r F ξ τ) =
+      section43FourierLaplace_iteratedFDerivWordMajorantIntegral d n r F ξ
+
+theorem section43FourierLaplace_iteratedFDerivWordMajorantIntegral_spatialRapid
+    (d n r : ℕ) [NeZero d]
+    (F : SchwartzNPoint d n)
+    (s : ℕ) :
+    ∃ C : ℝ, 0 ≤ C ∧
+      ∀ ξ : EuclideanSpace ℝ (Fin n × Fin d),
+        (1 + ‖ξ‖) ^ s *
+          section43FourierLaplace_iteratedFDerivWordMajorantIntegral
+            d n r F ξ ≤ C
+```
+
+Proof transcript for this package:
+
+1. Integrability is a finite sum over words.  For each word `a`, use
+   `integrable_timeMoment_norm_partialFourierSpatial_timeSlice` on the
+   transported Schwartz input
+   `section43DerivativeWordInput d n r F a` and time moment
+   `section43DerivativeWordTimeCount d n r a`, then multiply by the constant
+   `section43DerivativeWordCoeff d n r a`.
+2. The integral identity is `MeasureTheory.integral_finset_sum` followed by
+   `MeasureTheory.integral_const_mul` for each word summand.
+3. The spatial rapid theorem chooses, for each word `a`, a constant from
+   `section43PartialFourier_timeMomentIntegral_spatialRapid` applied to the
+   same transported input and time moment.  Sum the finitely many constants
+   after multiplying by the nonnegative word coefficients.
+4. Nonnegativity of the word-majorant integral follows termwise from
+   `section43DerivativeWordCoeff_nonneg` and `integral_nonneg`.
+
+The candidate norm estimate is:
+
+```lean
+theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_norm_le_exp_margin_word_integrals
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    {δ : ℝ}
+    (hδ_supp :
+      tsupport (f : NPointDomain d n → ℂ) ⊆
+        {x |
+          (∀ i : Fin n, δ ≤ x i 0) ∧
+          (∀ i j : Fin n, i < j → δ ≤ x j 0 - x i 0)})
+    (q : NPointDomain d n)
+    (hq : q ∈ section43PositiveEnergyRegion d n) :
+    let F : SchwartzNPoint d n := section43DiffPullbackCLM d n ⟨f, hf_ord⟩
+    let E : ℝ :=
+      Real.exp (-(δ * ∑ k : Fin n,
+        section43QTime (d := d) (n := n) q k))
+    let ξ : EuclideanSpace ℝ (Fin n × Fin d) :=
+      section43QSpatial (d := d) (n := n) q
+    ‖section43FourierLaplaceIntegral_iteratedFDerivCandidate
+      d n r f hf_ord q‖ ≤
+      E *
+        section43FourierLaplace_iteratedFDerivWordMajorantIntegral
+          d n r F ξ
+```
+
+Proof transcript:
+
+1. Unfold the candidate as `∫ τ, G τ`, where `G τ` is the pointwise
+   `iteratedFDeriv` CLM.
+2. Apply `MeasureTheory.norm_integral_le_integral_norm`.
+3. Apply the compiled operator bound
+   `norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words`,
+   rewritten as
+   `‖G τ‖ ≤ E * section43FourierLaplace_iteratedFDerivWordMajorant ... τ`.
+4. Use integrability of `E * wordMajorant` from the finite-sum integrability
+   theorem and `MeasureTheory.integral_mono_of_nonneg`.
+5. Pull out the constant `E` with `MeasureTheory.integral_const_mul`, then
+   use the word-majorant integral identity.
+
+The rapid theorem then has the exact first-derivative proof skeleton, with
+`J` equal to the word-majorant integral:
 
 theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_rapid_on_positiveEnergy
     (d n r : ℕ) [NeZero d]
@@ -20151,21 +20283,18 @@ theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_rapid_on_positiv
 
 Proof transcript:
 
-1. Apply `norm_integral_le_integral_norm` to the integrated candidate, or
-   unfold the finite word-sum candidate and use `norm_sum_le`.
-2. Apply the operator-norm word bound.
-3. Use `one_add_norm_le_section43_time_spatial_product` exactly as in the
+1. Use
+   `section43FourierLaplaceIntegral_iteratedFDerivCandidate_norm_le_exp_margin_word_integrals`.
+2. Use `one_add_norm_le_section43_time_spatial_product` exactly as in the
    zero- and first-derivative rapid proofs to split `(1 + ‖q‖)^s` into time
    and spatial weights.
-4. Use `exp_margin_sum_controls_positiveEnergy_time_polynomial` for the time
+3. Use `exp_margin_sum_controls_positiveEnergy_time_polynomial` for the time
    weight and exponential margin.
-5. For each word `a`, apply
-   `section43PartialFourier_timeMomentIntegral_spatialRapid` to the Schwartz
-   input `section43DerivativeWordInput ... a` with
-   `K = section43DerivativeWordTimeCount ... a`.
-6. Sum the finitely many word constants.  This is exactly why the word
-   expansion is the right implementation surface: every generated term
-   consumes one call to the compiled moment theorem.
+4. Use
+   `section43FourierLaplace_iteratedFDerivWordMajorantIntegral_spatialRapid`
+   for the spatial weight and finite word sum.
+5. Finish with the same product estimate as the compiled zero- and
+   first-derivative rapid theorems.
 
 Only after the compact-support smoothness theorem identifies the candidate
 with the actual derivative should production state the actual
@@ -20289,20 +20418,23 @@ Implementation readiness checkpoint:
   `section43FourierLaplace_timeIntegrand_iteratedFDeriv_eq_zero_of_exists_time_lt_margin`,
   and
   `norm_section43FourierLaplace_timeIntegrand_iteratedFDeriv_le_sum_words`.
-- Ready next: prove the integrated finite-word candidate rapid estimate.
-- Implementation caution for the next theorem: the induction step naturally
-  differentiates the CLM-valued map
-  `q ↦ iteratedFDeriv ℝ r G q`, while the desired statement is applied to
-  directions.  The clean Lean route is either to formulate an intermediate
-  CLM-valued finite-word candidate, or to use the constant-application
-  derivative theorem to pass from the CLM-valued derivative to the applied
-  scalar function.  This is now handled in the compiled proof by
-  `fderiv_continuousMultilinear_apply_const_apply`, after proving smoothness
-  of the pointwise integrand.
-- Then ready: prove the integrated candidate rapid theorem by finite
-  summation of `section43PartialFourier_timeMomentIntegral_spatialRapid`.
-- Then ready: under `hf_compact`, identify the candidate with actual
-  `iteratedFDeriv` and derive the actual derivative rapid theorem.
+- Compiled now in `Section43FourierLaplaceHigherDerivatives.lean`:
+  `section43FourierLaplaceIntegral_iteratedFDerivCandidate`,
+  `section43FourierLaplace_iteratedFDerivWordMajorant`,
+  `section43FourierLaplace_iteratedFDerivWordMajorantIntegral`,
+  `integrable_section43FourierLaplace_iteratedFDerivWordMajorant`,
+  `integral_section43FourierLaplace_iteratedFDerivWordMajorant`,
+  `section43FourierLaplace_iteratedFDerivWordMajorantIntegral_spatialRapid`,
+  `section43FourierLaplaceIntegral_iteratedFDerivCandidate_norm_le_exp_margin_word_integrals`,
+  and
+  `section43FourierLaplaceIntegral_iteratedFDerivCandidate_rapid_on_positiveEnergy`.
+  Exact file check and narrow module build both terminated successfully on
+  2026-04-17.
+- Ready next: under `hf_compact`, identify the candidate with actual
+  `iteratedFDeriv` by an all-order dominated differentiation theorem using
+  compact upper time-slab support.
+- Then ready: derive the actual derivative rapid theorem from that
+  identification and the compiled candidate rapid theorem.
 - Not ready to implement yet: the positive-half-space Schwartz extension
   theorem; it should be documented separately after the all-order witness
   packet is compiled.

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -19224,7 +19224,7 @@ structure Section43PositiveEnergySchwartzWitness
     (d n : ℕ) [NeZero d]
     (F : NPointDomain d n → ℂ) : Prop where
   smoothOn :
-    ContDiffOn ℝ ⊤ F (section43PositiveEnergyRegion d n)
+    ContDiffOn ℝ (↑(⊤ : ℕ∞)) F (section43PositiveEnergyRegion d n)
   rapid :
     ∀ k l : ℕ, ∃ C > 0,
       ∀ q ∈ section43PositiveEnergyRegion d n,
@@ -19807,7 +19807,7 @@ packet.
 
 #### Higher-Derivative Smooth/Rapid Induction
 
-For `ContDiffOn ℝ ⊤` and the full rapid field, do not try to write each order
+For `ContDiffOn ℝ (↑(⊤ : ℕ∞))` and the full rapid field, do not try to write each order
 by hand and do not introduce another first-derivative wrapper.  The compiled
 first derivative and C¹ package are the base case.  The remaining proof must
 encode the finite algebra of all higher derivatives of the same integrand.
@@ -20329,6 +20329,18 @@ Proof transcript:
    `section43FourierLaplaceIntegral_iteratedFDerivCandidate`.
 2. Close by the candidate rapid theorem.
 
+Compiled status, 2026-04-17: the actual derivative rapid theorem is
+implemented in `Section43FourierLaplaceCompactDifferentiation.lean` as
+
+```lean
+section43FourierLaplaceIntegral_iteratedFDeriv_rapid_on_positiveEnergy
+```
+
+The proof is exactly the two-line consumer described above: rewrite by
+`section43FourierLaplaceIntegral_iteratedFDeriv_eq_candidate_of_compact_orderedSupport`
+and apply
+`section43FourierLaplaceIntegral_iteratedFDerivCandidate_rapid_on_positiveEnergy`.
+
 The smoothness proof under compact support is a separate all-order dominated
 integral theorem.  It should use compact `τ`-slab domination, not the
 positive-energy exponential damping:
@@ -20340,7 +20352,7 @@ theorem section43FourierLaplaceIntegral_contDiff_of_compact_orderedSupport
     (hf_ord :
       tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
     (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ)) :
-    ContDiff ℝ ⊤
+    ContDiff ℝ (↑(⊤ : ℕ∞))
       (fun q : NPointDomain d n =>
         section43FourierLaplaceIntegral d n ⟨f, hf_ord⟩ q)
 ```
@@ -20361,8 +20373,16 @@ Implementation transcript:
 4. Apply Mathlib's dominated differentiation theorem at each finite order,
    inducting with `contDiff_succ_iff_fderiv_apply` or the corresponding
    finite-dimensional `ContDiff` theorem already used elsewhere in the repo.
-5. Upgrade finite-order smoothness to `ContDiff ℝ ⊤` by introducing the
+5. Upgrade finite-order smoothness to `ContDiff ℝ (↑(⊤ : ℕ∞))` by introducing the
    arbitrary finite order at the start of the proof.
+
+Compiled status, 2026-04-17: this ambient smoothness theorem is implemented in
+`Section43FourierLaplaceCompactDifferentiation.lean`.
+
+Important Lean-order correction: ordinary `C∞` smoothness is written
+`ContDiff ℝ (↑(⊤ : ℕ∞))`, not `ContDiff ℝ ⊤`.  The latter is a strictly
+stronger top order in Mathlib's `WithTop ℕ∞` scale and is not what follows
+from the all-finite-order dominated-differentiation induction.
 
 After the previous two theorem families are compiled, the positive-energy
 witness packet becomes implementation-ready:
@@ -20371,7 +20391,7 @@ witness packet becomes implementation-ready:
 structure Section43PositiveEnergySchwartzWitness
     (d n : ℕ) [NeZero d] (F : NPointDomain d n → ℂ) where
   smoothOn :
-    ContDiffOn ℝ ⊤ F (section43PositiveEnergyRegion d n)
+    ContDiffOn ℝ (↑(⊤ : ℕ∞)) F (section43PositiveEnergyRegion d n)
   rapid :
     ∀ k l : ℕ, ∃ C : ℝ,
       ∀ q ∈ section43PositiveEnergyRegion d n,
@@ -20455,18 +20475,15 @@ Implementation readiness checkpoint:
   `integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact`,
   and
   `aestronglyMeasurable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_curryLeft`.
-- Ready next: align the CMLM codomain topology/normed-space instance surface
-  for `hasFDerivAt_integral_of_dominated_of_fderiv_le`.  The first attempt
-  showed the honest remaining Lean seam: the theorem expects the normed /
-  pseudometric topology on
-  `ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ`, while
-  direct continuity lemmas naturally produce `AEStronglyMeasurable` under the
-  bundled CMLM topology.  Close this with a small topology-transport lemma, not
-  with heartbeat increases or wrapper reductions.
-- Then apply `hasFDerivAt_integral_of_dominated_of_fderiv_le` to identify the
-  derivative of the integrated candidate with the next candidate.
-- Then ready: identify the candidate with actual `iteratedFDeriv` by
+- Compiled next: the CMLM/CLM topology seam for
+  `hasFDerivAt_integral_of_dominated_of_fderiv_le` is closed by explicit
+  normed-topology `Integrable` hypotheses and a local `curryLI`.
+- Compiled next: `hasFDerivAt_integral_of_dominated_of_fderiv_le` identifies
+  the derivative of the integrated candidate with the next candidate.
+- Compiled next: the candidate is identified with actual `iteratedFDeriv` by
   induction.
+- Compiled next: ambient smoothness is available as
+  `ContDiff ℝ (↑(⊤ : ℕ∞))`.
 - Then ready: derive the actual derivative rapid theorem from that
   identification and the compiled candidate rapid theorem.
 - Not ready to implement yet: the positive-half-space Schwartz extension
@@ -20475,7 +20492,8 @@ Implementation readiness checkpoint:
 
 The all-order candidate-identification theorem should be proved in the
 following smaller theorem order.  Do **not** jump straight to
-`ContDiff ℝ ⊤`; the local domination theorem is the real seam.
+`ContDiff ℝ ⊤`; ordinary C∞ smoothness is
+`ContDiff ℝ (↑(⊤ : ℕ∞))`, and the local domination theorem is the real seam.
 
 First add the no-margin pointwise norm estimates.  These are the compact-slab
 analogues of the positive-energy word bounds, but with the exponential left as
@@ -20842,22 +20860,100 @@ Proof transcript for the continuity packet:
    with the continuous curry-left linear isometry.  This is why the compiled
    theorem includes the compact-support hypothesis.
 
-Remaining topology-transport seam before the dominated-integral theorem:
+Resolved topology-transport seam for the dominated-integral theorem:
 
-1. Add a small lemma that restates the compiled `AEStronglyMeasurable` facts
-   for CMLM-valued maps using the exact codomain topology inferred by
-   `hasFDerivAt_integral_of_dominated_of_fderiv_le`.
-2. The point is not new mathematics: it is an instance/topology alignment
+1. The point was not new mathematics: it was an instance/topology alignment
    between `ContinuousMultilinearMap.instTopologicalSpace` and the
    pseudometric topology coming from the operator norm.
-3. Do not use `set_option maxHeartbeats 0`; if a finite local synth-heartbeat
-   option appears necessary, first try explicit local instances or an
-   equality/identity transport lemma and document the exact statement.
-4. Once this transport compiles, the previously attempted `HasFDerivAt` proof
-   should be reintroduced with the same ingredients already compiled:
+2. The compiled solution does not add a wrapper theorem.  It keeps the
+   dominated-differentiation theorem at the real Section 4.3 surface and makes
+   the relevant `Integrable` hypotheses explicit with the normed/pseudometric
+   topology where Lean would otherwise infer the bundled CMLM/CLM topology.
+3. No `set_option maxHeartbeats 0` is used.  The compiled theorem has one
+   local finite `set_option maxHeartbeats 220000`, needed only for the final
+   Bochner integral/curry-left commutation after all implicit instances are
+   made explicit.  The same theorem times out at the default `200000`, while
+   `220000` exact-checks.
+4. The proof now uses the previously compiled ingredients exactly:
    local bound, `hF_meas`, `hF_int`, `hF'_meas`, pointwise curry-left
-   derivative, and the integral-application extensionality proof for the
-   derivative integral.
+   derivative, and Bochner integral compatibility for the derivative integral.
+
+Lean-ready refinement of the topology seam:
+
+1. In the dominated-differentiation proof, define
+
+```lean
+let Fint : NPointDomain d n → (Fin n → ℝ) →
+    ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ := ...
+
+let Fderiv : NPointDomain d n → (Fin n → ℝ) →
+    NPointDomain d n →L[ℝ]
+      ContinuousMultilinearMap ℝ (fun _ : Fin r => NPointDomain d n) ℂ := ...
+```
+
+where `Fderiv q' τ` is the curry-left pointwise `(r+1)`-derivative.
+2. Build `hF_meas` from the compiled integrability theorem, not from the
+continuity theorem:
+
+```lean
+have hF_meas : ∀ᶠ q' in 𝓝 q, AEStronglyMeasurable (Fint q') := by
+  exact Filter.Eventually.of_forall fun q' =>
+    (integrable_section43FourierLaplace_timeIntegrand_iteratedFDeriv_of_compact
+      d n r f hf_ord hf_compact q').aestronglyMeasurable
+```
+
+This is the preferred first attempt because `Integrable` packages the
+measurability field through the same normed codomain structure that the
+parametric-integral theorem quantifies over.
+3. Build `hF'_meas` from a normed-topology integrability proof for the
+   curry-left derivative.  The compiled proof introduces
+
+```lean
+let Phi : (Fin n → ℝ) →
+    ContinuousMultilinearMap ℝ
+      (fun _ : Fin (r + 1) => NPointDomain d n) ℂ := ...
+```
+
+then proves `Integrable (Fderiv q)` from `Integrable Phi` by the
+`LipschitzWith 1` map `L ↦ L.curryLeft` and the norm identity
+`ContinuousMultilinearMap.curryLeft_norm`.
+4. The derivative integral returned by
+`hasFDerivAt_integral_of_dominated_of_fderiv_le` has target
+
+```lean
+∫ τ, (iteratedFDeriv ℝ (r + 1) ... q).curryLeft
+```
+
+and must be identified with
+
+```lean
+(section43FourierLaplaceIntegral_iteratedFDerivCandidate
+  d n (r + 1) f hf_ord q).curryLeft
+```
+
+by applying Bochner integral compatibility to a locally defined linear
+isometry `curryLI : L ↦ L.curryLeft`.  This avoids the bundled-instance
+choice in `continuousMultilinearCurryLeftEquiv` and keeps the codomain in the
+same normed topology expected by `hasFDerivAt_integral_of_dominated_of_fderiv_le`.
+
+Compiled status, 2026-04-17:
+
+```lean
+theorem section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport
+    (d n r : ℕ) [NeZero d]
+    (f : SchwartzNPoint d n)
+    (hf_ord :
+      tsupport (f : NPointDomain d n → ℂ) ⊆ OrderedPositiveTimeRegion d n)
+    (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
+    (q : NPointDomain d n) :
+    HasFDerivAt
+      (fun q' : NPointDomain d n =>
+        section43FourierLaplaceIntegral_iteratedFDerivCandidate
+          d n r f hf_ord q')
+      ((section43FourierLaplaceIntegral_iteratedFDerivCandidate
+        d n (r + 1) f hf_ord q).curryLeft)
+      q
+```
 
 3. The parameter set is `Metric.closedBall q 1`, which is in `𝓝 q`.
 4. The pointwise `HasFDerivAt` hypothesis is
@@ -20867,9 +20963,9 @@ Remaining topology-transport seam before the dominated-integral theorem:
 6. Simplify the resulting derivative integral to
    `(section43FourierLaplaceIntegral_iteratedFDerivCandidate
       d n (r + 1) f hf_ord q).curryLeft` using
-   Bochner integral compatibility with the continuous linear map
-   `ContinuousMultilinearMap.curryLeft`, i.e. the linear isometry
-   `continuousMultilinearCurryLeftEquiv`.
+   Bochner integral compatibility with a local normed linear isometry
+   `curryLI : L ↦ L.curryLeft`.  The local isometry avoids the bundled
+   topology chosen by the global `continuousMultilinearCurryLeftEquiv`.
 
 Finally identify the actual iterated derivative by induction:
 
@@ -20901,6 +20997,23 @@ Proof transcript:
    `section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport`.
 3. Convert the resulting curried derivative equality back to an
    `(r+1)`-linear map by applying `.uncurryLeft`; this is exactly
+   `ContinuousMultilinearMap.uncurry_curryLeft`.
+
+Compiled status, 2026-04-17: the induction theorem is implemented in
+`Section43FourierLaplaceCompactDifferentiation.lean`.
+
+Implementation notes:
+
+1. The induction is generalized over `q`, so the successor step has a function
+   equality for all ambient variables.
+2. The base case first changes the goal to the zero-arity integral statement,
+   then uses `ContinuousMultilinearMap.integral_apply` with the already
+   compiled order-`0` integrability theorem.
+3. The successor step rewrites
+   `fderiv ℝ (iteratedFDeriv ℝ r G) q` by differentiating the induction
+   equality and applying
+   `section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport`;
+   the final `rfl` shape is discharged by
    `ContinuousMultilinearMap.uncurry_curryLeft`.
 
 There is one important implementation correction before the derivative theorem:
@@ -21320,7 +21433,7 @@ the positive-energy region by:
 (section43FourierLaplaceIntegral_hasFDerivAt_of_compact_orderedSupport ...).hasFDerivWithinAt
 ```
 
-The `smoothOn : ContDiffOn ℝ ⊤ ...` and `rapid` fields remain positive-energy
+The `smoothOn : ContDiffOn ℝ (↑(⊤ : ℕ∞)) ...` and `rapid` fields remain positive-energy
 estimates.  They should be proved by iterating the same pointwise derivative
 construction and reusing the already compiled positive-half-space damping
 `norm_section43FourierLaplace_timeIntegrand_le_exp_neg_margin_sum`; this is


### PR DESCRIPTION
## Summary
- prove the integrated Fourier-Laplace derivative candidate has the expected derivative under compact ordered support
- identify all actual iterated derivatives with the integrated candidates
- prove ambient C-infinity smoothness and actual all-order rapid bounds on the positive-energy region
- update the theorem-3 OS-route blueprint with the resolved topology seam and next witness-packaging seam

## Verification
- lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceCompactDifferentiation.lean
- lake build OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceCompactDifferentiation

Notes: no set_option maxHeartbeats 0; untracked docs/yinclaw_compare/ intentionally excluded.