### PR TITLE
R→E cluster scaffolding: kill dead sorry + Fubini + a.e. TranslatedPET triple + kernel perm invariance

### DIFF
--- a/OSReconstruction/GeneralResults/FinProductIntegral.lean
+++ b/OSReconstruction/GeneralResults/FinProductIntegral.lean
@@ -78,4 +78,59 @@ theorem integral_fin_add_split (n m : ℕ) (f : (Fin (n + m) → α) → E)
           (ν := (volume : Measure (Fin m → α)))
           (f := fun p : (Fin n → α) × (Fin m → α) => f (e.symm p)) hf')
 
+/-- **Bridge: the `finAddProd` inverse equals `Fin.append` componentwise.**
+
+This converts the abstract measure-theoretic equiv used by `finAddProd` into
+the concrete `Fin.append` that appears in QFT-side statements like the
+cluster integrand `F (Fin.append x y)`. -/
+theorem MeasurableEquiv.finAddProd_symm_apply
+    {α : Type*} [MeasurableSpace α] (n m : ℕ)
+    (x : Fin n → α) (y : Fin m → α) :
+    (MeasurableEquiv.finAddProd n m α).symm (x, y) = Fin.append x y := by
+  -- `finAddProd = A.trans B` with `A = (piCongrLeft _ finSumFinEquiv).symm`
+  -- and `B = sumPiEquivProdPi _`, so `finAddProd.symm (x, y) = A.symm (B.symm (x, y))`
+  -- and on indices via finSumFinEquiv this matches Fin.append componentwise.
+  have hBsymm :
+      (MeasurableEquiv.sumPiEquivProdPi (fun _ : Fin n ⊕ Fin m => α)).symm (x, y) =
+        fun (s : Fin n ⊕ Fin m) => Sum.rec (motive := fun _ => α) x y s := by
+    rfl
+  funext k
+  refine Fin.addCases (fun i => ?_) (fun j => ?_) k
+  · -- k = Fin.castAdd m i.  LHS: use piCongrLeft_apply_apply with e = finSumFinEquiv
+    --                              and a = inl i, so (e a) = finSumFinEquiv (inl i)
+    --                              = Fin.castAdd m i.
+    have : (MeasurableEquiv.finAddProd n m α).symm (x, y) (Fin.castAdd m i) = x i := by
+      change ((MeasurableEquiv.piCongrLeft (fun _ : Fin (n + m) => α) finSumFinEquiv)
+          ((MeasurableEquiv.sumPiEquivProdPi (fun _ : Fin n ⊕ Fin m => α)).symm (x, y)))
+          (Fin.castAdd m i) = x i
+      rw [MeasurableEquiv.coe_piCongrLeft, hBsymm]
+      have hcast : Fin.castAdd m i = finSumFinEquiv (Sum.inl i : Fin n ⊕ Fin m) := by
+        simp [finSumFinEquiv_apply_left]
+      rw [hcast, Equiv.piCongrLeft_apply_apply]
+    simpa [Fin.append_left] using this
+  · -- k = Fin.natAdd n j.
+    have : (MeasurableEquiv.finAddProd n m α).symm (x, y) (Fin.natAdd n j) = y j := by
+      change ((MeasurableEquiv.piCongrLeft (fun _ : Fin (n + m) => α) finSumFinEquiv)
+          ((MeasurableEquiv.sumPiEquivProdPi (fun _ : Fin n ⊕ Fin m => α)).symm (x, y)))
+          (Fin.natAdd n j) = y j
+      rw [MeasurableEquiv.coe_piCongrLeft, hBsymm]
+      have hnat : Fin.natAdd n j = finSumFinEquiv (Sum.inr j : Fin n ⊕ Fin m) := by
+        simp [finSumFinEquiv_apply_right]
+      rw [hnat, Equiv.piCongrLeft_apply_apply]
+    simpa [Fin.append_right] using this
+
+/-- **Fubini for Fin-indexed products, `Fin.append` form.** Direct QFT-side
+statement: an integral over `Fin (n + m) → α` splits via `Fin.append`:
+
+  `∫ z, f z = ∫ x, ∫ y, f (Fin.append x y)`
+
+Convenient for splitting (n+m)-point integrals where the downstream code
+uses `Fin.append` to build the joint configuration (as in BHW cluster
+integrands). -/
+theorem integral_fin_append_split (n m : ℕ) (f : (Fin (n + m) → α) → E)
+    (hf : Integrable f (volume : Measure (Fin (n + m) → α))) :
+    ∫ z, f z = ∫ x : Fin n → α, ∫ y : Fin m → α, f (Fin.append x y) := by
+  rw [integral_fin_add_split n m f hf]
+  simp_rw [MeasurableEquiv.finAddProd_symm_apply]
+
 end

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/BHWTranslation.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/BHWTranslation.lean
@@ -1049,14 +1049,17 @@ theorem baseFiber_isPreconnected_of_active_sector_geometry {m d : ℕ} [NeZero d
   · intro x y
     exact hactive x y
 
-/-- Combined reduction for the fixed-tail base fiber. To prove
-`isPreconnected_baseFiber`, it is enough to show:
-1. each nonempty sector has connected Lorentz index set of nonempty fixed-`Λ`
-   slices;
-2. the graph of nonempty sectors is connected under nonempty overlaps.
+/-- Combined reduction for the fixed-tail base fiber: preconnectedness of
+`baseFiber m d ζtail` follows from
+1. each nonempty sector having connected Lorentz index set of nonempty
+   fixed-`Λ` slices;
+2. the graph of nonempty sectors being connected under nonempty overlaps.
 
-This packages the current production strategy into the exact two geometric
-subproblems that remain after the slice-level convexity work. -/
+This packages the base-fiber preconnectedness target into the exact two
+geometric subproblems that remain after the slice-level convexity work. (The
+live BHW translation invariance proof uses Route 1 instead — see
+`bhw_translation_invariant` below — so this is a standalone geometric
+statement rather than a gating lemma.) -/
 theorem baseFiber_isPreconnected_of_index_and_active_geometry {m d : ℕ} [NeZero d]
     (ζtail : Fin m → Fin (d + 1) → ℂ)
     (hidx_conn :
@@ -1080,39 +1083,6 @@ theorem baseFiber_isPreconnected_of_index_and_active_geometry {m d : ℕ} [NeZer
         Set.eq_empty_iff_forall_notMem.mpr fun ζ₀ hζ₀ => hπ ⟨ζ₀, hζ₀⟩
       simpa [hempty] using (isPreconnected_empty : IsPreconnected (∅ : Set (Fin (d + 1) → ℂ)))
   · exact hactive
-
-/-- **Preconnectedness of the fixed-tail base fiber.**
-
-    For fixed tail difference coordinates `ζtail`, the set of base values `ζ₀`
-    for which `baseFiberConfig m d ζtail ζ₀` lies in the permuted extended tube
-    is preconnected.
-
-    This is the cleaner remaining geometric blocker for BHW translation
-    invariance. Once this theorem is available, the already-proved local
-    translation invariance in `bhw_translation_local` upgrades to global
-    constancy on the base fiber via
-    `bhw_translation_invariant_of_baseFiber_isPreconnected`.
-
-    Compared to the older overlap-domain theorem on
-    `PET ∩ {z | z + c ∈ PET}`, this fiber statement matches the actual
-    difference-variable geometry of translation invariance and avoids the
-    false-looking 1-dimensional line-fiber route that was removed.
-
-    The live production reduction is now
-    `baseFiber_isPreconnected_of_index_and_active_geometry`, so the remaining
-    work is exactly:
-    1. connectedness of the Lorentz index set for each nonempty fiber sector;
-    2. connectedness of the active sector graph under nonempty overlaps.
-
-    **Numerical status (2026-03-14).** In the tested `d = 1`, `n = 2` regime,
-    sampled base fibers remained connected even for the same shifts that split
-    the one-complex-dimensional line fiber `Ω = {t | z + t c ∈ PET}`.
-
-    Ref: Streater-Wightman §2.5; Jost, "General Theory of Quantized Fields" §III.1 -/
-theorem isPreconnected_baseFiber {m d : ℕ} [NeZero d]
-    (ζtail : Fin m → Fin (d + 1) → ℂ) :
-    IsPreconnected (baseFiber m d ζtail) := by
-  sorry
 
 /-! #### Route 1: Translation invariance via reduced difference coordinates
 

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/ForwardTubeLorentz.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/ForwardTubeLorentz.lean
@@ -7,6 +7,7 @@ import OSReconstruction.Wightman.Reconstruction
 import OSReconstruction.Wightman.Reconstruction.AnalyticContinuation
 import OSReconstruction.Wightman.Reconstruction.ForwardTubeDistributions
 import OSReconstruction.GeneralResults.SinusoidSeparation
+import OSReconstruction.GeneralResults.FinProductIntegral
 import OSReconstruction.SCV.VladimirovTillmann
 
 /-!
@@ -1542,6 +1543,102 @@ theorem ae_euclidean_points_in_translatedPET {d n : ℕ} [NeZero d] :
 -- `wickRotation_not_in_PET_null` and `ae_euclidean_points_in_permutedTube`
 -- were DELETED because the statements are FALSE for n ≥ d+2 (see W11Counterexample.lean).
 -- Use `wickRotation_in_translatedPET_null` / `ae_euclidean_points_in_translatedPET` instead.
+
+/-- **Joint TranslatedPET triple a.e. on the Fubini-split product space.**
+
+For a.e. `(y, z) ∈ NPointDomain d n × NPointDomain d m` under the product
+volume measure, all three of the Wick-rotated configurations that appear
+in the cluster decomposition lie in TranslatedPET:
+
+1. `wick(y) ∈ TranslatedPET d n` (the n-block),
+2. `wick(z) ∈ TranslatedPET d m` (the m-block),
+3. `wick(Fin.append y z) ∈ TranslatedPET d (n + m)` (the joint configuration).
+
+This is the post-Fubini-split a.e. statement needed by `W_analytic_cluster_integral`:
+after factoring the (n+m)-point integral via `integral_fin_append_split`, the
+integrand's `F_ext_on_translatedPET_total` kernel is well-defined a.e. on all
+three evaluation points of the cluster pointwise identity.
+
+Proof: each projection statement comes from `ae_euclidean_points_in_translatedPET`,
+and the joint one is transported from the (n+m)-point a.e. statement via the
+measure-preserving equiv `MeasurableEquiv.finAddProd`. -/
+theorem ae_joint_triple_translatedPET {d n m : ℕ} [NeZero d] :
+    ∀ᵐ (p : NPointDomain d n × NPointDomain d m) ∂
+      ((MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)).prod
+        (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d m))),
+      (fun i : Fin n => wickRotatePoint (p.1 i)) ∈ TranslatedPET d n ∧
+      (fun j : Fin m => wickRotatePoint (p.2 j)) ∈ TranslatedPET d m ∧
+      (fun k : Fin (n + m) => wickRotatePoint (Fin.append p.1 p.2 k)) ∈
+        TranslatedPET d (n + m) := by
+  -- (1) a.e. first projection in TranslatedPET d n (lift along Prod.fst projection)
+  have h1 :
+      ∀ᵐ (p : NPointDomain d n × NPointDomain d m) ∂
+        ((MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)).prod
+          (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d m))),
+        (fun i : Fin n => wickRotatePoint (p.1 i)) ∈ TranslatedPET d n := by
+    have hae := ae_euclidean_points_in_translatedPET (d := d) (n := n)
+    rw [MeasureTheory.ae_iff] at hae ⊢
+    set S : Set (NPointDomain d n) :=
+      { y | (fun k => wickRotatePoint (y k)) ∉ TranslatedPET d n }
+    change ((MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)).prod
+        (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d m)))
+      { p : NPointDomain d n × NPointDomain d m | p.1 ∈ S } = 0
+    have hcover :
+        { p : NPointDomain d n × NPointDomain d m | p.1 ∈ S } = S ×ˢ Set.univ := by
+      ext ⟨y, z⟩; simp
+    rw [hcover, MeasureTheory.Measure.prod_prod, hae, zero_mul]
+  -- (2) a.e. second projection in TranslatedPET d m (lift along Prod.snd projection)
+  have h2 :
+      ∀ᵐ (p : NPointDomain d n × NPointDomain d m) ∂
+        ((MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)).prod
+          (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d m))),
+        (fun j : Fin m => wickRotatePoint (p.2 j)) ∈ TranslatedPET d m := by
+    have hae := ae_euclidean_points_in_translatedPET (d := d) (n := m)
+    rw [MeasureTheory.ae_iff] at hae ⊢
+    set T : Set (NPointDomain d m) :=
+      { z | (fun k => wickRotatePoint (z k)) ∉ TranslatedPET d m }
+    change ((MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)).prod
+        (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d m)))
+      { p : NPointDomain d n × NPointDomain d m | p.2 ∈ T } = 0
+    have hcover :
+        { p : NPointDomain d n × NPointDomain d m | p.2 ∈ T } = Set.univ ×ˢ T := by
+      ext ⟨y, z⟩; simp
+    rw [hcover, MeasureTheory.Measure.prod_prod, hae, mul_zero]
+  -- (3) a.e. joint in TranslatedPET d (n+m) — transport from NPointDomain d (n+m)
+  have h3 :
+      ∀ᵐ (p : NPointDomain d n × NPointDomain d m) ∂
+        ((MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)).prod
+          (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d m))),
+        (fun k : Fin (n + m) => wickRotatePoint (Fin.append p.1 p.2 k)) ∈
+          TranslatedPET d (n + m) := by
+    -- Transport via `finAddProd.symm : NPointDomain d n × NPointDomain d m
+    --                                   ≃ᵐ NPointDomain d (n + m)` (measure-preserving).
+    let e := MeasurableEquiv.finAddProd n m (SpacetimeDim d)
+    have hpres : MeasureTheory.MeasurePreserving e.symm
+        (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n × NPointDomain d m))
+        (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d (n + m))) := by
+      have := MeasureTheory.volume_preserving_finAddProd n m (SpacetimeDim d)
+      simpa [e] using this.symm
+    have hvol :
+        (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n × NPointDomain d m)) =
+          (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)).prod
+            (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d m)) := by
+      rfl
+    have hpull : ∀ᵐ (p : NPointDomain d n × NPointDomain d m) ∂
+          (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n × NPointDomain d m)),
+          (fun k : Fin (n + m) => wickRotatePoint ((e.symm p) k)) ∈ TranslatedPET d (n + m) :=
+      hpres.quasiMeasurePreserving.ae (ae_euclidean_points_in_translatedPET (d := d) (n := n + m))
+    have hpull' : ∀ᵐ (p : NPointDomain d n × NPointDomain d m) ∂
+          (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n × NPointDomain d m)),
+          (fun k : Fin (n + m) => wickRotatePoint (Fin.append p.1 p.2 k)) ∈
+            TranslatedPET d (n + m) := by
+      filter_upwards [hpull] with p hp
+      convert hp using 2
+      ext k
+      rw [MeasurableEquiv.finAddProd_symm_apply]
+    rwa [hvol] at hpull'
+  -- Combine all three a.e. facts.
+  filter_upwards [h1, h2, h3] with p hp1 hp2 hp3 using ⟨hp1, hp2, hp3⟩
 
 /-- Connected Lorentz covariance of the boundary distribution implies that the
 boundary values of `z ↦ F(Λ z)` and `z ↦ F(z)` agree distributionally. This is

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean
@@ -3608,22 +3608,30 @@ theorem W_analytic_cluster_integral (Wfn : WightmanFunctions d) (n m : ℕ)
   -- Strategy: bhw_pointwise_cluster_forwardTube + dominated convergence.
   --
   -- Key steps:
-  -- (a) For a.e. x, the Wick-rotated config is in ForwardTube
-  --     (needs `wickRotation_not_in_PET_null`, sorry'd in ForwardTubeLorentz.lean).
-  --     Note: bhw_pointwise_cluster_forwardTube requires ForwardTube hypotheses,
-  --     not just PET membership — so the a.e. set must be refined to time-ordered
-  --     configurations where the specific (identity) permutation works.
+  -- (a) For a.e. x, the Wick-rotated config is in ForwardTube. Note that
+  --     `bhw_pointwise_cluster_forwardTube` requires full ForwardTube
+  --     hypotheses (not just PET membership) on all three evaluation points
+  --     (joint, n-block, m-block), which means the a.e. set needs the
+  --     identity-permutation variant: strictly-increasing-time configurations
+  --     in each block (and in the joint append).
   -- (b) The integrand is dominated by C(1+‖x‖)^N / infDist^q · |f| · |g|
-  --     (from HasForwardTubeGrowth), independent of a.
+  --     (from HasForwardTubeGrowth), independent of the spatial shift a.
   -- (c) Apply tendsto_integral_of_dominated_convergence.
-  -- (d) Factor the integral over Fin(n+m) into n-block × m-block products.
+  -- (d) Factor the integral over Fin(n+m) into n-block × m-block products via
+  --     Fubini; Mathlib provides `volume_measurePreserving_sumPiEquivProdPi`
+  --     and `volume_measurePreserving_piCongrLeft` over `finSumFinEquiv`.
   --
-  -- Blocked by:
-  -- (1) wickRotation_not_in_PET_null (a.e. ForwardTube membership;
-  --     sorry in ForwardTubeLorentz.lean — algebraic measure-zero step is
-  --     NOW PROVED in GeneralResults/PolynomialMeasureZeroProof.lean,
-  --     remaining gap is the Jost characterization)
-  -- (2) Fubini decomposition of Fin(n+m)-indexed integrals
+  -- Status of blockers (post-W11 migration):
+  -- (1) `wickRotation_in_translatedPET_null` is now a *theorem* (no sorry)
+  --     in ForwardTubeLorentz.lean. The outdated `wickRotation_not_in_PET_null`
+  --     was false for n ≥ d+2 and has been deleted (see W11Counterexample.lean).
+  --     What is still needed here is a *refinement* of that a.e. statement to
+  --     the identity-permutation variant: a.e. x with strictly increasing
+  --     positive times in each block of the Fin.append structure.
+  -- (2) Fubini decomposition of Fin(n+m)-indexed integrals is available via
+  --     `MeasurableEquiv.sumPiEquivProdPi` composed with a piCongrLeft
+  --     transport along `finSumFinEquiv`. A dedicated helper lemma would make
+  --     this clean to invoke here (future work).
   sorry
 
 /-- The Schwinger functions satisfy clustering (E4).

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerTemperedness.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerTemperedness.lean
@@ -720,6 +720,34 @@ theorem bhw_euclidean_kernel_measurable {d n : ℕ} [NeZero d]
   rw [hwick_add]
   exact key
 
+/-- **Permutation-invariance of the Wick-rotated BHW kernel, a.e. form.**
+
+For a.e. Euclidean configuration `x : NPointDomain d n`, the TranslatedPET
+extension kernel is invariant under post-composition with any permutation
+`σ : Equiv.Perm (Fin n)`:
+
+  F_ext_on_translatedPET_total(wick(x)) = F_ext_on_translatedPET_total(wick(x ∘ σ))
+
+This is the integrated-form consequence of
+`F_ext_on_translatedPET_total_perm_invariant` (a pointwise invariance on
+TranslatedPET) combined with `ae_euclidean_points_in_translatedPET`
+(a.e. TranslatedPET membership of Wick-rotated Euclidean configurations).
+
+Used by change-of-variables / symmetrization arguments in the cluster
+decomposition and similar permutation-averaged integral identities. -/
+theorem bhw_euclidean_kernel_perm_invariant_ae {d n : ℕ} [NeZero d]
+    (Wfn : WightmanFunctions d) (σ : Equiv.Perm (Fin n)) :
+    ∀ᵐ (x : NPointDomain d n) ∂(MeasureTheory.volume : MeasureTheory.Measure _),
+      F_ext_on_translatedPET_total Wfn (fun k => wickRotatePoint (x k)) =
+      F_ext_on_translatedPET_total Wfn (fun k => wickRotatePoint (x (σ k))) := by
+  filter_upwards [ae_euclidean_points_in_translatedPET (d := d) (n := n)] with x hx
+  have hperm :=
+    F_ext_on_translatedPET_total_perm_invariant Wfn σ
+      (fun k => wickRotatePoint (x k)) hx
+  -- hperm : F_ext ... (fun k => wick(x k)) = F_ext ... (fun k => (fun j => wick(x j)) (σ k))
+  -- Collapse the inner composition to `fun k => wick(x (σ k))`.
+  convert hperm using 2
+
 theorem schwartz_polynomial_kernel_integrable {d n : ℕ} [NeZero d]
     (K : NPointDomain d n → ℂ)
     (hK_meas : MeasureTheory.AEStronglyMeasurable K MeasureTheory.volume)

--- a/OSReconstruction/Wightman/TODO.md
+++ b/OSReconstruction/Wightman/TODO.md
@@ -151,20 +151,27 @@ Current blocker sharpening (2026-03-10):
   on that overlap, extracted from the real Jost-support boundary theorem
   `wightman_real_on_jost_support`.
 
-`WickRotation/ForwardTubeLorentz.lean` (2):
-- `polynomial_growth_on_slice`
-- `wickRotation_not_in_PET_null`
+Current blocker sharpening (2026-04-29):
+- `W_analytic_cluster_integral` and `bhw_pointwise_cluster_forwardTube` are now blocked
+  on a single live geometric refinement: the **identity-permutation ForwardTube
+  refinement** — lifting the a.e. TranslatedPET triple to identity-permutation
+  ForwardTube triples that `bhw_pointwise_cluster_forwardTube` consumes.
+- Mechanical scaffolding now present (PR #72): `integral_fin_append_split` (Fubini
+  over `Fin.append`), `ae_joint_triple_translatedPET` (a.e. block + joint TranslatedPET),
+  `bhw_euclidean_kernel_perm_invariant_ae` (a.e. permutation invariance of the kernel).
+- Two viable routes: (i) a block-respecting joint sorting argument that preserves the
+  tensor-product test function structure — joint-sorting generally interleaves the
+  (n, m) blocks and breaks `f ⊗ g_a`; or (ii) a TranslatedPET version of
+  `bhw_pointwise_cluster_forwardTube` itself (i.e., lifting the SCV cluster axiom's
+  ForwardTube hypothesis to TranslatedPET). Both are research-boundary work.
 
-`WickRotation/BHWTranslation.lean` (1):
-- `isPreconnected_baseFiber` (base-variable fiber connectivity in PET)
-  - STATUS ON MERGED PATH: no longer needed to prove `bhw_translation_invariant`
-  - CURRENT ROLE: old-route residual theorem, kept as a separate geometric target
-  - ROOT CAUSE: our ForwardTube k=0 condition `Im(z₀) ∈ V⁺` breaks translation invariance
-  - MATHEMATICAL PROOF: PET is a domain of holomorphy (BEG 1967). baseFiber = PET ∩ (complex affine subspace). Intersection of DOH with complex affine subspace is connected (standard SCV).
-  - Alternative proof: fiber bundle over contractible base (tailDiffPermSector is convex) with connected fiber (stabilizer in SO(d+1;ℂ) is connected). See Proofideas/baseFiber_inflation_proof.lean.
-  - PROVED helpers (0 sorrys): inOpenForwardCone_add_time, forwardTube_add_broadcast_iTime, complexLorentzAction_add_broadcast, lorentz_action_inflation_dir (in test/proofideas_baseFiber_inflation.lean)
-  - Production reduction: baseFiber_isPreconnected_of_index_and_active_geometry reduces to index set connectivity + sector overlap
-  - FORMALIZATION GAP: needs SCV domain-of-holomorphy infrastructure OR Lie group fiber bundle theory, neither in Mathlib
+`WickRotation/ForwardTubeLorentz.lean` (0) — COMPLETE
+- `wickRotation_not_in_PET_null` retired by the TranslatedPET migration: extension `F` is realized on TranslatedPET rather than the old ForwardTube k=0 surface (which broke translation invariance). The W11 false-statement counterexample is preserved in `W11Counterexample.lean` for the record.
+- `polynomial_growth_on_slice` discharged.
+- PR #72 additions (0 sorrys): `ae_joint_triple_translatedPET` — simultaneous a.e. TranslatedPET admissibility on the product space.
+
+`WickRotation/BHWTranslation.lean` (0) — COMPLETE
+- `isPreconnected_baseFiber` deleted as retired old-route surface (PR #72). It was unreachable from any live R→E lane after the merged path migrated to using `bhw_translation_invariant` directly. The geometric content (PET fiber connectivity via DOH or Lie-group fiber bundle theory) is no longer load-bearing and has been removed from the active TODO.
 
 `WickRotation/BHWReducedExtension.lean` (axiom 1):
 - `reduced_bargmann_hall_wightman_of_input`
@@ -212,8 +219,7 @@ Not on the shortest OS reconstruction lane:
 4. After `boundary_values_tempered`, finish the six transfer theorems and `bvt_cluster` in `OSToWightmanBoundaryValues.lean`.
 5. In parallel or next, attack the live R→E front after the Route 1 merge:
    - `SchwingerTemperedness.lean`: coincidence-singularity / zero-diagonal continuity
-   - `SchwingerAxioms.lean`: Euclidean reality / reflection, OS=W term, cluster
-   - `BHWTranslation.isPreconnected_baseFiber` is now optional old-route cleanup, not required for the merged proof path
+   - `SchwingerAxioms.lean`: Euclidean reality / reflection, OS=W term, cluster (live: identity-permutation ForwardTube refinement; see sharpening above)
 6. Defer `StoneTheorem` / GNS operator-theoretic work until the analyticity lane is materially settled.
 
 ## Recently Completed (2026-03-14)

--- a/docs/cluster_property_analysis.md
+++ b/docs/cluster_property_analysis.md
@@ -148,3 +148,83 @@ connecting `wickRotatedBoundaryPairing` to `Wfn.W`.
 | `SCV/VladimirovTillmann.lean` | +2 axioms (`vladimirov_tillmann` pre-existing, `distributional_cluster_lifts_to_tube` new) |
 | `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean` | Bug fix + 4 new lemmas + sorry-free `bhw_pointwise_cluster_forwardTube` |
 | `README.md` | Documentation of fork changes |
+
+## Update 2026-04-30: Vetting + dependency mapping
+
+### Failed reduction attempt
+
+A proposed axiom `F_ext_pointwise_cluster_translatedPET` (pointwise cluster of
+`F_ext_on_translatedPET_total` lifted from `ForwardTube` to all of
+`TranslatedPET`) was drafted and vetted via Gemini deep-think. **Verdict:
+mathematically wrong in generic configurations.**
+
+Reason (Streater-Wightman 1964 ed. p.135 + Araki-Hepp-Ruelle 1962 *Helv. Phys.
+Acta* 35:164 Thm 2): for a configuration in the permuted-extended tube T'
+with complex Lorentz witness Λ, applying the cluster shift `+λ·a` (real
+spatial) yields `Im(Λ(ζ - λa)) = Im(Λ ζ) − λ·Im(Λa)`. For generic complex
+Λ, `Im(Λa) ≠ 0` even when `a` is real spatial — the shifted configuration
+**escapes the analytic continuation domain** as `λ → ∞`. Pointwise cluster
+on T' is therefore false, not just hard.
+
+The "Jost-point un-interleaving" hand-wave doesn't rescue it: Jost points are
+strictly real by definition (Streater-Wightman §3.3), so complex
+configurations cannot become Jost points under real shifts.
+
+### What the vetting confirmed
+
+- The standard textbook cluster axiom for OS reconstruction (Glimm-Jaffe Ch
+  19; OS 1973/75 axiom E4) is **distributional, on real Euclidean spacetime**,
+  not pointwise on complex tubes.
+- The Wightman-side analog is `Wfn.cluster` (R4), already an axiom of
+  `WightmanFunctions`. **No new axiom is needed.**
+- Pointwise cluster on the standard forward tube T (Araki-Hepp-Ruelle Thm 2)
+  is a corollary of the distributional version via Vitali. Restricted to T,
+  this is `bhw_pointwise_cluster_forwardTube` (already proved).
+
+### The actual dependency chain
+
+```
+W_analytic_cluster_integral
+  ← schwingerExtension_os_term_eq_wightman_term  (SchwingerAxioms.lean:2371, sorry)
+        bridge: wickRotatedBoundaryPairing = Wfn.W on OrderedPositiveTimeRegion supports
+  ← boundary_values_tempered + distributional BV infrastructure  (E→R lane)
+  ← Fourier-Laplace + Paley-Wiener + the OSToWightmanBoundaryValues plan
+```
+
+So the R→E cluster blocker is **structurally downstream of E→R
+boundary-values work**. The OS-W bridge theorem (sorried at line 2371)
+requires the same Edge-of-the-Wedge / Vitali / boundary-values plumbing
+that the E→R lane is building. Closing R→E cluster in isolation requires
+re-deriving this infrastructure.
+
+### Recommended path (Option 1)
+
+Wait for `boundary_values_tempered` to land via the E→R lane, then close
+`schwingerExtension_os_term_eq_wightman_term` for tensor-product test
+functions, then `W_analytic_cluster_integral` is a ~30-line corollary of
+`Wfn.cluster` + the bridge.
+
+Structural plumbing the cluster-corollary proof will need (Fubini split
+over `Fin.append`, push-through of `wickRotation` and `tensorProduct`):
+PR #72 (`integral_fin_append_split`, `MeasurableEquiv.finAddProd_symm_apply`,
+`ae_joint_triple_translatedPET`, `bhw_euclidean_kernel_perm_invariant_ae`)
+provides about half. The remaining `Fin.append`/`splitFirst`/`splitLast`
+simp bridges and componentwise composition lemma are minor and can ship
+in the same PR that closes the cluster integral.
+
+### Refinement of the resolution options
+
+The 2026-03-24 doc above proposed three resolution options. Updated assessment:
+
+- **Option 1 (strengthen axiom to PET)**: subsumed by the vetting finding —
+  pointwise cluster on PET / TranslatedPET is *false* in generic configs, not
+  just an open problem. This option is mathematically incorrect.
+- **Option 2 (sector decomposition)**: still plausible in principle but
+  would require careful handling of the witness-dependent translation /
+  permutation. Probably ~2–4 weeks of independent Edge-of-the-Wedge work
+  re-deriving content the E→R lane will provide. Don't pursue.
+- **Option 3 (direct distributional proof)**: confirmed as the right path.
+  The "new infrastructure connecting `wickRotatedBoundaryPairing` to
+  `Wfn.W`" is exactly the existing sorried theorem
+  `schwingerExtension_os_term_eq_wightman_term`, which depends on
+  `boundary_values_tempered`.


### PR DESCRIPTION
Forward progress on the R→E direction, specifically the `W_analytic_cluster_integral` (Schwinger E4 / cluster decomposition) sorry in `SchwingerAxioms.lean:3627`. Five focused commits, all building green against the current `origin/main` tip (`6d9a639`, post-#76). No new sorrys, no new axioms.

(Rebased onto current `main`; verified `lake build` green on 2026-04-29 against `6d9a639`.)

## Commit-by-commit

| # | SHA | Net effect |
|---|---|---|
| 1 | `17c2de6` | **Delete** deprecated sorry'd `isPreconnected_baseFiber` in `BHWTranslation.lean`. Net `-1` sorry in the R→E kernel files. |
| 2 | `bf3a06a` | Refresh the stale strategy comment in `W_analytic_cluster_integral` — the old `wickRotation_not_in_PET_null` blocker was eliminated by the TranslatedPET migration, and the comment now points to the actual remaining blockers and the Mathlib `sumPiEquivProdPi` + `piCongrLeft` machinery. |
| 3 | `1d12b79` | `integral_fin_append_split` + `MeasurableEquiv.finAddProd_symm_apply` in `GeneralResults/FinProductIntegral.lean`. Discharges the **Fubini-over-`Fin.append`** blocker for the cluster proof. |
| 4 | `51020a8` | `ae_joint_triple_translatedPET` in `ForwardTubeLorentz.lean`. Post-Fubini a.e. TranslatedPET triple: for a.e. `(y, z)` on the product space, `wick(y) ∈ TPET`, `wick(z) ∈ TPET`, and `wick(Fin.append y z) ∈ TPET`. |
| 5 | `26a2119` | `bhw_euclidean_kernel_perm_invariant_ae` in `SchwingerTemperedness.lean`. A.e. permutation invariance of the Wick-rotated kernel `K(x) = F_ext_on_translatedPET_total(wick(x))`: `K(x) = K(x ∘ σ)` a.e. for any `σ : Equiv.Perm (Fin n)`. The symmetrization input for change-of-variable arguments. |

## What this unlocks for `W_analytic_cluster_integral`

- ✅ **Split via Fubini**: `integral_fin_append_split`
- ✅ **A.e. triple TranslatedPET** for both blocks and joint: `ae_joint_triple_translatedPET`
- ✅ **A.e. kernel permutation invariance** for block-level change-of-variables: `bhw_euclidean_kernel_perm_invariant_ae`

## What still remains (honest framing — this PR is scaffolding, not the closure)

The *symmetrization refinement* step from TranslatedPET triples to **identity-permutation ForwardTube triples** (which `bhw_pointwise_cluster_forwardTube` consumes) needs either:
- a block-respecting joint sorting argument that preserves the tensor-product test function structure — joint-sorting generally interleaves the (n, m) blocks and breaks `f ⊗ g_a`; or
- a TranslatedPET version of `bhw_pointwise_cluster_forwardTube` itself (i.e., lifting the SCV cluster axiom's ForwardTube hypothesis to TranslatedPET).

Both routes are genuinely research-boundary work beyond this PR's scope. The scaffolding here is the mechanical half that was blocked by missing Fubini / a.e. / invariance plumbing.

## Verification

| Theorem | `#print axioms` |
|---|---|
| `integral_fin_append_split` | `[propext, Classical.choice, Quot.sound]` |
| `MeasurableEquiv.finAddProd_symm_apply` | `[propext, Classical.choice, Quot.sound]` |
| `ae_joint_triple_translatedPET` | `[propext, Classical.choice, Quot.sound]` |
| `bhw_euclidean_kernel_perm_invariant_ae` | `[propext, sorryAx, BHW.reduced_..., Classical.choice, Quot.sound]` |

The `sorryAx` in the last entry traces to the pre-existing upstream chain through `bhw_translation_invariant` → `W_analytic_BHW_unique` → `BHW.bargmann_hall_wightman_theorem` → `PermutationFlowBlocker.lean` — out of scope.

## Files touched

```
OSReconstruction/GeneralResults/FinProductIntegral.lean         (+55)
OSReconstruction/Wightman/Reconstruction/WickRotation/BHWTranslation.lean          (-30)
OSReconstruction/Wightman/Reconstruction/WickRotation/ForwardTubeLorentz.lean      (+98)
OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean         (+21 -13, stale comment refresh)
OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerTemperedness.lean   (+28)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
