### PR TITLE
Close theorem 3 positivity on OS route

### DIFF
--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
@@ -7,6 +7,7 @@ import OSReconstruction.Wightman.Reconstruction.WickRotation.OSToWightmanBoundar
 import OSReconstruction.Wightman.Reconstruction.WickRotation.OSToWightmanBoundaryValueLimits
 import OSReconstruction.Wightman.Reconstruction.WickRotation.OSToWightmanBoundaryValuesCompactApprox
 import OSReconstruction.Wightman.Reconstruction.WickRotation.OSToWightmanBoundaryValuesEuclidean
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceOrderedDensity
 import OSReconstruction.Wightman.Reconstruction.WightmanTwoPoint
 
 /-!
@@ -383,7 +384,12 @@ private theorem bvt_W_positive
     (lgc : OSLinearGrowthCondition d OS) :
     ∀ F : BorchersSequence d,
       (WightmanInnerProduct d (bvt_W OS lgc) F F).re ≥ 0 := by
-  sorry
+  intro F
+  exact
+    OSReconstruction.bvt_W_positive_of_component_dense_preimage (d := d) OS lgc
+      (fun n =>
+        OSReconstruction.dense_section43FourierLaplace_compact_ordered_preimage_raw d n)
+      F
 
 /-- Theorem 4 frontier: cluster transfer for the canonical BV pairing.
 

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceDensity.lean
@@ -41,6 +41,83 @@ noncomputable def section43OneSidedLaplaceRaw
     (g : Section43CompactPositiveTimeSource1D) (σ : ℝ) : ℂ :=
   ∫ t : ℝ, Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t
 
+/-- The candidate for the `r`-th real derivative of the compact one-sided
+Laplace transform.  Compact source support makes this integral meaningful for
+every real `σ`, including the cutoff transition strip. -/
+noncomputable def section43OneSidedLaplaceRawDerivCandidate
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) : ℂ :=
+  ∫ t : ℝ,
+    ((-t : ℂ) ^ r *
+      Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t
+
+@[simp] theorem section43OneSidedLaplaceRawDerivCandidate_zero
+    (g : Section43CompactPositiveTimeSource1D) (σ : ℝ) :
+    section43OneSidedLaplaceRawDerivCandidate g 0 σ =
+      section43OneSidedLaplaceRaw g σ := by
+  unfold section43OneSidedLaplaceRawDerivCandidate section43OneSidedLaplaceRaw
+  simp
+
+theorem section43OneSidedLaplaceRawDerivCandidate_integrable
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) :
+    Integrable
+      (fun t : ℝ =>
+        ((-t : ℂ) ^ r *
+          Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t) := by
+  have hcont :
+      Continuous
+        (fun t : ℝ =>
+          ((-t : ℂ) ^ r *
+            Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t) := by
+    have h :
+        Continuous
+          (((fun t : ℝ => (-t : ℂ) ^ r) *
+              (fun t : ℝ =>
+                Complex.exp (-(t : ℂ) * (σ : ℂ)))) *
+            (g.f : ℝ → ℂ)) := by
+      exact (((Complex.continuous_ofReal.comp continuous_id).neg.pow r).mul
+        (Complex.continuous_exp.comp
+          ((Complex.continuous_ofReal.comp continuous_id).neg.mul
+            (continuous_const : Continuous (fun _ : ℝ => (σ : ℂ)))))).mul
+        g.f.continuous
+    simpa [Pi.mul_apply] using h
+  have hcomp :
+      HasCompactSupport
+        (fun t : ℝ =>
+          ((-t : ℂ) ^ r *
+            Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t) := by
+    simpa [Pi.mul_apply] using
+      (HasCompactSupport.mul_left
+        (f := fun t : ℝ =>
+          (-t : ℂ) ^ r * Complex.exp (-(t : ℂ) * (σ : ℂ)))
+        (f' := (g.f : ℝ → ℂ)) g.compact)
+  exact hcont.integrable_of_hasCompactSupport hcomp
+
+theorem section43OneSidedLaplaceRawDerivKernel_hasDerivAt
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (t σ : ℝ) :
+    HasDerivAt
+      (fun σ : ℝ =>
+        ((-t : ℂ) ^ r *
+          Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t)
+      (((-t : ℂ) ^ (r + 1) *
+        Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t)
+      σ := by
+  have hexp :
+      HasDerivAt
+        (fun σ : ℝ => Complex.exp (-(t : ℂ) * (σ : ℂ)))
+        (-(t : ℂ) * Complex.exp (-(t : ℂ) * (σ : ℂ))) σ := by
+    have hlin :
+        HasDerivAt (fun σ : ℝ => -(t : ℂ) * (σ : ℂ)) (-(t : ℂ)) σ := by
+      have hmul :
+          HasDerivAt (fun σ : ℝ => (t : ℂ) * (σ : ℂ)) (t : ℂ) σ := by
+        simpa using
+          ((hasDerivAt_const (x := σ) (c := (t : ℂ))).mul
+            (Complex.ofRealCLM.hasDerivAt (x := σ)))
+      simpa [neg_mul] using hmul.neg
+    simpa [mul_comm, mul_left_comm, mul_assoc] using hlin.cexp
+  have h := (hexp.const_mul ((-t : ℂ) ^ r)).mul_const (g.f t)
+  convert h using 1
+  ring
+
 theorem Section43CompactPositiveTimeSource1D.tsupport_subset_Ici
     (g : Section43CompactPositiveTimeSource1D) :
     tsupport (g.f : ℝ → ℂ) ⊆ Set.Ici (0 : ℝ) := by
@@ -179,6 +256,181 @@ theorem exists_positive_Icc_bounds_of_compactPositiveTimeSource
       (g := g.f) hδ_supp g.compact with
     ⟨R, hδR, hR⟩
   exact ⟨δ, R, hδ_pos, hδR, hR⟩
+
+theorem section43OneSidedLaplaceRawDerivCandidate_hasDerivAt
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ₀ : ℝ) :
+    HasDerivAt
+      (section43OneSidedLaplaceRawDerivCandidate g r)
+      (section43OneSidedLaplaceRawDerivCandidate g (r + 1) σ₀)
+      σ₀ := by
+  classical
+  rcases exists_positive_Icc_bounds_of_compactPositiveTimeSource g with
+    ⟨δ, R, hδ_pos, hδR, hsupp⟩
+  let B : ℝ :=
+    (max |δ| |R|) ^ (r + 1) * Real.exp (R * (|σ₀| + 1))
+  let bound : ℝ → ℝ := fun t => B * ‖g.f t‖
+  have hR_pos : 0 < R := lt_of_lt_of_le hδ_pos hδR
+  have hs : Metric.closedBall σ₀ (1 : ℝ) ∈ 𝓝 σ₀ :=
+    Metric.closedBall_mem_nhds σ₀ zero_lt_one
+  have hF_meas :
+      ∀ᶠ σ : ℝ in 𝓝 σ₀,
+        AEStronglyMeasurable
+          (fun t : ℝ =>
+            ((-t : ℂ) ^ r *
+              Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t)
+          (volume : Measure ℝ) := by
+    filter_upwards with σ
+    exact (section43OneSidedLaplaceRawDerivCandidate_integrable g r σ).aestronglyMeasurable
+  have hF_int :
+      Integrable
+        (fun t : ℝ =>
+          ((-t : ℂ) ^ r *
+            Complex.exp (-(t : ℂ) * (σ₀ : ℂ))) * g.f t) :=
+    section43OneSidedLaplaceRawDerivCandidate_integrable g r σ₀
+  have hF'_meas :
+      AEStronglyMeasurable
+        (fun t : ℝ =>
+          ((-t : ℂ) ^ (r + 1) *
+            Complex.exp (-(t : ℂ) * (σ₀ : ℂ))) * g.f t)
+        (volume : Measure ℝ) :=
+    (section43OneSidedLaplaceRawDerivCandidate_integrable g (r + 1) σ₀).aestronglyMeasurable
+  have hbound_int : Integrable bound volume := by
+    dsimp [bound]
+    exact g.f.integrable.norm.const_mul B
+  have h_bound :
+      ∀ᵐ (t : ℝ) ∂(volume : Measure ℝ), ∀ σ ∈ Metric.closedBall σ₀ (1 : ℝ),
+        ‖((-t : ℂ) ^ (r + 1) *
+            Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t‖ ≤ bound t := by
+    filter_upwards with t σ hσ
+    by_cases htzero : g.f t = 0
+    · simp [bound, htzero]
+    · have ht_supp : t ∈ tsupport (g.f : ℝ → ℂ) :=
+        subset_tsupport _ htzero
+      have htIcc : t ∈ Set.Icc δ R := hsupp ht_supp
+      have htδ : δ ≤ t := htIcc.1
+      have htR : t ≤ R := htIcc.2
+      have ht_nonneg : 0 ≤ t := le_trans (le_of_lt hδ_pos) htδ
+      have hσ_dist : dist σ σ₀ ≤ (1 : ℝ) := by
+        simpa [Metric.mem_closedBall] using hσ
+      have hσ_abs : |σ| ≤ |σ₀| + 1 := by
+        have hsub : |σ - σ₀| ≤ (1 : ℝ) := by
+          simpa [Real.dist_eq] using hσ_dist
+        calc
+          |σ| = |(σ - σ₀) + σ₀| := by ring_nf
+          _ ≤ |σ - σ₀| + |σ₀| := abs_add_le _ _
+          _ ≤ |σ₀| + 1 := by linarith
+      have ht_abs_le : |t| ≤ max |δ| |R| := by
+        rw [abs_of_nonneg ht_nonneg]
+        exact htR.trans ((le_abs_self R).trans (le_max_right |δ| |R|))
+      have hexp_re :
+          (-(t : ℂ) * (σ : ℂ)).re ≤ R * (|σ₀| + 1) := by
+        have hre : (-(t : ℂ) * (σ : ℂ)).re = -(t * σ) := by
+          simp [Complex.mul_re]
+        rw [hre]
+        have h_abs_mul : |t * σ| ≤ R * (|σ₀| + 1) := by
+          calc
+            |t * σ| = |t| * |σ| := abs_mul t σ
+            _ ≤ R * (|σ₀| + 1) := by
+              rw [abs_of_nonneg ht_nonneg]
+              exact mul_le_mul htR hσ_abs (abs_nonneg σ) (le_of_lt hR_pos)
+        exact (neg_le_abs (t * σ)).trans h_abs_mul
+      calc
+        ‖((-t : ℂ) ^ (r + 1) *
+            Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t‖
+            = ‖(-t : ℂ) ^ (r + 1)‖ *
+                ‖Complex.exp (-(t : ℂ) * (σ : ℂ))‖ * ‖g.f t‖ := by
+              rw [norm_mul, norm_mul]
+        _ = |t| ^ (r + 1) *
+                Real.exp ((-(t : ℂ) * (σ : ℂ)).re) * ‖g.f t‖ := by
+              rw [norm_pow, norm_neg, Complex.norm_real, Real.norm_eq_abs,
+                Complex.norm_exp]
+        _ ≤ (max |δ| |R|) ^ (r + 1) *
+                Real.exp (R * (|σ₀| + 1)) * ‖g.f t‖ := by
+              gcongr
+        _ = bound t := by
+              rfl
+  have h_diff :
+      ∀ᵐ (t : ℝ) ∂(volume : Measure ℝ), ∀ σ ∈ Metric.closedBall σ₀ (1 : ℝ),
+        HasDerivAt
+          (fun σ : ℝ =>
+            ((-t : ℂ) ^ r *
+              Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t)
+          (((-t : ℂ) ^ (r + 1) *
+            Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t)
+          σ := by
+    filter_upwards with t σ _hσ
+    exact section43OneSidedLaplaceRawDerivKernel_hasDerivAt g r t σ
+  have hmain :=
+    (hasDerivAt_integral_of_dominated_loc_of_deriv_le
+      (𝕜 := ℝ) (μ := volume)
+      (F := fun (σ : ℝ) (t : ℝ) =>
+        ((-t : ℂ) ^ r *
+          Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t)
+      (F' := fun (σ : ℝ) (t : ℝ) =>
+        ((-t : ℂ) ^ (r + 1) *
+          Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t)
+      (x₀ := σ₀) (s := Metric.closedBall σ₀ (1 : ℝ))
+      (bound := bound)
+      hs hF_meas hF_int hF'_meas h_bound hbound_int h_diff).2
+  change HasDerivAt
+    (fun σ : ℝ =>
+      ∫ t : ℝ,
+        ((-t : ℂ) ^ r *
+          Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t)
+    (∫ t : ℝ,
+      ((-t : ℂ) ^ (r + 1) *
+        Complex.exp (-(t : ℂ) * (σ₀ : ℂ))) * g.f t)
+    σ₀
+  simpa [neg_mul, mul_assoc] using hmain
+
+theorem section43OneSidedLaplaceRaw_iteratedDeriv_formula
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) :
+    iteratedDeriv r (section43OneSidedLaplaceRaw g) σ =
+      section43OneSidedLaplaceRawDerivCandidate g r σ := by
+  revert σ
+  induction r with
+  | zero =>
+      intro σ
+      simp
+  | succ r ih =>
+      intro σ
+      rw [iteratedDeriv_succ]
+      have hfun :
+          iteratedDeriv r (section43OneSidedLaplaceRaw g) =
+            section43OneSidedLaplaceRawDerivCandidate g r := by
+        ext u
+        exact ih u
+      rw [hfun]
+      exact (section43OneSidedLaplaceRawDerivCandidate_hasDerivAt g r σ).deriv
+
+theorem section43OneSidedLaplaceRaw_contDiff
+    (g : Section43CompactPositiveTimeSource1D) :
+    ContDiff ℝ (↑(⊤ : ℕ∞)) (section43OneSidedLaplaceRaw g) := by
+  apply contDiff_of_differentiable_iteratedDeriv
+  intro r _hr
+  have hfun :
+      iteratedDeriv r (section43OneSidedLaplaceRaw g) =
+        section43OneSidedLaplaceRawDerivCandidate g r := by
+    ext σ
+    exact section43OneSidedLaplaceRaw_iteratedDeriv_formula g r σ
+  rw [hfun]
+  exact fun σ =>
+    (section43OneSidedLaplaceRawDerivCandidate_hasDerivAt g r σ).differentiableAt
+
+theorem section43OneSidedLaplaceRaw_iteratedFDeriv_formula
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) :
+    iteratedFDeriv ℝ r (section43OneSidedLaplaceRaw g) σ =
+      (ContinuousMultilinearMap.mkPiAlgebraFin ℝ r ℝ).smulRight
+        (section43OneSidedLaplaceRawDerivCandidate g r σ) := by
+  apply ContinuousMultilinearMap.ext
+  intro m
+  rw [iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod,
+    section43OneSidedLaplaceRaw_iteratedDeriv_formula]
+  change (∏ i, m i) • section43OneSidedLaplaceRawDerivCandidate g r σ =
+    ((ContinuousMultilinearMap.mkPiAlgebraFin ℝ r ℝ) m) •
+      section43OneSidedLaplaceRawDerivCandidate g r σ
+  rw [ContinuousMultilinearMap.mkPiAlgebraFin_apply]
+  rw [List.prod_ofFn]
 
 /-- Local name for Mathlib's inverse Fourier continuous linear map on
 one-dimensional Schwartz space. -/

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceDensity.lean
@@ -1,3 +1,4 @@
+import OSReconstruction.Mathlib429Compat
 import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43OneVariableSlice
 import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceCompactDifferentiation
 
@@ -12,7 +13,7 @@ Fourier-Laplace kernels, and the positive-energy quotient.
 
 noncomputable section
 
-open scoped Topology FourierTransform
+open scoped Topology FourierTransform BoundedContinuousFunction
 open Set MeasureTheory Filter
 
 namespace OSReconstruction
@@ -124,6 +125,19 @@ theorem Section43CompactPositiveTimeSource1D.tsupport_subset_Ici
     tsupport (g.f : ℝ → ℂ) ⊆ Set.Ici (0 : ℝ) := by
   intro t ht
   exact le_of_lt (Set.mem_Ioi.mp (g.positive ht))
+
+theorem Section43CompactPositiveTimeSource1D.pos_of_ne_zero
+    (g : Section43CompactPositiveTimeSource1D)
+    {t : ℝ} (ht : g.f t ≠ 0) :
+    0 < t :=
+  g.positive (subset_tsupport _ ht)
+
+theorem Section43CompactPositiveTimeSource1D.eq_zero_of_not_pos
+    (g : Section43CompactPositiveTimeSource1D)
+    {t : ℝ} (ht : ¬ 0 < t) :
+    g.f t = 0 := by
+  by_contra hne
+  exact ht (g.pos_of_ne_zero hne)
 
 theorem section43OneSidedLaplaceRaw_eq_complexLaplaceTransform
     (g : Section43CompactPositiveTimeSource1D) (σ : ℝ) :
@@ -861,6 +875,633 @@ noncomputable def section43ImagAxisPsiKernel (t : ℝ) : SchwartzMap ℝ ℂ :=
       (by simpa [Complex.mul_im] using ht)
   else
     0
+
+@[simp] theorem section43ImagAxisPsiKernel_of_pos
+    {t : ℝ} (ht : 0 < t) :
+    section43ImagAxisPsiKernel t =
+      SCV.schwartzPsiZ ((t : ℂ) * Complex.I)
+        (by simpa [Complex.mul_im] using ht) := by
+  simp [section43ImagAxisPsiKernel, ht]
+
+theorem section43ImagAxisPsiKernel_of_not_pos
+    {t : ℝ} (ht : ¬ 0 < t) :
+    section43ImagAxisPsiKernel t = 0 := by
+  simp [section43ImagAxisPsiKernel, ht]
+
+@[simp] theorem section43ImagAxisPsiKernel_apply_of_not_pos
+    {t σ : ℝ} (ht : ¬ 0 < t) :
+    section43ImagAxisPsiKernel t σ = 0 := by
+  rw [section43ImagAxisPsiKernel_of_not_pos ht]
+  rfl
+
+theorem section43ImagAxisPsiKernel_apply_of_pos_of_nonneg
+    {t σ : ℝ} (ht : 0 < t) (hσ : 0 ≤ σ) :
+    section43ImagAxisPsiKernel t σ =
+      Complex.exp (-(t : ℂ) * (σ : ℂ)) := by
+  rw [section43ImagAxisPsiKernel_of_pos ht, SCV.schwartzPsiZ_apply,
+    SCV.psiZ_eq_exp_of_nonneg hσ]
+  congr 1
+  calc
+    Complex.I * ((t : ℂ) * Complex.I) * (σ : ℂ)
+        = (Complex.I * Complex.I) * (t : ℂ) * (σ : ℂ) := by ring
+    _ = -(t : ℂ) * (σ : ℂ) := by
+          rw [Complex.I_mul_I]
+          ring
+
+theorem section43ImagAxisPsiKernel_apply_mul_source_of_nonneg
+    (g : Section43CompactPositiveTimeSource1D)
+    {σ : ℝ} (hσ : 0 ≤ σ) (t : ℝ) :
+    section43ImagAxisPsiKernel t σ * g.f t =
+      Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t := by
+  by_cases ht : 0 < t
+  · rw [section43ImagAxisPsiKernel_apply_of_pos_of_nonneg ht hσ]
+  · rw [section43ImagAxisPsiKernel_apply_of_not_pos ht,
+      g.eq_zero_of_not_pos ht]
+    simp
+
+theorem section43ImagAxisPsiKernel_apply_mul_source
+    (g : Section43CompactPositiveTimeSource1D)
+    (σ t : ℝ) :
+    section43ImagAxisPsiKernel t σ * g.f t =
+      (SCV.smoothCutoff σ : ℂ) *
+        (Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t) := by
+  by_cases ht : 0 < t
+  · rw [section43ImagAxisPsiKernel_of_pos ht, SCV.schwartzPsiZ_apply]
+    simp only [SCV.psiZ_eq]
+    have harg :
+        Complex.I * ((t : ℂ) * Complex.I) * (σ : ℂ) =
+          -(t : ℂ) * (σ : ℂ) := by
+      calc
+        Complex.I * ((t : ℂ) * Complex.I) * (σ : ℂ)
+            = (Complex.I * Complex.I) * (t : ℂ) * (σ : ℂ) := by ring
+        _ = -(t : ℂ) * (σ : ℂ) := by
+              rw [Complex.I_mul_I]
+              ring
+    rw [harg]
+    ring
+  · rw [section43ImagAxisPsiKernel_apply_of_not_pos ht,
+      g.eq_zero_of_not_pos ht]
+    simp
+
+theorem section43OneSidedLaplaceCutoffFun_eq_integral_imagAxisPsiKernel
+    (g : Section43CompactPositiveTimeSource1D)
+    (σ : ℝ) :
+    section43OneSidedLaplaceCutoffFun g σ =
+      ∫ t : ℝ, section43ImagAxisPsiKernel t σ * g.f t := by
+  unfold section43OneSidedLaplaceCutoffFun section43OneSidedLaplaceRaw
+  calc
+    (SCV.smoothCutoff σ : ℂ) *
+        ∫ t : ℝ, Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t
+        = ∫ t : ℝ,
+            (SCV.smoothCutoff σ : ℂ) *
+              (Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t) := by
+            simpa using
+              (MeasureTheory.integral_const_mul
+                (SCV.smoothCutoff σ : ℂ)
+                (fun t : ℝ =>
+                  Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t)).symm
+    _ = ∫ t : ℝ, section43ImagAxisPsiKernel t σ * g.f t := by
+          refine MeasureTheory.integral_congr_ae ?_
+          filter_upwards with t
+          exact (section43ImagAxisPsiKernel_apply_mul_source g σ t).symm
+
+theorem section43OneSidedLaplaceRaw_eq_integral_imagAxisPsiKernel_of_nonneg
+    (g : Section43CompactPositiveTimeSource1D)
+    {σ : ℝ} (hσ : 0 ≤ σ) :
+    section43OneSidedLaplaceRaw g σ =
+      ∫ t : ℝ, section43ImagAxisPsiKernel t σ * g.f t := by
+  unfold section43OneSidedLaplaceRaw
+  refine (MeasureTheory.integral_congr_ae ?_).symm
+  filter_upwards with t
+  exact section43ImagAxisPsiKernel_apply_mul_source_of_nonneg g hσ t
+
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_eq_integral_imagAxisPsiKernel_of_nonneg
+    (g : Section43CompactPositiveTimeSource1D)
+    {σ : ℝ} (hσ : 0 ≤ σ) :
+    section43OneSidedLaplaceSchwartzRepresentative1D g σ =
+      ∫ t : ℝ, section43ImagAxisPsiKernel t σ * g.f t := by
+  rw [section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg g hσ,
+    section43OneSidedLaplaceRaw_eq_integral_imagAxisPsiKernel_of_nonneg g hσ]
+
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_eq_integral_imagAxisPsiKernel
+    (g : Section43CompactPositiveTimeSource1D)
+    (σ : ℝ) :
+    section43OneSidedLaplaceSchwartzRepresentative1D g σ =
+      ∫ t : ℝ, section43ImagAxisPsiKernel t σ * g.f t := by
+  rw [section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceCutoffFun_eq_integral_imagAxisPsiKernel]
+
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_formula
+    (g : Section43CompactPositiveTimeSource1D) (n : ℕ) (σ : ℝ) :
+    iteratedDeriv n (section43OneSidedLaplaceSchwartzRepresentative1D g) σ =
+      ∑ i ∈ Finset.range (n + 1),
+        n.choose i *
+          iteratedDeriv i (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ *
+            section43OneSidedLaplaceRawDerivCandidate g (n - i) σ := by
+  have hχ :
+      ContDiffAt ℝ n (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ := by
+    have hχ_smooth :
+        ContDiff ℝ (↑(⊤ : ℕ∞)) (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) := by
+      simpa using (Complex.ofRealCLM.contDiff.comp SCV.smoothCutoff_contDiff)
+    exact (hχ_smooth.contDiffAt.of_le
+      (show (n : WithTop ℕ∞) ≤ (↑(⊤ : ℕ∞) : WithTop ℕ∞) by
+        exact mod_cast le_top))
+  have hraw :
+      ContDiffAt ℝ n (section43OneSidedLaplaceRaw g) σ := by
+    exact ((section43OneSidedLaplaceRaw_contDiff g).contDiffAt.of_le
+      (show (n : WithTop ℕ∞) ≤ (↑(⊤ : ℕ∞) : WithTop ℕ∞) by
+        exact mod_cast le_top))
+  change iteratedDeriv n
+      (fun σ : ℝ =>
+        (SCV.smoothCutoff σ : ℂ) * section43OneSidedLaplaceRaw g σ) σ = _
+  have hmul :=
+    iteratedDeriv_mul (x := σ) hχ hraw
+  have hmul' :
+      iteratedDeriv n
+          (fun σ : ℝ =>
+            (SCV.smoothCutoff σ : ℂ) * section43OneSidedLaplaceRaw g σ) σ =
+        ∑ i ∈ Finset.range (n + 1),
+          n.choose i *
+            iteratedDeriv i (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ *
+              iteratedDeriv (n - i) (section43OneSidedLaplaceRaw g) σ := by
+    simpa only [Pi.mul_apply] using hmul
+  rw [hmul']
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  rw [section43OneSidedLaplaceRaw_iteratedDeriv_formula]
+
+theorem section43ImagAxisPsiKernel_iteratedDeriv_mul_source
+    (g : Section43CompactPositiveTimeSource1D)
+    (n : ℕ) (σ t : ℝ) :
+    iteratedDeriv n (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+        g.f t =
+      ∑ i ∈ Finset.range (n + 1),
+        n.choose i *
+          iteratedDeriv i (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ *
+            ((-(t : ℂ)) ^ (n - i) *
+              Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t) := by
+  by_cases ht : 0 < t
+  · have hχ :
+        ContDiffAt ℝ n (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ := by
+      have hχ_smooth :
+          ContDiff ℝ (↑(⊤ : ℕ∞)) (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) := by
+        simpa using (Complex.ofRealCLM.contDiff.comp SCV.smoothCutoff_contDiff)
+      exact (hχ_smooth.contDiffAt.of_le
+        (show (n : WithTop ℕ∞) ≤ (↑(⊤ : ℕ∞) : WithTop ℕ∞) by
+          exact mod_cast le_top))
+    have he :
+        ContDiffAt ℝ n
+          (fun σ : ℝ => Complex.exp (-(t : ℂ) * (σ : ℂ))) σ := by
+      have he_smooth :
+          ContDiff ℝ (↑(⊤ : ℕ∞))
+            (fun σ : ℝ => Complex.exp (-(t : ℂ) * (σ : ℂ))) := by
+        have hcoef :
+            ContDiff ℝ (↑(⊤ : ℕ∞)) (fun _ : ℝ => -(t : ℂ)) :=
+          contDiff_const
+        have hofReal :
+            ContDiff ℝ (↑(⊤ : ℕ∞)) (fun σ : ℝ => (σ : ℂ)) :=
+          Complex.ofRealCLM.contDiff
+        exact Complex.contDiff_exp.comp (hcoef.mul hofReal)
+      exact (he_smooth.contDiffAt.of_le
+        (show (n : WithTop ℕ∞) ≤ (↑(⊤ : ℕ∞) : WithTop ℕ∞) by
+          exact mod_cast le_top))
+    have hkernel :
+        (fun σ : ℝ => section43ImagAxisPsiKernel t σ) =
+          fun σ : ℝ =>
+            (SCV.smoothCutoff σ : ℂ) *
+              Complex.exp (-(t : ℂ) * (σ : ℂ)) := by
+      funext σ'
+      rw [section43ImagAxisPsiKernel_of_pos ht, SCV.schwartzPsiZ_apply,
+        SCV.psiZ_eq]
+      have harg :
+          Complex.I * ((t : ℂ) * Complex.I) * (σ' : ℂ) =
+            -(t : ℂ) * (σ' : ℂ) := by
+        calc
+          Complex.I * ((t : ℂ) * Complex.I) * (σ' : ℂ)
+              = (Complex.I * Complex.I) * (t : ℂ) * (σ' : ℂ) := by ring
+          _ = -(t : ℂ) * (σ' : ℂ) := by
+                rw [Complex.I_mul_I]
+                ring
+      rw [harg]
+    rw [hkernel]
+    have hmul :=
+      iteratedDeriv_mul (x := σ) hχ he
+    have hmul' :
+        iteratedDeriv n
+            (fun σ : ℝ =>
+              (SCV.smoothCutoff σ : ℂ) *
+                Complex.exp (-(t : ℂ) * (σ : ℂ))) σ =
+          ∑ i ∈ Finset.range (n + 1),
+            n.choose i *
+              iteratedDeriv i (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ *
+                iteratedDeriv (n - i)
+                  (fun σ : ℝ => Complex.exp (-(t : ℂ) * (σ : ℂ))) σ := by
+      simpa only [Pi.mul_apply] using hmul
+    rw [hmul']
+    rw [Finset.sum_mul]
+    refine Finset.sum_congr rfl ?_
+    intro i hi
+    have hexp :
+        iteratedDeriv (n - i)
+            (fun σ : ℝ => Complex.exp (-(t : ℂ) * (σ : ℂ))) σ =
+          (-(t : ℂ)) ^ (n - i) *
+            Complex.exp (-(t : ℂ) * (σ : ℂ)) := by
+      simpa using
+        congrFun (SCV.iteratedDeriv_cexp_const_mul_real (n - i) (-(t : ℂ))) σ
+    rw [hexp]
+    ring
+  · rw [section43ImagAxisPsiKernel_of_not_pos ht,
+      g.eq_zero_of_not_pos ht]
+    simp
+
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_eq_integral_kernel_iteratedDeriv
+    (g : Section43CompactPositiveTimeSource1D) (n : ℕ) (σ : ℝ) :
+    iteratedDeriv n (section43OneSidedLaplaceSchwartzRepresentative1D g) σ =
+      ∫ t : ℝ,
+        iteratedDeriv n (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+          g.f t := by
+  classical
+  let χ : ℕ → ℂ := fun i =>
+    n.choose i *
+      iteratedDeriv i (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ
+  let K : ℕ → ℝ → ℂ := fun i t =>
+    (-(t : ℂ)) ^ (n - i) *
+      Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t
+  have hterm_int :
+      ∀ i ∈ Finset.range (n + 1),
+        Integrable (fun t : ℝ => χ i * K i t) := by
+    intro i hi
+    have hbase := section43OneSidedLaplaceRawDerivCandidate_integrable
+      (g := g) (r := n - i) (σ := σ)
+    simpa [K, mul_assoc] using hbase.const_mul (χ i)
+  have hkernel_integral :
+      (∫ t : ℝ,
+        iteratedDeriv n (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+          g.f t) =
+        ∫ t : ℝ, ∑ i ∈ Finset.range (n + 1), χ i * K i t := by
+    refine MeasureTheory.integral_congr_ae ?_
+    filter_upwards with t
+    have hpoint :=
+      section43ImagAxisPsiKernel_iteratedDeriv_mul_source
+        (g := g) (n := n) (σ := σ) (t := t)
+    simpa [χ, K, mul_assoc] using hpoint
+  rw [section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_formula]
+  rw [hkernel_integral]
+  rw [MeasureTheory.integral_finset_sum]
+  · refine Finset.sum_congr rfl ?_
+    intro i hi
+    unfold section43OneSidedLaplaceRawDerivCandidate
+    calc
+      n.choose i *
+          iteratedDeriv i (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ *
+            ∫ t : ℝ,
+              (-(t : ℂ)) ^ (n - i) *
+                Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t
+          = χ i * ∫ t : ℝ, K i t := by
+            rfl
+      _ = ∫ t : ℝ, χ i * K i t := by
+            simpa using
+              (MeasureTheory.integral_const_mul
+                (χ i) (fun t : ℝ => K i t)).symm
+  · intro i hi
+    exact hterm_int i hi
+
+/-- Polynomial weight used in the finite-probe reduction of Schwartz
+functionals. -/
+def section43PolyWeight (k : ℕ) (σ : ℝ) : ℂ := ((1 + σ ^ 2) ^ k : ℝ)
+
+theorem section43PolyWeight_hasTemperateGrowth (k : ℕ) :
+    (section43PolyWeight k).HasTemperateGrowth := by
+  unfold section43PolyWeight
+  fun_prop
+
+/-- Continuous linear map sending a Schwartz function to its `n`th derivative,
+as a Schwartz function. -/
+noncomputable def section43IteratedDerivCLM :
+    ℕ → SchwartzMap ℝ ℂ →L[ℂ] SchwartzMap ℝ ℂ
+  | 0 => ContinuousLinearMap.id ℂ _
+  | n + 1 => (SchwartzMap.derivCLM ℂ ℂ).comp (section43IteratedDerivCLM n)
+
+theorem section43IteratedDerivCLM_apply
+    (n : ℕ) (f : SchwartzMap ℝ ℂ) (σ : ℝ) :
+    section43IteratedDerivCLM n f σ = iteratedDeriv n f σ := by
+  induction n generalizing f σ with
+  | zero => simp [section43IteratedDerivCLM]
+  | succ n ih =>
+      have hf : ⇑(section43IteratedDerivCLM n f) =
+          fun y : ℝ => iteratedDeriv n f y := by
+        ext y
+        exact ih f y
+      rw [section43IteratedDerivCLM, ContinuousLinearMap.comp_apply,
+        SchwartzMap.derivCLM_apply]
+      rw [hf, ← iteratedDeriv_succ]
+
+/-- Weighted derivative probe into bounded continuous functions. -/
+noncomputable def section43WeightedDerivToBCFCLM
+    (k n : ℕ) : SchwartzMap ℝ ℂ →L[ℂ] ℝ →ᵇ ℂ :=
+  (SchwartzMap.toBoundedContinuousFunctionCLM ℂ ℝ ℂ).comp <|
+    (SchwartzMap.smulLeftCLM ℂ (section43PolyWeight k)).comp <|
+      section43IteratedDerivCLM n
+
+theorem section43WeightedDerivToBCFCLM_apply
+    (k n : ℕ) (f : SchwartzMap ℝ ℂ) (σ : ℝ) :
+    section43WeightedDerivToBCFCLM k n f σ =
+      section43PolyWeight k σ * iteratedDeriv n f σ := by
+  rw [section43WeightedDerivToBCFCLM, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.comp_apply,
+    SchwartzMap.toBoundedContinuousFunctionCLM_apply,
+    SchwartzMap.smulLeftCLM_apply_apply
+      (section43PolyWeight_hasTemperateGrowth k),
+    section43IteratedDerivCLM_apply]
+  simp [section43PolyWeight]
+
+theorem section43_abs_pow_le_polyWeight (k : ℕ) (σ : ℝ) :
+    |σ| ^ k ≤ ‖section43PolyWeight k σ‖ := by
+  rw [section43PolyWeight, Complex.norm_real]
+  have h1 : |σ| ≤ 1 + σ ^ 2 := by
+    have hσ2_nonneg : 0 ≤ σ ^ 2 := sq_nonneg σ
+    nlinarith [sq_abs σ]
+  calc
+    |σ| ^ k ≤ (1 + σ ^ 2) ^ k := by
+      exact pow_le_pow_left₀ (abs_nonneg σ) h1 k
+    _ = ‖((1 + σ ^ 2) ^ k : ℝ)‖ := by
+      rw [Real.norm_of_nonneg]
+      positivity
+
+/-- Finite product of weighted derivative probes.  This is the Banach-valued
+target where the later parameter integral is legal. -/
+noncomputable def section43ProbeCLM (s : Finset (ℕ × ℕ)) :
+    SchwartzMap ℝ ℂ →L[ℂ] ((p : ↑s.attach) → (ℝ →ᵇ ℂ)) :=
+  ContinuousLinearMap.pi fun p : ↑s.attach =>
+    section43WeightedDerivToBCFCLM p.1.1.1 p.1.1.2
+
+set_option backward.isDefEq.respectTransparency false in
+theorem section43SchwartzSeminorm_le_probe_component_norm
+    (k n : ℕ) (f : SchwartzMap ℝ ℂ) :
+    SchwartzMap.seminorm ℝ k n f ≤
+      ‖section43WeightedDerivToBCFCLM k n f‖ := by
+  refine SchwartzMap.seminorm_le_bound' (𝕜 := ℝ) k n f (norm_nonneg _) ?_
+  intro σ
+  have h1 :
+      |σ| ^ k * ‖iteratedDeriv n f σ‖ ≤
+        ‖section43PolyWeight k σ‖ * ‖iteratedDeriv n f σ‖ := by
+    exact mul_le_mul_of_nonneg_right
+      (section43_abs_pow_le_polyWeight k σ) (norm_nonneg _)
+  calc
+    |σ| ^ k * ‖iteratedDeriv n f σ‖
+        ≤ ‖section43PolyWeight k σ‖ * ‖iteratedDeriv n f σ‖ := h1
+    _ = ‖section43PolyWeight k σ * iteratedDeriv n f σ‖ := by
+          rw [norm_mul]
+    _ = ‖section43WeightedDerivToBCFCLM k n f σ‖ := by
+          rw [section43WeightedDerivToBCFCLM_apply]
+    _ ≤ ‖section43WeightedDerivToBCFCLM k n f‖ := by
+          simpa using
+            (BoundedContinuousFunction.norm_coe_le_norm
+              (section43WeightedDerivToBCFCLM k n f) σ)
+
+set_option backward.isDefEq.respectTransparency false in
+theorem section43SchwartzSeminorm_le_probe_norm
+    (s : Finset (ℕ × ℕ)) (p : ↑s.attach) (f : SchwartzMap ℝ ℂ) :
+    SchwartzMap.seminorm ℝ p.1.1.1 p.1.1.2 f ≤
+      ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ := by
+  calc
+    SchwartzMap.seminorm ℝ p.1.1.1 p.1.1.2 f
+        ≤ ‖section43WeightedDerivToBCFCLM p.1.1.1 p.1.1.2 f‖ :=
+          section43SchwartzSeminorm_le_probe_component_norm
+            p.1.1.1 p.1.1.2 f
+    _ ≤ ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ := by
+          simpa [section43ProbeCLM] using
+            (norm_le_pi_norm
+              (section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ))) p)
+
+set_option backward.isDefEq.respectTransparency false in
+theorem section43SchwartzFunctional_bound_by_probeNorm
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ) :
+    ∃ s : Finset (ℕ × ℕ), ∃ C : NNReal, C ≠ 0 ∧
+      ∀ f : SchwartzMap ℝ ℂ,
+        ‖T f‖ ≤
+          (C : ℝ) *
+            ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ := by
+  classical
+  obtain ⟨s, C0, hC0, hbound⟩ := SCV.schwartz_functional_bound T
+  refine ⟨s, C0 * (s.card + 1), by
+    refine mul_ne_zero hC0 ?_
+    exact_mod_cast Nat.succ_ne_zero s.card, ?_⟩
+  intro f
+  have hsup_sum :
+      (s.sup (schwartzSeminormFamily ℂ ℝ ℂ)) f ≤
+        (∑ p ∈ s, schwartzSeminormFamily ℂ ℝ ℂ p) f := by
+    exact Seminorm.le_def.mp
+      (Seminorm.finset_sup_le_sum (schwartzSeminormFamily ℂ ℝ ℂ) s) f
+  have hsum_apply_all :
+      ∀ s' : Finset (ℕ × ℕ),
+        (∑ p ∈ s', schwartzSeminormFamily ℂ ℝ ℂ p) f =
+          ∑ p ∈ s', schwartzSeminormFamily ℂ ℝ ℂ p f := by
+    intro s'
+    induction s' using Finset.induction with
+    | empty =>
+        simp
+    | insert a s' ha ih =>
+        simp [Finset.sum_insert, ha, ih]
+  have hsum_apply :
+      (∑ p ∈ s, schwartzSeminormFamily ℂ ℝ ℂ p) f =
+        ∑ p ∈ s, schwartzSeminormFamily ℂ ℝ ℂ p f := hsum_apply_all s
+  have hsum_probe :
+      ∑ p ∈ s, schwartzSeminormFamily ℂ ℝ ℂ p f ≤
+        s.card *
+          ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ := by
+    calc
+      ∑ p ∈ s, schwartzSeminormFamily ℂ ℝ ℂ p f
+          ≤ ∑ _p ∈ s,
+              ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ := by
+              refine Finset.sum_le_sum ?_
+              intro a ha
+              let p : ↑s.attach := ⟨⟨a, ha⟩, by simp⟩
+              simpa [schwartzSeminormFamily, p] using
+                section43SchwartzSeminorm_le_probe_norm s p f
+      _ = s.card *
+            ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ := by
+            simp
+  calc
+    ‖T f‖ ≤ (C0 • s.sup (schwartzSeminormFamily ℂ ℝ ℂ)) f := hbound f
+    _ = (C0 : ℝ) * (s.sup (schwartzSeminormFamily ℂ ℝ ℂ)) f := by rfl
+    _ ≤ (C0 : ℝ) *
+          ((∑ p ∈ s, schwartzSeminormFamily ℂ ℝ ℂ p) f) := by
+        exact mul_le_mul_of_nonneg_left hsup_sum C0.coe_nonneg
+    _ = (C0 : ℝ) *
+          (∑ p ∈ s, schwartzSeminormFamily ℂ ℝ ℂ p f) := by
+        rw [hsum_apply]
+    _ ≤ (C0 : ℝ) *
+          (s.card *
+            ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖) := by
+        exact mul_le_mul_of_nonneg_left hsum_probe C0.coe_nonneg
+    _ ≤ (C0 : ℝ) *
+          ((s.card + 1 : ℝ) *
+            ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖) := by
+        have hcard : (s.card : ℝ) ≤ s.card + 1 := by
+          exact_mod_cast Nat.le_succ s.card
+        have hnorm :=
+          norm_nonneg (section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))
+        have hcardnorm :
+            (s.card : ℝ) *
+                ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ ≤
+              (s.card + 1 : ℝ) *
+                ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ := by
+          exact mul_le_mul_of_nonneg_right hcard hnorm
+        exact mul_le_mul_of_nonneg_left hcardnorm C0.coe_nonneg
+    _ = ((C0 * (s.card + 1) : NNReal) : ℝ) *
+          ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ := by
+        rw [NNReal.coe_mul]
+        norm_num
+        ring
+
+private noncomputable def section43RangeLiftLinear
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ)
+    (s : Finset (ℕ × ℕ))
+    (hker :
+      LinearMap.ker (section43ProbeCLM s).toLinearMap ≤
+        LinearMap.ker T.toLinearMap) :
+    LinearMap.range (section43ProbeCLM s).toLinearMap →ₗ[ℂ] ℂ :=
+  ((LinearMap.ker (section43ProbeCLM s).toLinearMap).liftQ
+      T.toLinearMap hker).comp
+    ((section43ProbeCLM s).toLinearMap.quotKerEquivRange.symm.toLinearMap)
+
+private theorem section43RangeLiftLinear_apply
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ)
+    (s : Finset (ℕ × ℕ))
+    (hker :
+      LinearMap.ker (section43ProbeCLM s).toLinearMap ≤
+        LinearMap.ker T.toLinearMap)
+    (f : SchwartzMap ℝ ℂ) :
+    section43RangeLiftLinear T s hker
+        ⟨section43ProbeCLM s f, LinearMap.mem_range_self _ f⟩ = T f := by
+  change
+    ((LinearMap.ker (section43ProbeCLM s).toLinearMap).liftQ
+        T.toLinearMap hker)
+      (((section43ProbeCLM s).toLinearMap.quotKerEquivRange.symm)
+        ⟨section43ProbeCLM s f, LinearMap.mem_range_self _ f⟩) = T f
+  have hsymm :
+      ((section43ProbeCLM s).toLinearMap.quotKerEquivRange.symm)
+          ⟨section43ProbeCLM s f, LinearMap.mem_range_self _ f⟩ =
+        (LinearMap.ker (section43ProbeCLM s).toLinearMap).mkQ f := by
+    simpa using
+      (LinearMap.quotKerEquivRange_symm_apply_image
+        ((section43ProbeCLM s).toLinearMap) f
+        (LinearMap.mem_range_self _ f))
+  rw [hsymm]
+  simp
+
+private theorem section43RangeLiftLinear_bound
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ)
+    (s : Finset (ℕ × ℕ))
+    (C : NNReal)
+    (hbound : ∀ f : SchwartzMap ℝ ℂ,
+      ‖T f‖ ≤
+        (C : ℝ) *
+          ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖)
+    (hker :
+      LinearMap.ker (section43ProbeCLM s).toLinearMap ≤
+        LinearMap.ker T.toLinearMap) :
+    ∀ y, ‖section43RangeLiftLinear T s hker y‖ ≤ (C : ℝ) * ‖y‖ := by
+  intro y
+  rcases y with ⟨y, hy⟩
+  rcases hy with ⟨f, rfl⟩
+  simpa [section43RangeLiftLinear_apply] using hbound f
+
+/-- Any continuous Schwartz functional factors through finitely many weighted
+derivative probes landing in a Banach finite product.  This is the finite
+normed replacement for the unavailable `SchwartzMap`-valued Bochner integral. -/
+theorem section43_exists_probe_factorization
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ) :
+    ∃ s : Finset (ℕ × ℕ),
+    ∃ G : ((p : ↑s.attach) → (ℝ →ᵇ ℂ)) →L[ℂ] ℂ,
+      T = G.comp (section43ProbeCLM s) := by
+  classical
+  obtain ⟨s, C, _hC, hbound⟩ :=
+    section43SchwartzFunctional_bound_by_probeNorm T
+  have hker :
+      LinearMap.ker (section43ProbeCLM s).toLinearMap ≤
+        LinearMap.ker T.toLinearMap := by
+    intro f hf
+    rw [LinearMap.mem_ker] at hf ⊢
+    apply norm_eq_zero.mp
+    apply le_antisymm
+    · calc
+        ‖T f‖ ≤
+            (C : ℝ) *
+              ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ :=
+              hbound f
+        _ = 0 := by
+          have hfnorm :
+              ‖(section43ProbeCLM s f : (↑s.attach → (ℝ →ᵇ ℂ)))‖ = 0 := by
+            simpa using congrArg norm hf
+          rw [hfnorm, mul_zero]
+    · exact norm_nonneg _
+  let FrangeLin :
+      LinearMap.range (section43ProbeCLM s).toLinearMap →ₗ[ℂ] ℂ :=
+    section43RangeLiftLinear T s hker
+  let Frange :
+      StrongDual ℂ (LinearMap.range (section43ProbeCLM s).toLinearMap) :=
+    FrangeLin.mkContinuous (C : ℝ)
+      (section43RangeLiftLinear_bound T s C hbound hker)
+  obtain ⟨G, hGext, _⟩ :=
+    exists_extension_norm_eq
+      (LinearMap.range (section43ProbeCLM s).toLinearMap) Frange
+  refine ⟨s, G, ?_⟩
+  ext f
+  have hmem : section43ProbeCLM s f ∈
+      LinearMap.range (section43ProbeCLM s).toLinearMap :=
+    LinearMap.mem_range_self _ f
+  change T f = G (section43ProbeCLM s f)
+  calc
+    T f = FrangeLin ⟨section43ProbeCLM s f, hmem⟩ := by
+      exact (section43RangeLiftLinear_apply T s hker f).symm
+    _ = Frange ⟨section43ProbeCLM s f, hmem⟩ := by
+      rfl
+    _ = G (section43ProbeCLM s f) := by
+      symm
+      exact hGext ⟨section43ProbeCLM s f, hmem⟩
+
+theorem section43WeightedDerivToBCFCLM_representative_eq_integral_kernel_apply
+    (g : Section43CompactPositiveTimeSource1D)
+    (k n : ℕ) (σ : ℝ) :
+    section43WeightedDerivToBCFCLM k n
+        (section43OneSidedLaplaceSchwartzRepresentative1D g) σ =
+      ∫ t : ℝ,
+        g.f t *
+          section43WeightedDerivToBCFCLM k n
+            (section43ImagAxisPsiKernel t) σ := by
+  rw [section43WeightedDerivToBCFCLM_apply]
+  rw [section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_eq_integral_kernel_iteratedDeriv]
+  calc
+    section43PolyWeight k σ *
+        ∫ t : ℝ,
+          iteratedDeriv n
+              (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+            g.f t
+        =
+          ∫ t : ℝ,
+            section43PolyWeight k σ *
+              (iteratedDeriv n
+                  (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+                g.f t) := by
+          simpa using
+            (MeasureTheory.integral_const_mul
+              (section43PolyWeight k σ)
+              (fun t : ℝ =>
+                iteratedDeriv n
+                    (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+                  g.f t)).symm
+    _ =
+        ∫ t : ℝ,
+          g.f t *
+            section43WeightedDerivToBCFCLM k n
+              (section43ImagAxisPsiKernel t) σ := by
+          refine MeasureTheory.integral_congr_ae ?_
+          filter_upwards with t
+          rw [section43WeightedDerivToBCFCLM_apply]
+          ring
 
 @[simp] theorem section43OneSidedAnnihilatorFLOnImag_of_pos
     (A : Section43PositiveEnergy1D →L[ℂ] ℂ)

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceDensity.lean
@@ -1,4 +1,5 @@
 import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43OneVariableSlice
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceCompactDifferentiation
 
 /-!
 # Section 4.3 Fourier-Laplace Density
@@ -432,6 +433,335 @@ theorem section43OneSidedLaplaceRaw_iteratedFDeriv_formula
   rw [ContinuousMultilinearMap.mkPiAlgebraFin_apply]
   rw [List.prod_ofFn]
 
+/-- If the exponential kernel has a real-part bound on the compact source
+support, then the derivative-candidate integral has the corresponding scalar
+norm bound. -/
+theorem section43OneSidedLaplaceRawDerivCandidate_norm_le_of_re_bound
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ)
+    {δ R σ E : ℝ}
+    (hδ_pos : 0 < δ)
+    (hsupp : tsupport (g.f : ℝ → ℂ) ⊆ Set.Icc δ R)
+    (hRe : ∀ t : ℝ, g.f t ≠ 0 →
+      (-(t : ℂ) * (σ : ℂ)).re ≤ E) :
+    ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖ ≤
+      ((max |δ| |R|) ^ r * Real.exp E) * ∫ t : ℝ, ‖g.f t‖ := by
+  let M : ℝ := max |δ| |R|
+  let K : ℝ := M ^ r * Real.exp E
+  have hM_nonneg : 0 ≤ M := by
+    dsimp [M]
+    exact (abs_nonneg δ).trans (le_max_left |δ| |R|)
+  have hK_nonneg : 0 ≤ K := by
+    dsimp [K]
+    exact mul_nonneg (pow_nonneg hM_nonneg r) (Real.exp_pos E).le
+  have hpoint :
+      ∀ t : ℝ,
+        ‖((-t : ℂ) ^ r *
+            Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t‖ ≤
+          K * ‖g.f t‖ := by
+    intro t
+    by_cases htzero : g.f t = 0
+    · simp [K, htzero]
+    · have ht_supp : t ∈ tsupport (g.f : ℝ → ℂ) :=
+        subset_tsupport _ htzero
+      have htIcc : t ∈ Set.Icc δ R := hsupp ht_supp
+      have htδ : δ ≤ t := htIcc.1
+      have htR : t ≤ R := htIcc.2
+      have ht_nonneg : 0 ≤ t := le_trans (le_of_lt hδ_pos) htδ
+      have ht_abs_le : |t| ≤ M := by
+        rw [abs_of_nonneg ht_nonneg]
+        exact htR.trans ((le_abs_self R).trans (le_max_right |δ| |R|))
+      have hpow_le : ‖(-t : ℂ) ^ r‖ ≤ M ^ r := by
+        calc
+          ‖(-t : ℂ) ^ r‖ = |t| ^ r := by
+            rw [norm_pow, norm_neg, Complex.norm_real, Real.norm_eq_abs]
+          _ ≤ M ^ r := pow_le_pow_left₀ (abs_nonneg t) ht_abs_le r
+      have hexp_le :
+          ‖Complex.exp (-(t : ℂ) * (σ : ℂ))‖ ≤ Real.exp E := by
+        rw [Complex.norm_exp]
+        exact Real.exp_le_exp.mpr (hRe t htzero)
+      calc
+        ‖((-t : ℂ) ^ r *
+            Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t‖
+            = ‖(-t : ℂ) ^ r‖ *
+                ‖Complex.exp (-(t : ℂ) * (σ : ℂ))‖ * ‖g.f t‖ := by
+              rw [norm_mul, norm_mul]
+        _ ≤ (M ^ r * Real.exp E) * ‖g.f t‖ := by
+              exact mul_le_mul_of_nonneg_right
+                (mul_le_mul hpow_le hexp_le (norm_nonneg _)
+                  (pow_nonneg hM_nonneg r))
+                (norm_nonneg (g.f t))
+        _ = K * ‖g.f t‖ := by
+              rfl
+  have hleft_int :
+      Integrable
+        (fun t : ℝ =>
+          ‖((-t : ℂ) ^ r *
+            Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t‖) :=
+    (section43OneSidedLaplaceRawDerivCandidate_integrable g r σ).norm
+  have hright_int : Integrable (fun t : ℝ => K * ‖g.f t‖) :=
+    g.f.integrable.norm.const_mul K
+  calc
+    ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖
+        ≤ ∫ t : ℝ,
+            ‖((-t : ℂ) ^ r *
+              Complex.exp (-(t : ℂ) * (σ : ℂ))) * g.f t‖ := by
+          exact MeasureTheory.norm_integral_le_integral_norm _
+    _ ≤ ∫ t : ℝ, K * ‖g.f t‖ := by
+          exact integral_mono hleft_int hright_int hpoint
+    _ = K * ∫ t : ℝ, ‖g.f t‖ := by
+          rw [integral_const_mul]
+    _ = ((max |δ| |R|) ^ r * Real.exp E) * ∫ t : ℝ, ‖g.f t‖ := by
+          rfl
+
+/-- Uniform bound for derivative candidates in the cutoff transition strip
+`-1 ≤ σ ≤ 0`. -/
+theorem section43OneSidedLaplaceRawDerivCandidate_norm_le_strip
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ)
+    {δ R σ : ℝ}
+    (hδ_pos : 0 < δ) (hδR : δ ≤ R)
+    (hsupp : tsupport (g.f : ℝ → ℂ) ⊆ Set.Icc δ R)
+    (hσ_lower : -1 ≤ σ) (hσ_nonpos : σ ≤ 0) :
+    ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖ ≤
+      ((max |δ| |R|) ^ r * Real.exp R) * ∫ t : ℝ, ‖g.f t‖ := by
+  refine section43OneSidedLaplaceRawDerivCandidate_norm_le_of_re_bound
+    (g := g) (r := r) (δ := δ) (R := R) (σ := σ) (E := R)
+    hδ_pos hsupp ?_
+  intro t htzero
+  have ht_supp : t ∈ tsupport (g.f : ℝ → ℂ) :=
+    subset_tsupport _ htzero
+  have htIcc : t ∈ Set.Icc δ R := hsupp ht_supp
+  have htδ : δ ≤ t := htIcc.1
+  have htR : t ≤ R := htIcc.2
+  have ht_nonneg : 0 ≤ t := le_trans (le_of_lt hδ_pos) htδ
+  have hR_pos : 0 < R := lt_of_lt_of_le hδ_pos hδR
+  have hneg_nonneg : 0 ≤ -σ := by linarith
+  have hneg_le_one : -σ ≤ 1 := by linarith
+  have hre : (-(t : ℂ) * (σ : ℂ)).re = -(t * σ) := by
+    simp [Complex.mul_re]
+  rw [hre]
+  calc
+    -(t * σ) = t * (-σ) := by ring
+    _ ≤ R * 1 := by
+          exact mul_le_mul htR hneg_le_one hneg_nonneg (le_of_lt hR_pos)
+    _ = R := by ring
+
+/-- Exponential-decay bound for derivative candidates on the positive half-line. -/
+theorem section43OneSidedLaplaceRawDerivCandidate_norm_le_nonneg
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ)
+    {δ R σ : ℝ}
+    (hδ_pos : 0 < δ)
+    (hsupp : tsupport (g.f : ℝ → ℂ) ⊆ Set.Icc δ R)
+    (hσ_nonneg : 0 ≤ σ) :
+    ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖ ≤
+      ((max |δ| |R|) ^ r * Real.exp (-(δ * σ))) *
+        ∫ t : ℝ, ‖g.f t‖ := by
+  refine section43OneSidedLaplaceRawDerivCandidate_norm_le_of_re_bound
+    (g := g) (r := r) (δ := δ) (R := R) (σ := σ) (E := -(δ * σ))
+    hδ_pos hsupp ?_
+  intro t htzero
+  have ht_supp : t ∈ tsupport (g.f : ℝ → ℂ) :=
+    subset_tsupport _ htzero
+  have htIcc : t ∈ Set.Icc δ R := hsupp ht_supp
+  have htδ : δ ≤ t := htIcc.1
+  have hre : (-(t : ℂ) * (σ : ℂ)).re = -(t * σ) := by
+    simp [Complex.mul_re]
+  rw [hre]
+  have hmul : δ * σ ≤ t * σ :=
+    mul_le_mul_of_nonneg_right htδ hσ_nonneg
+  linarith
+
+/-- The raw compact one-sided Laplace transform has rapid decay on the support
+of the cutoff derivatives, namely on `Set.Ici (-1)`. -/
+theorem section43OneSidedLaplaceRaw_rapid_on_Ici_neg_one
+    (g : Section43CompactPositiveTimeSource1D) :
+    ∀ r s : ℕ, ∃ C : ℝ, 0 ≤ C ∧
+      ∀ σ ∈ Set.Ici (-1 : ℝ),
+        (1 + ‖σ‖) ^ s *
+          ‖iteratedFDeriv ℝ r (section43OneSidedLaplaceRaw g) σ‖ ≤ C := by
+  intro r s
+  rcases exists_positive_Icc_bounds_of_compactPositiveTimeSource g with
+    ⟨δ, R, hδ_pos, hδR, hsupp⟩
+  rcases SCV.pow_mul_exp_neg_le_const hδ_pos s with
+    ⟨C0, hC0_pos, hC0_bound⟩
+  let M : ℝ := max |δ| |R|
+  let I : ℝ := ∫ t : ℝ, ‖g.f t‖
+  let Cstrip : ℝ := (2 : ℝ) ^ s * ((M ^ r * Real.exp R) * I)
+  let Cpos : ℝ := (M ^ r * I) * (Real.exp δ * C0)
+  let C : ℝ := Cstrip + Cpos
+  have hM_nonneg : 0 ≤ M := by
+    dsimp [M]
+    exact (abs_nonneg δ).trans (le_max_left |δ| |R|)
+  have hI_nonneg : 0 ≤ I := by
+    dsimp [I]
+    exact integral_nonneg fun t => norm_nonneg (g.f t)
+  have hstripBase_nonneg : 0 ≤ (M ^ r * Real.exp R) * I := by
+    exact mul_nonneg
+      (mul_nonneg (pow_nonneg hM_nonneg r) (Real.exp_pos R).le)
+      hI_nonneg
+  have hCstrip_nonneg : 0 ≤ Cstrip := by
+    dsimp [Cstrip]
+    exact mul_nonneg (pow_nonneg (by norm_num : (0 : ℝ) ≤ 2) s)
+      hstripBase_nonneg
+  have hA_nonneg : 0 ≤ M ^ r * I := by
+    exact mul_nonneg (pow_nonneg hM_nonneg r) hI_nonneg
+  have hC0_nonneg : 0 ≤ C0 := le_of_lt hC0_pos
+  have hCpos_nonneg : 0 ≤ Cpos := by
+    dsimp [Cpos]
+    exact mul_nonneg hA_nonneg
+      (mul_nonneg (Real.exp_pos δ).le hC0_nonneg)
+  refine ⟨C, add_nonneg hCstrip_nonneg hCpos_nonneg, ?_⟩
+  intro σ hσ_mem
+  have hσ_lower : -1 ≤ σ := by
+    simpa [Set.mem_Ici] using hσ_mem
+  have hF_norm :
+      ‖iteratedFDeriv ℝ r (section43OneSidedLaplaceRaw g) σ‖ =
+        ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖ := by
+    rw [norm_iteratedFDeriv_eq_norm_iteratedDeriv,
+      section43OneSidedLaplaceRaw_iteratedDeriv_formula]
+  by_cases hσ_nonpos : σ ≤ 0
+  · have hraw_bound :
+        ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖ ≤
+          (M ^ r * Real.exp R) * I := by
+      simpa [M, I] using
+        section43OneSidedLaplaceRawDerivCandidate_norm_le_strip
+          (g := g) (r := r) (δ := δ) (R := R) (σ := σ)
+          hδ_pos hδR hsupp hσ_lower hσ_nonpos
+    have hnorm_le_one : ‖σ‖ ≤ 1 := by
+      rw [Real.norm_eq_abs]
+      exact abs_le.mpr ⟨hσ_lower, by linarith⟩
+    have hpoly_le : (1 + ‖σ‖) ^ s ≤ (2 : ℝ) ^ s := by
+      exact pow_le_pow_left₀ (by positivity) (by linarith) s
+    calc
+      (1 + ‖σ‖) ^ s *
+          ‖iteratedFDeriv ℝ r (section43OneSidedLaplaceRaw g) σ‖
+          = (1 + ‖σ‖) ^ s *
+              ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖ := by
+            rw [hF_norm]
+      _ ≤ (1 + ‖σ‖) ^ s * ((M ^ r * Real.exp R) * I) := by
+            exact mul_le_mul_of_nonneg_left hraw_bound (by positivity)
+      _ ≤ (2 : ℝ) ^ s * ((M ^ r * Real.exp R) * I) := by
+            exact mul_le_mul_of_nonneg_right hpoly_le hstripBase_nonneg
+      _ = Cstrip := by
+            rfl
+      _ ≤ C := by
+            dsimp [C]
+            exact le_add_of_nonneg_right hCpos_nonneg
+  · have hσ_nonneg : 0 ≤ σ := le_of_not_ge hσ_nonpos
+    have hraw_bound :
+        ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖ ≤
+          (M ^ r * Real.exp (-(δ * σ))) * I := by
+      simpa [M, I] using
+        section43OneSidedLaplaceRawDerivCandidate_norm_le_nonneg
+          (g := g) (r := r) (δ := δ) (R := R) (σ := σ)
+          hδ_pos hsupp hσ_nonneg
+    have hposBase_nonneg :
+        0 ≤ (M ^ r * Real.exp (-(δ * σ))) * I := by
+      exact mul_nonneg
+        (mul_nonneg (pow_nonneg hM_nonneg r)
+          (Real.exp_pos (-(δ * σ))).le)
+        hI_nonneg
+    have htail :
+        (1 + ‖σ‖) ^ s * Real.exp (-(δ * σ)) ≤
+          Real.exp δ * C0 := by
+      have hx_nonneg : 0 ≤ 1 + σ := by linarith
+      have htail0 := hC0_bound (1 + σ) hx_nonneg
+      have hexp_eq :
+          Real.exp (-(δ * σ)) =
+            Real.exp δ * Real.exp (-(δ * (1 + σ))) := by
+        rw [← Real.exp_add]
+        congr 1
+        ring
+      rw [Real.norm_eq_abs, abs_of_nonneg hσ_nonneg]
+      calc
+        (1 + σ) ^ s * Real.exp (-(δ * σ))
+            = Real.exp δ *
+                ((1 + σ) ^ s * Real.exp (-(δ * (1 + σ)))) := by
+              rw [hexp_eq]
+              ring
+        _ ≤ Real.exp δ * C0 := by
+              exact mul_le_mul_of_nonneg_left htail0 (Real.exp_pos δ).le
+    calc
+      (1 + ‖σ‖) ^ s *
+          ‖iteratedFDeriv ℝ r (section43OneSidedLaplaceRaw g) σ‖
+          = (1 + ‖σ‖) ^ s *
+              ‖section43OneSidedLaplaceRawDerivCandidate g r σ‖ := by
+            rw [hF_norm]
+      _ ≤ (1 + ‖σ‖) ^ s *
+            ((M ^ r * Real.exp (-(δ * σ))) * I) := by
+            exact mul_le_mul_of_nonneg_left hraw_bound (by positivity)
+      _ = (M ^ r * I) *
+            ((1 + ‖σ‖) ^ s * Real.exp (-(δ * σ))) := by
+            ring
+      _ ≤ (M ^ r * I) * (Real.exp δ * C0) := by
+            exact mul_le_mul_of_nonneg_left htail hA_nonneg
+      _ = Cpos := by
+            rfl
+      _ ≤ C := by
+            dsimp [C]
+            exact le_add_of_nonneg_left hCstrip_nonneg
+
+/-- The cutoff product is the ambient Schwartz representative of the compact
+one-sided Laplace transform. -/
+noncomputable def section43OneSidedLaplaceSchwartzRepresentative1D
+    (g : Section43CompactPositiveTimeSource1D) : SchwartzMap ℝ ℂ :=
+  schwartzMap_of_temperate_mul_rapid_on_derivSupport
+    (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ))
+    (section43OneSidedLaplaceRaw g)
+    (Set.Ici (-1 : ℝ))
+    SCV.smoothCutoff_complex_hasTemperateGrowth
+    section43SmoothCutoff_complex_iteratedFDeriv_support_subset_Ici_neg_one
+    (section43OneSidedLaplaceRaw_contDiff g)
+    (section43OneSidedLaplaceRaw_rapid_on_Ici_neg_one g)
+
+@[simp] theorem section43OneSidedLaplaceSchwartzRepresentative1D_apply
+    (g : Section43CompactPositiveTimeSource1D) (σ : ℝ) :
+    section43OneSidedLaplaceSchwartzRepresentative1D g σ =
+      section43OneSidedLaplaceCutoffFun g σ := rfl
+
+theorem exists_section43OneSidedLaplaceRepresentative1D
+    (g : Section43CompactPositiveTimeSource1D) :
+    ∃ Φ : SchwartzMap ℝ ℂ,
+      section43OneSidedLaplaceRepresentative1D g Φ := by
+  refine ⟨section43OneSidedLaplaceSchwartzRepresentative1D g, ?_⟩
+  intro σ hσ
+  rw [section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg g hσ]
+  rfl
+
+/-- Compact strict-positive one-sided Laplace sources as elements of the
+one-dimensional positive-energy quotient. -/
+noncomputable def section43OneSidedLaplaceCompactTransform1D :
+    Section43CompactPositiveTimeSource1D → Section43PositiveEnergy1D :=
+  fun g =>
+    section43PositiveEnergyQuotientMap1D
+      (Classical.choose (exists_section43OneSidedLaplaceRepresentative1D g))
+
+theorem section43OneSidedLaplaceCompactTransform1D_choose_spec
+    (g : Section43CompactPositiveTimeSource1D) :
+    section43OneSidedLaplaceRepresentative1D g
+      (Classical.choose (exists_section43OneSidedLaplaceRepresentative1D g)) :=
+  Classical.choose_spec (exists_section43OneSidedLaplaceRepresentative1D g)
+
+/-- The abstractly chosen compact transform is represented by the explicit
+cutoff-Schwartz representative. -/
+theorem section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient
+    (g : Section43CompactPositiveTimeSource1D) :
+    section43OneSidedLaplaceCompactTransform1D g =
+      section43PositiveEnergyQuotientMap1D
+        (section43OneSidedLaplaceSchwartzRepresentative1D g) := by
+  dsimp [section43OneSidedLaplaceCompactTransform1D]
+  apply section43PositiveEnergyQuotientMap1D_eq_of_eqOn_nonneg
+  intro σ hσ
+  calc
+    Classical.choose (exists_section43OneSidedLaplaceRepresentative1D g) σ
+        = ∫ t : ℝ,
+            Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t :=
+          section43OneSidedLaplaceCompactTransform1D_choose_spec g σ hσ
+    _ = section43OneSidedLaplaceSchwartzRepresentative1D g σ := by
+          rw [section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+            section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg g hσ]
+          rfl
+
 /-- Local name for Mathlib's inverse Fourier continuous linear map on
 one-dimensional Schwartz space. -/
 noncomputable def section43FourierInvCLM1D :
@@ -523,6 +853,15 @@ noncomputable def section43OneSidedAnnihilatorFLOnImag
   else
     0
 
+/-- Imaginary-axis Paley-Wiener kernel, with a zero branch off the strict
+positive half-line. -/
+noncomputable def section43ImagAxisPsiKernel (t : ℝ) : SchwartzMap ℝ ℂ :=
+  if ht : 0 < t then
+    SCV.schwartzPsiZ ((t : ℂ) * Complex.I)
+      (by simpa [Complex.mul_im] using ht)
+  else
+    0
+
 @[simp] theorem section43OneSidedAnnihilatorFLOnImag_of_pos
     (A : Section43PositiveEnergy1D →L[ℂ] ℂ)
     {t : ℝ} (ht : 0 < t) :
@@ -536,6 +875,49 @@ theorem section43OneSidedAnnihilatorFLOnImag_of_not_pos
     {t : ℝ} (ht : ¬ 0 < t) :
     section43OneSidedAnnihilatorFLOnImag A t = 0 := by
   simp [section43OneSidedAnnihilatorFLOnImag, ht]
+
+theorem section43OneSidedAnnihilatorFLOnImag_eq_apply_kernel
+    (A : Section43PositiveEnergy1D →L[ℂ] ℂ) (t : ℝ) :
+    section43OneSidedAnnihilatorFLOnImag A t =
+      A (section43PositiveEnergyQuotientMap1D
+        (section43ImagAxisPsiKernel t)) := by
+  by_cases ht : 0 < t
+  · simp [section43OneSidedAnnihilatorFLOnImag, section43ImagAxisPsiKernel,
+      section43OneSidedAnnihilatorFL, ht]
+  · simp [section43OneSidedAnnihilatorFLOnImag, section43ImagAxisPsiKernel,
+      ht]
+
+theorem continuousOn_section43OneSidedAnnihilatorFLOnImag_Ioi
+    (A : Section43PositiveEnergy1D →L[ℂ] ℂ) :
+    ContinuousOn (section43OneSidedAnnihilatorFLOnImag A) (Set.Ioi (0 : ℝ)) := by
+  let T := section43PositiveEnergy1D_to_oneSidedFourierFunctional A
+  let F : ℂ → ℂ := fun w =>
+    if hw : 0 < w.im then
+      SCV.fourierLaplaceExt T w hw
+    else
+      0
+  have hF_cont : ContinuousOn F SCV.upperHalfPlane := by
+    simpa [F] using (SCV.fourierLaplaceExt_differentiableOn T).continuousOn
+  have hpath_cont :
+      ContinuousOn (fun t : ℝ => (t : ℂ) * Complex.I) (Set.Ioi (0 : ℝ)) := by
+    exact ((Complex.continuous_ofReal.comp continuous_id).mul
+      (continuous_const : Continuous (fun _ : ℝ => Complex.I))).continuousOn
+  have hmap :
+      Set.MapsTo (fun t : ℝ => (t : ℂ) * Complex.I)
+        (Set.Ioi (0 : ℝ)) SCV.upperHalfPlane := by
+    intro t ht
+    simpa [SCV.upperHalfPlane, Complex.mul_im] using ht
+  refine (hF_cont.comp hpath_cont hmap).congr ?_
+  intro t ht
+  have htpos : 0 < t := by simpa using ht
+  have hw : 0 < (((t : ℂ) * Complex.I).im) := by
+    simpa [Complex.mul_im] using htpos
+  change section43OneSidedAnnihilatorFLOnImag A t = F (((t : ℂ) * Complex.I))
+  rw [section43OneSidedAnnihilatorFLOnImag_of_pos A htpos]
+  dsimp [F]
+  rw [dif_pos (by simpa [Complex.mul_im] using htpos)]
+  exact section43OneSidedAnnihilatorFL_eq_fourierLaplaceExt_to_oneSided
+    (A := A) (((t : ℂ) * Complex.I)) hw
 
 theorem section43PositiveEnergy1D_ext_of_FL_zero
     (A : Section43PositiveEnergy1D →L[ℂ] ℂ)

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceFiniteProbe.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceFiniteProbe.lean
@@ -1,0 +1,1008 @@
+import Mathlib.LinearAlgebra.Complex.Module
+import OSReconstruction.SCV.DistributionalUniqueness
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceDensity
+
+/-!
+# Section 4.3 finite-probe Fubini support
+
+This companion file continues the pure-analysis density packet from
+`Section43FourierLaplaceDensity.lean`.  The goal is to keep the already-large
+density file stable while proving the Banach finite-probe bridge needed for the
+weak scalar Fubini theorem.
+-/
+
+noncomputable section
+
+open scoped Topology FourierTransform BoundedContinuousFunction
+open Set MeasureTheory Filter
+
+namespace OSReconstruction
+
+namespace Section43CompactPositiveTimeSource1D
+
+private theorem ext_f {g h : Section43CompactPositiveTimeSource1D}
+    (hf : g.f = h.f) : g = h := by
+  cases g
+  cases h
+  simp at hf
+  subst hf
+  rfl
+
+private theorem f_injective :
+    Function.Injective (fun g : Section43CompactPositiveTimeSource1D => g.f) := by
+  intro g h hf
+  exact ext_f hf
+
+instance : Zero Section43CompactPositiveTimeSource1D where
+  zero :=
+    { f := 0
+      positive := by
+        intro t ht
+        simp at ht
+      compact := by
+        simpa using
+          (HasCompactSupport.zero : HasCompactSupport (0 : ℝ → ℂ)) }
+
+instance : Add Section43CompactPositiveTimeSource1D where
+  add g h :=
+    { f := g.f + h.f
+      positive := by
+        intro t ht
+        have ht' := tsupport_add (g.f : ℝ → ℂ) (h.f : ℝ → ℂ) ht
+        exact ht'.elim (fun hg => g.positive hg) (fun hh => h.positive hh)
+      compact := by
+        simpa using HasCompactSupport.add g.compact h.compact }
+
+instance : SMul ℕ Section43CompactPositiveTimeSource1D where
+  smul n g :=
+    { f := (n : ℂ) • g.f
+      positive := by
+        exact
+          (tsupport_smul_subset_right
+            (fun _ : ℝ => (n : ℂ)) (g.f : ℝ → ℂ)).trans g.positive
+      compact := by
+        simpa using
+          (HasCompactSupport.smul_left
+            (f := fun _ : ℝ => (n : ℂ)) (f' := (g.f : ℝ → ℂ)) g.compact) }
+
+instance : AddCommMonoid Section43CompactPositiveTimeSource1D :=
+  Function.Injective.addCommMonoid
+    (fun g : Section43CompactPositiveTimeSource1D => g.f)
+    f_injective rfl
+    (by intro g h; rfl)
+    (by
+      intro g n
+      change (n : ℂ) • g.f = n • g.f
+      rw [Nat.cast_smul_eq_nsmul ℂ])
+
+instance : SMul ℂ Section43CompactPositiveTimeSource1D where
+  smul c g :=
+    { f := c • g.f
+      positive := by
+        exact
+          (tsupport_smul_subset_right
+            (fun _ : ℝ => c) (g.f : ℝ → ℂ)).trans g.positive
+      compact := by
+        simpa using
+          (HasCompactSupport.smul_left
+            (f := fun _ : ℝ => c) (f' := (g.f : ℝ → ℂ)) g.compact) }
+
+private def fAddMonoidHom :
+    Section43CompactPositiveTimeSource1D →+ SchwartzMap ℝ ℂ where
+  toFun := fun g => g.f
+  map_zero' := rfl
+  map_add' := by intro g h; rfl
+
+instance : Module ℂ Section43CompactPositiveTimeSource1D :=
+  Function.Injective.module ℂ fAddMonoidHom
+    (by
+      intro g h hf
+      exact f_injective hf)
+    (by intro c g; rfl)
+
+end Section43CompactPositiveTimeSource1D
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The weighted derivative BCF probe is controlled by two Schwartz seminorms.
+This is the public Section 4.3 copy of the private Paley-Wiener estimate used to
+turn Schwartz-topology convergence of `ψ_z` into BCF-norm convergence. -/
+theorem section43WeightedDerivToBCFCLM_norm_le
+    (k n : ℕ) (f : SchwartzMap ℝ ℂ) :
+    ‖section43WeightedDerivToBCFCLM k n f‖ ≤
+      (2 : ℝ) ^ k *
+        (SchwartzMap.seminorm ℝ 0 n f +
+          SchwartzMap.seminorm ℝ (2 * k) n f) := by
+  rw [show ‖section43WeightedDerivToBCFCLM k n f‖ =
+      dist (section43WeightedDerivToBCFCLM k n f) 0 by rfl]
+  refine (BoundedContinuousFunction.dist_le ?_).2 ?_
+  · positivity
+  · intro σ
+    have hsemi0 := SchwartzMap.le_seminorm' (𝕜 := ℝ) (k := 0) (n := n) f σ
+    have hsemi2 := SchwartzMap.le_seminorm' (𝕜 := ℝ) (k := 2 * k) (n := n) f σ
+    simp only [BoundedContinuousFunction.coe_zero, Pi.zero_apply, dist_eq_norm, sub_zero,
+      section43WeightedDerivToBCFCLM_apply]
+    by_cases hσ : |σ| ≤ 1
+    · have hpoly : ‖section43PolyWeight k σ‖ ≤ (2 : ℝ) ^ k := by
+        rw [section43PolyWeight, Complex.norm_real, Real.norm_of_nonneg]
+        · have hσsq : σ ^ 2 ≤ 1 := by
+            have hsqabs : |σ| ^ 2 ≤ (1 : ℝ) ^ 2 := by
+              gcongr
+            simpa [sq_abs] using hsqabs
+          calc
+            (1 + σ ^ 2) ^ k ≤ (1 + 1) ^ k := by
+              gcongr
+            _ = (2 : ℝ) ^ k := by ring
+        · positivity
+      calc
+        ‖section43PolyWeight k σ * iteratedDeriv n f σ‖
+            ≤ (2 : ℝ) ^ k * ‖iteratedDeriv n f σ‖ := by
+              rw [norm_mul]
+              gcongr
+        _ ≤ (2 : ℝ) ^ k * SchwartzMap.seminorm ℝ 0 n f := by
+              exact mul_le_mul_of_nonneg_left
+                (by simpa using hsemi0) (pow_nonneg (by positivity) _)
+        _ ≤ (2 : ℝ) ^ k *
+              (SchwartzMap.seminorm ℝ 0 n f +
+                SchwartzMap.seminorm ℝ (2 * k) n f) := by
+              gcongr
+              exact le_add_of_nonneg_right (apply_nonneg _ _)
+    · have hσgt : 1 < |σ| := lt_of_not_ge hσ
+      have hone : 1 ≤ |σ| ^ 2 := by
+        have : 1 ≤ |σ| := le_of_lt hσgt
+        nlinarith
+      have hpoly :
+          ‖section43PolyWeight k σ‖ ≤ (2 : ℝ) ^ k * |σ| ^ (2 * k) := by
+        rw [section43PolyWeight, Complex.norm_real, Real.norm_of_nonneg]
+        · have hσsq : σ ^ 2 = |σ| ^ 2 := by rw [sq_abs]
+          calc
+            (1 + σ ^ 2) ^ k = (1 + |σ| ^ 2) ^ k := by rw [hσsq]
+            _ ≤ (2 * |σ| ^ 2) ^ k := by
+                  gcongr
+                  linarith
+            _ = (2 : ℝ) ^ k * |σ| ^ (2 * k) := by
+                  rw [mul_pow]
+                  ring_nf
+        · positivity
+      calc
+        ‖section43PolyWeight k σ * iteratedDeriv n f σ‖
+            ≤ ((2 : ℝ) ^ k * |σ| ^ (2 * k)) *
+                ‖iteratedDeriv n f σ‖ := by
+              rw [norm_mul]
+              gcongr
+        _ = (2 : ℝ) ^ k *
+              (|σ| ^ (2 * k) * ‖iteratedDeriv n f σ‖) := by ring
+        _ ≤ (2 : ℝ) ^ k * SchwartzMap.seminorm ℝ (2 * k) n f := by
+              exact mul_le_mul_of_nonneg_left
+                (by simpa using hsemi2) (pow_nonneg (by positivity) _)
+        _ ≤ (2 : ℝ) ^ k *
+              (SchwartzMap.seminorm ℝ 0 n f +
+                SchwartzMap.seminorm ℝ (2 * k) n f) := by
+              gcongr
+              exact le_add_of_nonneg_left (apply_nonneg _ _)
+
+private theorem section43_schwartzPsiZ_imagAxis_diff_eq
+    (t h : ℝ) (ht : 0 < t) (hth : 0 < t + h)
+    (hh_im : ‖((h : ℂ) * Complex.I)‖ ≤ (((t : ℂ) * Complex.I).im) / 2)
+    (hh1 : ‖((h : ℂ) * Complex.I)‖ ≤ 1) :
+    SCV.schwartzPsiZ (((t + h : ℝ) : ℂ) * Complex.I)
+        (by simpa [Complex.mul_im] using hth) -
+      SCV.schwartzPsiZ ((t : ℂ) * Complex.I)
+        (by simpa [Complex.mul_im] using ht) -
+      ((h : ℂ) * Complex.I) •
+        (SchwartzMap.smulLeftCLM ℂ (fun σ : ℝ => Complex.I * (σ : ℂ)))
+          (SCV.schwartzPsiZ ((t : ℂ) * Complex.I)
+            (by simpa [Complex.mul_im] using ht)) =
+    ((h : ℂ) * Complex.I) •
+      SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+        ((t : ℂ) * Complex.I)
+        (by simpa [Complex.mul_im] using ht)
+        ((h : ℂ) * Complex.I) hh_im hh1 := by
+  have hzadd :
+      ((t : ℂ) * Complex.I) + ((h : ℂ) * Complex.I) =
+        (((t + h : ℝ) : ℂ) * Complex.I) := by
+    norm_num
+    ring
+  have htemp : (fun σ : ℝ => Complex.I * (σ : ℂ)).HasTemperateGrowth := by
+    fun_prop
+  ext σ
+  simpa [hzadd, SCV.schwartzPsiZ_apply,
+    SCV.schwartzPsiZExpTaylorLinearRemainderQuot_apply,
+    SchwartzMap.smulLeftCLM_apply_apply htemp, smul_eq_mul] using
+    (SCV.psiZ_sub_sub_deriv_eq_smul_remainder
+      ((t : ℂ) * Complex.I) ((h : ℂ) * Complex.I) σ)
+
+set_option backward.isDefEq.respectTransparency false in
+set_option maxHeartbeats 800000 in
+theorem continuousAt_section43WeightedDerivToBCFCLM_imagAxisPsiKernel_of_pos
+    {t : ℝ} (ht : 0 < t) (k n : ℕ) :
+    ContinuousAt
+      (fun y : ℝ =>
+        section43WeightedDerivToBCFCLM k n
+          (section43ImagAxisPsiKernel y))
+      t := by
+  rw [Metric.continuousAt_iff]
+  intro ε hε
+  let z : ℂ := (t : ℂ) * Complex.I
+  have hz : 0 < z.im := by simpa [z, Complex.mul_im] using ht
+  let D : ℝ := ‖section43WeightedDerivToBCFCLM k n
+    ((SchwartzMap.smulLeftCLM ℂ (fun σ : ℝ => Complex.I * (σ : ℂ)))
+      (SCV.schwartzPsiZ z hz))‖
+  obtain ⟨C0, hC0_nonneg, hC0⟩ :=
+    SCV.schwartzPsiZExpTaylorLinearRemainderQuot_seminorm_le z hz 0 n
+  obtain ⟨C2, hC2_nonneg, hC2⟩ :=
+    SCV.schwartzPsiZExpTaylorLinearRemainderQuot_seminorm_le z hz (2 * k) n
+  let C : ℝ := (2 : ℝ) ^ k * (C0 + C2)
+  have hD_nonneg : 0 ≤ D := norm_nonneg _
+  have hC_nonneg : 0 ≤ C := by
+    dsimp [C]
+    positivity
+  let δ : ℝ := min (t / 2) (min 1 (ε / (2 * (D + C + 1))))
+  have hδ_pos : 0 < δ := by
+    dsimp [δ]
+    refine lt_min ?_ ?_
+    · positivity
+    · refine lt_min (by norm_num) ?_
+      have hden_pos : 0 < 2 * (D + C + 1) := by nlinarith
+      exact div_pos hε hden_pos
+  refine ⟨δ, hδ_pos, ?_⟩
+  intro y hy
+  let h : ℝ := y - t
+  have hyδ_real : |h| < δ := by
+    simpa [h, Real.dist_eq] using hy
+  have hhδ : ‖((h : ℂ) * Complex.I)‖ < δ := by
+    simpa [Complex.norm_mul, Complex.norm_I, Real.norm_eq_abs] using hyδ_real
+  have hδ_t : δ ≤ t / 2 := by
+    dsimp [δ]
+    exact min_le_left _ _
+  have h_abs_lt_t2 : |y - t| < t / 2 := by
+    exact lt_of_lt_of_le (by simpa [h] using hyδ_real) hδ_t
+  have hypos : 0 < y := by
+    have hleft := (abs_lt.mp h_abs_lt_t2).1
+    nlinarith
+  have ht_add_h : t + h = y := by
+    dsimp [h]
+    ring
+  have hth : 0 < t + h := by
+    rw [ht_add_h]
+    exact hypos
+  have hh1 : ‖((h : ℂ) * Complex.I)‖ ≤ 1 := by
+    exact le_trans (le_of_lt hhδ)
+      (by
+        dsimp [δ]
+        exact le_trans (min_le_right _ _) (min_le_left _ _))
+  have hh_im : ‖((h : ℂ) * Complex.I)‖ ≤ z.im / 2 := by
+    have hle_t : ‖((h : ℂ) * Complex.I)‖ ≤ t / 2 :=
+      le_trans (le_of_lt hhδ) hδ_t
+    simpa [z, Complex.mul_im] using hle_t
+  have hdecomp :=
+    section43_schwartzPsiZ_imagAxis_diff_eq t h ht hth hh_im hh1
+  have hsplit :
+      section43WeightedDerivToBCFCLM k n
+        (SCV.schwartzPsiZ (((t + h : ℝ) : ℂ) * Complex.I)
+            (by simpa [Complex.mul_im] using hth) -
+          SCV.schwartzPsiZ z hz) =
+        ((h : ℂ) * Complex.I) •
+            section43WeightedDerivToBCFCLM k n
+              (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+                z hz ((h : ℂ) * Complex.I) hh_im hh1) +
+          ((h : ℂ) * Complex.I) •
+            section43WeightedDerivToBCFCLM k n
+              ((SchwartzMap.smulLeftCLM ℂ
+                  (fun σ : ℝ => Complex.I * (σ : ℂ)))
+                (SCV.schwartzPsiZ z hz)) := by
+    have htmp :
+        section43WeightedDerivToBCFCLM k n
+            (SCV.schwartzPsiZ (((t + h : ℝ) : ℂ) * Complex.I)
+                (by simpa [Complex.mul_im] using hth) -
+              SCV.schwartzPsiZ z hz) -
+          ((h : ℂ) * Complex.I) •
+            section43WeightedDerivToBCFCLM k n
+              ((SchwartzMap.smulLeftCLM ℂ
+                  (fun σ : ℝ => Complex.I * (σ : ℂ)))
+                (SCV.schwartzPsiZ z hz)) =
+          ((h : ℂ) * Complex.I) •
+            section43WeightedDerivToBCFCLM k n
+              (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+                z hz ((h : ℂ) * Complex.I) hh_im hh1) := by
+      simpa [z, hdecomp, map_sub, map_smul] using
+        congrArg (section43WeightedDerivToBCFCLM k n) hdecomp
+    have htmp2 := eq_add_of_sub_eq htmp
+    simpa [add_comm, add_left_comm, add_assoc] using htmp2
+  have hrem :
+      ‖section43WeightedDerivToBCFCLM k n
+          (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+            z hz ((h : ℂ) * Complex.I) hh_im hh1)‖ ≤
+        C * ‖((h : ℂ) * Complex.I)‖ := by
+    calc
+      ‖section43WeightedDerivToBCFCLM k n
+          (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+            z hz ((h : ℂ) * Complex.I) hh_im hh1)‖
+          ≤ (2 : ℝ) ^ k *
+              (SchwartzMap.seminorm ℝ 0 n
+                  (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+                    z hz ((h : ℂ) * Complex.I) hh_im hh1) +
+                SchwartzMap.seminorm ℝ (2 * k) n
+                  (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+                    z hz ((h : ℂ) * Complex.I) hh_im hh1)) := by
+              exact section43WeightedDerivToBCFCLM_norm_le k n _
+      _ ≤ (2 : ℝ) ^ k *
+            (C0 * ‖((h : ℂ) * Complex.I)‖ +
+              C2 * ‖((h : ℂ) * Complex.I)‖) := by
+            gcongr
+            · exact hC0 ((h : ℂ) * Complex.I) hh_im hh1
+            · exact hC2 ((h : ℂ) * Complex.I) hh_im hh1
+      _ = C * ‖((h : ℂ) * Complex.I)‖ := by
+            dsimp [C]
+            ring
+  have hmain :
+      ‖section43WeightedDerivToBCFCLM k n
+          (SCV.schwartzPsiZ (((t + h : ℝ) : ℂ) * Complex.I)
+              (by simpa [Complex.mul_im] using hth) -
+            SCV.schwartzPsiZ z hz)‖
+        ≤ ‖((h : ℂ) * Complex.I)‖ *
+            (C * ‖((h : ℂ) * Complex.I)‖) +
+          ‖((h : ℂ) * Complex.I)‖ * D := by
+    calc
+      ‖section43WeightedDerivToBCFCLM k n
+          (SCV.schwartzPsiZ (((t + h : ℝ) : ℂ) * Complex.I)
+              (by simpa [Complex.mul_im] using hth) -
+            SCV.schwartzPsiZ z hz)‖
+          = ‖((h : ℂ) * Complex.I) •
+                section43WeightedDerivToBCFCLM k n
+                  (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+                    z hz ((h : ℂ) * Complex.I) hh_im hh1) +
+              ((h : ℂ) * Complex.I) •
+                section43WeightedDerivToBCFCLM k n
+                  ((SchwartzMap.smulLeftCLM ℂ
+                      (fun σ : ℝ => Complex.I * (σ : ℂ)))
+                    (SCV.schwartzPsiZ z hz))‖ := by
+              rw [hsplit]
+      _ ≤ ‖((h : ℂ) * Complex.I) •
+                section43WeightedDerivToBCFCLM k n
+                  (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+                    z hz ((h : ℂ) * Complex.I) hh_im hh1)‖ +
+            ‖((h : ℂ) * Complex.I) •
+                section43WeightedDerivToBCFCLM k n
+                  ((SchwartzMap.smulLeftCLM ℂ
+                      (fun σ : ℝ => Complex.I * (σ : ℂ)))
+                    (SCV.schwartzPsiZ z hz))‖ := norm_add_le _ _
+      _ = ‖((h : ℂ) * Complex.I)‖ *
+              ‖section43WeightedDerivToBCFCLM k n
+                (SCV.schwartzPsiZExpTaylorLinearRemainderQuot
+                  z hz ((h : ℂ) * Complex.I) hh_im hh1)‖ +
+            ‖((h : ℂ) * Complex.I)‖ * D := by
+            simp only [D, norm_smul]
+      _ ≤ ‖((h : ℂ) * Complex.I)‖ *
+              (C * ‖((h : ℂ) * Complex.I)‖) +
+            ‖((h : ℂ) * Complex.I)‖ * D := by
+            gcongr
+  have hδ_small : δ ≤ ε / (2 * (D + C + 1)) := by
+    dsimp [δ]
+    exact le_trans (min_le_right _ _) (min_le_right _ _)
+  have hsmall :
+      ‖((h : ℂ) * Complex.I)‖ *
+            (C * ‖((h : ℂ) * Complex.I)‖) +
+          ‖((h : ℂ) * Complex.I)‖ * D < ε := by
+    have hδfrac : δ * (D + C + 1) < ε := by
+      have hden_pos : 0 < 2 * (D + C + 1) := by nlinarith
+      have htmp : δ * (2 * (D + C + 1)) ≤ ε := by
+        exact (le_div_iff₀ hden_pos).mp hδ_small
+      have hlt : δ * (D + C + 1) ≤ ε / 2 := by
+        nlinarith
+      linarith
+    have hnorm_le :
+        ‖((h : ℂ) * Complex.I)‖ *
+              (C * ‖((h : ℂ) * Complex.I)‖) +
+            ‖((h : ℂ) * Complex.I)‖ * D ≤
+          δ * (D + C + 1) := by
+      have hh_norm_le : ‖((h : ℂ) * Complex.I)‖ ≤ δ := le_of_lt hhδ
+      have hsq :
+          ‖((h : ℂ) * Complex.I)‖ *
+              ‖((h : ℂ) * Complex.I)‖ ≤ δ := by
+        have :
+            ‖((h : ℂ) * Complex.I)‖ *
+                ‖((h : ℂ) * Complex.I)‖ ≤ δ * 1 := by
+          refine mul_le_mul hh_norm_le hh1 ?_ ?_
+          · exact norm_nonneg _
+          · positivity
+        simpa using this
+      calc
+        ‖((h : ℂ) * Complex.I)‖ *
+              (C * ‖((h : ℂ) * Complex.I)‖) +
+            ‖((h : ℂ) * Complex.I)‖ * D
+            = C *
+                (‖((h : ℂ) * Complex.I)‖ *
+                  ‖((h : ℂ) * Complex.I)‖) +
+              D * ‖((h : ℂ) * Complex.I)‖ := by ring
+        _ ≤ C * δ + D * δ := by
+              gcongr
+        _ ≤ δ * (D + C + 1) := by
+              ring_nf
+              nlinarith [hδ_pos, hC_nonneg, hD_nonneg]
+    exact lt_of_le_of_lt hnorm_le hδfrac
+  have hdist_eq :
+      dist
+        (section43WeightedDerivToBCFCLM k n (section43ImagAxisPsiKernel y))
+        (section43WeightedDerivToBCFCLM k n (section43ImagAxisPsiKernel t)) =
+      ‖section43WeightedDerivToBCFCLM k n
+          (SCV.schwartzPsiZ (((t + h : ℝ) : ℂ) * Complex.I)
+              (by simpa [Complex.mul_im] using hth) -
+            SCV.schwartzPsiZ z hz)‖ := by
+    rw [dist_eq_norm, ← map_sub]
+    rw [section43ImagAxisPsiKernel_of_pos hypos,
+      section43ImagAxisPsiKernel_of_pos ht]
+    simp [z, ht_add_h]
+  rw [hdist_eq]
+  exact lt_of_le_of_lt hmain hsmall
+
+theorem continuousOn_section43WeightedDerivToBCFCLM_imagAxisPsiKernel_Ioi
+    (k n : ℕ) :
+    ContinuousOn
+      (fun t : ℝ =>
+        section43WeightedDerivToBCFCLM k n
+          (section43ImagAxisPsiKernel t))
+      (Set.Ioi (0 : ℝ)) := by
+  intro t ht
+  exact
+    (continuousAt_section43WeightedDerivToBCFCLM_imagAxisPsiKernel_of_pos
+      (Set.mem_Ioi.mp ht) k n).continuousWithinAt
+
+private theorem section43_identity_theorem_right_halfplane
+    (f g : ℂ → ℂ)
+    (hf : DifferentiableOn ℂ f {z : ℂ | 0 < z.re})
+    (hg : DifferentiableOn ℂ g {z : ℂ | 0 < z.re})
+    (hagree : ∀ t : ℝ, 0 < t → f (t : ℂ) = g (t : ℂ)) :
+    ∀ z : ℂ, 0 < z.re → f z = g z := by
+  have hU_open : IsOpen {z : ℂ | 0 < z.re} :=
+    isOpen_lt continuous_const Complex.continuous_re
+  have hU_preconn : IsPreconnected {z : ℂ | 0 < z.re} := by
+    apply Convex.isPreconnected
+    intro z hz w hw a b ha hb hab
+    simp only [Set.mem_setOf_eq] at hz hw ⊢
+    calc
+      (a • z + b • w).re = a * z.re + b * w.re := by
+        simp [Complex.add_re]
+      _ > 0 := by
+        rcases ha.lt_or_eq with ha' | ha'
+        · have : 0 ≤ b * w.re := mul_nonneg hb hw.le
+          have : 0 < a * z.re := mul_pos ha' hz
+          linarith
+        · have hab' : b = 1 := by linarith
+          simp [← ha', hab', hw]
+  have hf_an : AnalyticOnNhd ℂ f {z : ℂ | 0 < z.re} :=
+    hf.analyticOnNhd hU_open
+  have hg_an : AnalyticOnNhd ℂ g {z : ℂ | 0 < z.re} :=
+    hg.analyticOnNhd hU_open
+  have h1_mem : (1 : ℂ) ∈ {z : ℂ | 0 < z.re} := by simp
+  have hfg_an : AnalyticAt ℂ (f - g) 1 :=
+    (hf_an 1 h1_mem).sub (hg_an 1 h1_mem)
+  have hfreq : ∃ᶠ z in nhdsWithin (1 : ℂ) {(1 : ℂ)}ᶜ, (f - g) z = 0 := by
+    rw [Filter.Frequently]
+    intro hev
+    rw [Filter.Eventually] at hev
+    rw [(nhdsWithin_basis_open 1 {(1 : ℂ)}ᶜ).mem_iff] at hev
+    obtain ⟨u, ⟨h1u, hu_open⟩, hus⟩ := hev
+    obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.mp hu_open 1 h1u
+    have hmem : ((1 + ε / 2 : ℝ) : ℂ) ∈ u := by
+      apply hball
+      rw [Metric.mem_ball, Complex.dist_eq]
+      have hsub : ((1 + ε / 2 : ℝ) : ℂ) - 1 =
+          ((ε / 2 : ℝ) : ℂ) := by
+        push_cast
+        ring
+      rw [hsub]
+      simp only [Complex.norm_real, Real.norm_eq_abs, abs_of_pos (half_pos hε)]
+      linarith
+    have hne : ((1 + ε / 2 : ℝ) : ℂ) ≠ (1 : ℂ) := by
+      intro heq
+      have := congr_arg Complex.re heq
+      simp at this
+      linarith [half_pos hε]
+    have hzero : (f - g) ((1 + ε / 2 : ℝ) : ℂ) = 0 := by
+      simp only [Pi.sub_apply, sub_eq_zero]
+      exact hagree (1 + ε / 2) (by linarith)
+    exact hus ⟨hmem, hne⟩ hzero
+  have hev : ∀ᶠ z in nhds (1 : ℂ), (f - g) z = 0 :=
+    hfg_an.frequently_zero_iff_eventually_zero.mp hfreq
+  have hfg_an_on : AnalyticOnNhd ℂ (f - g) {z : ℂ | 0 < z.re} :=
+    hf_an.sub hg_an
+  have heqOn : Set.EqOn (f - g) 0 {z : ℂ | 0 < z.re} :=
+    hfg_an_on.eqOn_zero_of_preconnected_of_eventuallyEq_zero
+      hU_preconn h1_mem hev
+  intro z hz
+  have := heqOn hz
+  simp only [Pi.sub_apply, Pi.zero_apply, sub_eq_zero] at this
+  exact this
+
+private theorem section43_identity_theorem_upperHalfPlane
+    (f g : ℂ → ℂ)
+    (hf : DifferentiableOn ℂ f SCV.upperHalfPlane)
+    (hg : DifferentiableOn ℂ g SCV.upperHalfPlane)
+    (hagree : ∀ η : ℝ, 0 < η → f ((η : ℂ) * Complex.I) = g ((η : ℂ) * Complex.I)) :
+    ∀ z : ℂ, 0 < z.im → f z = g z := by
+  let fR : ℂ → ℂ := fun w => f (Complex.I * w)
+  let gR : ℂ → ℂ := fun w => g (Complex.I * w)
+  have hmap : Set.MapsTo (fun w : ℂ => Complex.I * w)
+      {z : ℂ | 0 < z.re} SCV.upperHalfPlane := by
+    intro z hz
+    simpa [SCV.upperHalfPlane, Complex.mul_im] using hz
+  have hmul :
+      DifferentiableOn ℂ (fun w : ℂ => Complex.I * w)
+        {z : ℂ | 0 < z.re} := by
+    intro z hz
+    simpa using
+      (((differentiableAt_id : DifferentiableAt ℂ (fun y : ℂ => y) z).const_mul
+        Complex.I).differentiableWithinAt)
+  have hfR : DifferentiableOn ℂ fR {z : ℂ | 0 < z.re} := hf.comp hmul hmap
+  have hgR : DifferentiableOn ℂ gR {z : ℂ | 0 < z.re} := hg.comp hmul hmap
+  have hagreeR : ∀ t : ℝ, 0 < t → fR (t : ℂ) = gR (t : ℂ) := by
+    intro t ht
+    simpa [fR, gR, mul_comm] using hagree t ht
+  intro z hz
+  have hzR : 0 < (-Complex.I * z).re := by
+    simpa [Complex.mul_re] using hz
+  have hmain :=
+    section43_identity_theorem_right_halfplane fR gR hfR hgR hagreeR
+      (-Complex.I * z) hzR
+  dsimp [fR, gR] at hmain
+  convert hmain using 1 <;> ring_nf <;> simp
+
+theorem integrable_section43WeightedProbe_imagAxisPsiKernel_source
+    (g : Section43CompactPositiveTimeSource1D)
+    (k n : ℕ) :
+    Integrable
+      (fun t : ℝ =>
+        g.f t •
+          section43WeightedDerivToBCFCLM k n
+            (section43ImagAxisPsiKernel t)) := by
+  obtain ⟨δ, R, hδ_pos, _hδR, hsupport⟩ :=
+    exists_positive_Icc_bounds_of_compactPositiveTimeSource g
+  let F : ℝ → (ℝ →ᵇ ℂ) := fun t =>
+    g.f t • section43WeightedDerivToBCFCLM k n
+      (section43ImagAxisPsiKernel t)
+  have hsupp : Function.support F ⊆ Set.Icc δ R := by
+    intro t htF
+    have hgf : g.f t ≠ 0 := by
+      intro hzero
+      apply htF
+      simp [F, hzero]
+    exact hsupport (subset_tsupport _ hgf)
+  have hIcc_subset_Ioi : Set.Icc δ R ⊆ Set.Ioi (0 : ℝ) := by
+    intro t ht
+    exact lt_of_lt_of_le hδ_pos ht.1
+  have hcont_probe :
+      ContinuousOn
+        (fun t : ℝ =>
+          section43WeightedDerivToBCFCLM k n
+            (section43ImagAxisPsiKernel t))
+        (Set.Icc δ R) :=
+    (continuousOn_section43WeightedDerivToBCFCLM_imagAxisPsiKernel_Ioi k n).mono
+      hIcc_subset_Ioi
+  have hcont_F : ContinuousOn F (Set.Icc δ R) := by
+    exact g.f.continuous.continuousOn.smul hcont_probe
+  have hIntOn : IntegrableOn F (Set.Icc δ R) :=
+    hcont_F.integrableOn_compact isCompact_Icc
+  exact (integrableOn_iff_integrable_of_support_subset hsupp).mp hIntOn
+
+/-- The finite-probe imaginary-axis family.  This is Banach-valued, unlike the
+unavailable `SchwartzMap`-valued Bochner integral. -/
+noncomputable def section43ProbeImagAxisFamily
+    (s : Finset (ℕ × ℕ)) (g : Section43CompactPositiveTimeSource1D) :
+    ℝ → ((p : ↑s.attach) → (ℝ →ᵇ ℂ)) :=
+  fun t => g.f t • section43ProbeCLM s (section43ImagAxisPsiKernel t)
+
+theorem section43ProbeImagAxisFamily_apply
+    (s : Finset (ℕ × ℕ)) (g : Section43CompactPositiveTimeSource1D)
+    (t : ℝ) (p : ↑s.attach) (σ : ℝ) :
+    section43ProbeImagAxisFamily s g t p σ =
+      g.f t *
+        section43WeightedDerivToBCFCLM p.1.1.1 p.1.1.2
+          (section43ImagAxisPsiKernel t) σ := by
+  simp [section43ProbeImagAxisFamily, section43ProbeCLM, smul_eq_mul]
+
+theorem integrable_section43Probe_imagAxisPsiKernel_source
+    (s : Finset (ℕ × ℕ))
+    (g : Section43CompactPositiveTimeSource1D) :
+    Integrable (section43ProbeImagAxisFamily s g) := by
+  refine Integrable.of_eval ?_
+  intro p
+  simpa [section43ProbeImagAxisFamily, section43ProbeCLM] using
+    integrable_section43WeightedProbe_imagAxisPsiKernel_source
+      g p.1.1.1 p.1.1.2
+
+theorem section43Probe_representative_component_apply_eq_integral_probeImagAxisFamily
+    (s : Finset (ℕ × ℕ)) (g : Section43CompactPositiveTimeSource1D)
+    (p : ↑s.attach) (σ : ℝ) :
+    section43ProbeCLM s
+        (section43OneSidedLaplaceSchwartzRepresentative1D g) p σ =
+      ∫ t : ℝ, section43ProbeImagAxisFamily s g t p σ := by
+  simpa [section43ProbeImagAxisFamily_apply] using
+    section43WeightedDerivToBCFCLM_representative_eq_integral_kernel_apply
+      g p.1.1.1 p.1.1.2 σ
+
+/-- Once the finite-probe imaginary-axis family is known to be Bochner
+integrable, the scalar component identities assemble into the Banach finite
+product identity. -/
+theorem section43Probe_integral_imagAxisPsiKernel_of_integrable
+    (s : Finset (ℕ × ℕ)) (g : Section43CompactPositiveTimeSource1D)
+    (hInt : Integrable (section43ProbeImagAxisFamily s g)) :
+    section43ProbeCLM s (section43OneSidedLaplaceSchwartzRepresentative1D g) =
+      ∫ t : ℝ, section43ProbeImagAxisFamily s g t := by
+  ext p σ
+  have h_eval_p :
+      (∫ t : ℝ, section43ProbeImagAxisFamily s g t) p =
+        ∫ t : ℝ, section43ProbeImagAxisFamily s g t p := by
+    simpa using
+      ((ContinuousLinearMap.proj
+          (R := ℂ) (φ := fun _ : ↑s.attach => ℝ →ᵇ ℂ) p).integral_comp_comm
+        hInt).symm
+  have hInt_p :
+      Integrable (fun t : ℝ => section43ProbeImagAxisFamily s g t p) :=
+    (ContinuousLinearMap.proj
+      (R := ℂ) (φ := fun _ : ↑s.attach => ℝ →ᵇ ℂ) p).integrable_comp hInt
+  have h_eval_σ :
+      (∫ t : ℝ, section43ProbeImagAxisFamily s g t p) σ =
+        ∫ t : ℝ, section43ProbeImagAxisFamily s g t p σ := by
+    simpa using
+      ((BoundedContinuousFunction.evalCLM ℂ σ).integral_comp_comm
+        hInt_p).symm
+  rw [h_eval_p, h_eval_σ]
+  exact
+    section43Probe_representative_component_apply_eq_integral_probeImagAxisFamily
+      s g p σ
+
+theorem section43Probe_integral_imagAxisPsiKernel
+    (s : Finset (ℕ × ℕ)) (g : Section43CompactPositiveTimeSource1D) :
+    section43ProbeCLM s (section43OneSidedLaplaceSchwartzRepresentative1D g) =
+      ∫ t : ℝ, section43ProbeImagAxisFamily s g t :=
+  section43Probe_integral_imagAxisPsiKernel_of_integrable s g
+    (integrable_section43Probe_imagAxisPsiKernel_source s g)
+
+/-- Weak scalar Fubini through a fixed finite-probe factorization.  The only
+remaining analytic hypothesis is the honest Bochner integrability of the
+finite-probe imaginary-axis family. -/
+theorem section43OneSidedLaplace_scalar_fubini_apply_of_probe_factorization
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ)
+    (g : Section43CompactPositiveTimeSource1D)
+    (s : Finset (ℕ × ℕ))
+    (G : ((p : ↑s.attach) → (ℝ →ᵇ ℂ)) →L[ℂ] ℂ)
+    (hTG : T = G.comp (section43ProbeCLM s))
+    (hInt : Integrable (section43ProbeImagAxisFamily s g)) :
+    T (section43OneSidedLaplaceSchwartzRepresentative1D g) =
+      ∫ t : ℝ, T (section43ImagAxisPsiKernel t) * g.f t := by
+  have hT_apply :
+      ∀ f : SchwartzMap ℝ ℂ, T f = G (section43ProbeCLM s f) := by
+    intro f
+    exact congrArg (fun H => H f) hTG
+  calc
+    T (section43OneSidedLaplaceSchwartzRepresentative1D g)
+        = G (section43ProbeCLM s
+            (section43OneSidedLaplaceSchwartzRepresentative1D g)) := by
+            exact hT_apply _
+    _ = G (∫ t : ℝ, section43ProbeImagAxisFamily s g t) := by
+          rw [section43Probe_integral_imagAxisPsiKernel_of_integrable s g hInt]
+    _ = ∫ t : ℝ, G (section43ProbeImagAxisFamily s g t) := by
+          simpa using (G.integral_comp_comm hInt).symm
+    _ = ∫ t : ℝ, T (section43ImagAxisPsiKernel t) * g.f t := by
+          refine integral_congr_ae ?_
+          filter_upwards with t
+          rw [hT_apply (section43ImagAxisPsiKernel t)]
+          simp [section43ProbeImagAxisFamily, map_smul, smul_eq_mul, mul_comm]
+
+theorem section43OneSidedLaplace_scalar_fubini_apply
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ)
+    (g : Section43CompactPositiveTimeSource1D) :
+    T (section43OneSidedLaplaceSchwartzRepresentative1D g) =
+      ∫ t : ℝ, T (section43ImagAxisPsiKernel t) * g.f t := by
+  obtain ⟨s, G, hTG⟩ := section43_exists_probe_factorization T
+  exact section43OneSidedLaplace_scalar_fubini_apply_of_probe_factorization
+    T g s G hTG (integrable_section43Probe_imagAxisPsiKernel_source s g)
+
+theorem section43OneSidedAnnihilatorFL_integral_zero_of_annihilates_laplace
+    (A : Section43PositiveEnergy1D →L[ℂ] ℂ)
+    (hA :
+      ∀ g : Section43CompactPositiveTimeSource1D,
+        A (section43OneSidedLaplaceCompactTransform1D g) = 0)
+    (g : Section43CompactPositiveTimeSource1D) :
+    ∫ t : ℝ,
+      section43OneSidedAnnihilatorFLOnImag A t * g.f t = 0 := by
+  let T : SchwartzMap ℝ ℂ →L[ℂ] ℂ :=
+    A.comp section43PositiveEnergyQuotientMap1D
+  have hF := section43OneSidedLaplace_scalar_fubini_apply T g
+  calc
+    ∫ t : ℝ, section43OneSidedAnnihilatorFLOnImag A t * g.f t
+        = ∫ t : ℝ, T (section43ImagAxisPsiKernel t) * g.f t := by
+            refine integral_congr_ae ?_
+            filter_upwards with t
+            rw [section43OneSidedAnnihilatorFLOnImag_eq_apply_kernel]
+            rfl
+    _ = T (section43OneSidedLaplaceSchwartzRepresentative1D g) := hF.symm
+    _ = A (section43PositiveEnergyQuotientMap1D
+          (section43OneSidedLaplaceSchwartzRepresentative1D g)) := rfl
+    _ = A (section43OneSidedLaplaceCompactTransform1D g) := by
+          rw [section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient]
+    _ = 0 := hA g
+
+theorem section43OneSidedAnnihilatorFLOnImag_eq_zero_of_annihilates_laplace
+    (A : Section43PositiveEnergy1D →L[ℂ] ℂ)
+    (hA :
+      ∀ g : Section43CompactPositiveTimeSource1D,
+        A (section43OneSidedLaplaceCompactTransform1D g) = 0) :
+    ∀ t : ℝ, 0 < t →
+      section43OneSidedAnnihilatorFLOnImag A t = 0 := by
+  have hEqOn :
+      Set.EqOn (section43OneSidedAnnihilatorFLOnImag A)
+        (fun _ : ℝ => 0) (Set.Ioi (0 : ℝ)) := by
+    refine SCV.eqOn_open_of_compactSupport_schwartz_integral_eq_of_continuousOn
+      (E := ℝ) isOpen_Ioi
+      (continuousOn_section43OneSidedAnnihilatorFLOnImag_Ioi A)
+      continuousOn_const ?_
+    intro f hf_compact hf_support
+    let g : Section43CompactPositiveTimeSource1D :=
+      ⟨f, hf_support, hf_compact⟩
+    have hzero :=
+      section43OneSidedAnnihilatorFL_integral_zero_of_annihilates_laplace
+        A hA g
+    simpa [g] using hzero
+  intro t ht
+  exact hEqOn (Set.mem_Ioi.mpr ht)
+
+theorem section43OneSidedAnnihilatorFL_eq_zero_of_annihilates_laplace
+    (A : Section43PositiveEnergy1D →L[ℂ] ℂ)
+    (hA :
+      ∀ g : Section43CompactPositiveTimeSource1D,
+        A (section43OneSidedLaplaceCompactTransform1D g) = 0) :
+    ∀ (z : ℂ) (hz : 0 < z.im),
+      section43OneSidedAnnihilatorFL A z hz = 0 := by
+  let T := section43PositiveEnergy1D_to_oneSidedFourierFunctional A
+  let F : ℂ → ℂ := fun z =>
+    if hz : 0 < z.im then
+      SCV.fourierLaplaceExt T z hz
+    else
+      0
+  have hF_diff : DifferentiableOn ℂ F SCV.upperHalfPlane := by
+    simpa [F, T] using (SCV.fourierLaplaceExt_differentiableOn T)
+  have haxis : ∀ η : ℝ, 0 < η → F ((η : ℂ) * Complex.I) = 0 := by
+    intro η hη
+    have hOn :=
+      section43OneSidedAnnihilatorFLOnImag_eq_zero_of_annihilates_laplace
+        A hA η hη
+    rw [section43OneSidedAnnihilatorFLOnImag_of_pos A hη] at hOn
+    have him : 0 < (((η : ℂ) * Complex.I).im) := by
+      simpa [Complex.mul_im] using hη
+    have hEq :=
+      section43OneSidedAnnihilatorFL_eq_fourierLaplaceExt_to_oneSided
+        A (((η : ℂ) * Complex.I)) him
+    have hExtZero :
+        SCV.fourierLaplaceExt T (((η : ℂ) * Complex.I)) him = 0 := by
+      simpa [T] using hEq.symm.trans hOn
+    simpa [F, Complex.mul_im, hη] using hExtZero
+  intro z hz
+  have hFz := section43_identity_theorem_upperHalfPlane F 0
+    hF_diff (differentiableOn_const 0) haxis z hz
+  have hEq :=
+    section43OneSidedAnnihilatorFL_eq_fourierLaplaceExt_to_oneSided A z hz
+  dsimp [F] at hFz
+  rw [dif_pos hz] at hFz
+  exact hEq.trans (by simpa [T] using hFz)
+
+theorem section43OneSidedLaplaceCompactTransform1D_dual_annihilator
+    (A : Section43PositiveEnergy1D →L[ℂ] ℂ)
+    (hA :
+      ∀ g : Section43CompactPositiveTimeSource1D,
+        A (section43OneSidedLaplaceCompactTransform1D g) = 0) :
+    A = 0 :=
+  section43PositiveEnergy1D_ext_of_FL_zero A
+    (section43OneSidedAnnihilatorFL_eq_zero_of_annihilates_laplace A hA)
+
+theorem section43OneSidedLaplaceCompactTransform1D_map_add
+    (g h : Section43CompactPositiveTimeSource1D) :
+    section43OneSidedLaplaceCompactTransform1D (g + h) =
+      section43OneSidedLaplaceCompactTransform1D g +
+        section43OneSidedLaplaceCompactTransform1D h := by
+  rw [section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient,
+    section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient,
+    section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient]
+  rw [← map_add]
+  apply section43PositiveEnergyQuotientMap1D_eq_of_eqOn_nonneg
+  intro σ hσ
+  have hσ0 : 0 ≤ σ := Set.mem_Ici.mp hσ
+  change
+    section43OneSidedLaplaceSchwartzRepresentative1D (g + h) σ =
+      section43OneSidedLaplaceSchwartzRepresentative1D g σ +
+        section43OneSidedLaplaceSchwartzRepresentative1D h σ
+  rw [section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg (g + h) hσ0,
+    section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg g hσ0,
+    section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg h hσ0]
+  unfold section43OneSidedLaplaceRaw
+  rw [← integral_add (section43OneSidedLaplaceRaw_integrable_of_nonneg g hσ0)
+    (section43OneSidedLaplaceRaw_integrable_of_nonneg h hσ0)]
+  refine integral_congr_ae ?_
+  filter_upwards with t
+  change
+    Complex.exp (-(t : ℂ) * (σ : ℂ)) * (g.f t + h.f t) =
+      Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t +
+        Complex.exp (-(t : ℂ) * (σ : ℂ)) * h.f t
+  ring
+
+theorem section43OneSidedLaplaceCompactTransform1D_map_smul
+    (c : ℂ) (g : Section43CompactPositiveTimeSource1D) :
+    section43OneSidedLaplaceCompactTransform1D (c • g) =
+      c • section43OneSidedLaplaceCompactTransform1D g := by
+  rw [section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient,
+    section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient]
+  rw [← map_smul]
+  apply section43PositiveEnergyQuotientMap1D_eq_of_eqOn_nonneg
+  intro σ hσ
+  have hσ0 : 0 ≤ σ := Set.mem_Ici.mp hσ
+  change
+    section43OneSidedLaplaceSchwartzRepresentative1D (c • g) σ =
+      c • section43OneSidedLaplaceSchwartzRepresentative1D g σ
+  rw [section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg (c • g) hσ0,
+    section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg g hσ0]
+  unfold section43OneSidedLaplaceRaw
+  change
+    ∫ t : ℝ, Complex.exp (-(t : ℂ) * (σ : ℂ)) * (c * g.f t) =
+      c * ∫ t : ℝ, Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t
+  calc
+    ∫ t : ℝ, Complex.exp (-(t : ℂ) * (σ : ℂ)) * (c * g.f t)
+        = ∫ t : ℝ, c * (Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t) := by
+            refine integral_congr_ae ?_
+            filter_upwards with t
+            ring
+    _ = c * ∫ t : ℝ,
+          Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t := by
+          simpa using
+            (integral_const_mul c
+              (fun t : ℝ => Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t))
+
+/-- The compact strict-positive one-sided Laplace transform as a linear map.
+This exposes its range as a genuine submodule for the Hahn-Banach density step. -/
+noncomputable def section43OneSidedLaplaceCompactTransform1DLinearMap :
+    Section43CompactPositiveTimeSource1D →ₗ[ℂ] Section43PositiveEnergy1D where
+  toFun := section43OneSidedLaplaceCompactTransform1D
+  map_add' := section43OneSidedLaplaceCompactTransform1D_map_add
+  map_smul' := section43OneSidedLaplaceCompactTransform1D_map_smul
+
+theorem dense_section43OneSidedLaplaceCompactTransform1D_preimage :
+    Dense
+      (section43PositiveEnergyQuotientMap1D ⁻¹'
+        Set.range section43OneSidedLaplaceCompactTransform1D) := by
+  let L := section43OneSidedLaplaceCompactTransform1DLinearMap
+  let Mq : Submodule ℂ Section43PositiveEnergy1D := LinearMap.range L
+  let q := section43PositiveEnergyQuotientMap1D
+  let S : Submodule ℂ (SchwartzMap ℝ ℂ) := Mq.comap q.toLinearMap
+  have htarget :
+      section43PositiveEnergyQuotientMap1D ⁻¹'
+          Set.range section43OneSidedLaplaceCompactTransform1D =
+        (S : Set (SchwartzMap ℝ ℂ)) := by
+    ext φ
+    simp [S, Mq, L, q, section43OneSidedLaplaceCompactTransform1DLinearMap]
+  rw [htarget]
+  rw [Submodule.dense_iff_topologicalClosure_eq_top]
+  by_contra hS
+  have hx : ∃ x : SchwartzMap ℝ ℂ, x ∉ S.topologicalClosure := by
+    by_contra hx
+    apply hS
+    rw [Submodule.eq_top_iff']
+    intro x
+    by_contra hx'
+    exact hx ⟨x, hx'⟩
+  letI : Module ℝ (SchwartzMap ℝ ℂ) :=
+    Module.complexToReal (SchwartzMap ℝ ℂ)
+  haveI : IsScalarTower ℝ ℂ (SchwartzMap ℝ ℂ) :=
+    IsScalarTower.complexToReal (M := ℂ) (E := SchwartzMap ℝ ℂ)
+  have hconv : Convex ℝ (S.topologicalClosure : Set (SchwartzMap ℝ ℂ)) := by
+    intro x hx y hy a b _ha _hb _hab
+    exact S.topologicalClosure.add_mem
+      (S.topologicalClosure.smul_mem (a : ℂ) hx)
+      (S.topologicalClosure.smul_mem (b : ℂ) hy)
+  rcases hx with ⟨x, hx⟩
+  obtain ⟨f, u, hleft, hright⟩ :=
+    geometric_hahn_banach_closed_point
+      hconv S.isClosed_topologicalClosure hx
+  have hu_pos : 0 < u := by
+    have hzero := hleft 0 S.topologicalClosure.zero_mem
+    simpa using hzero
+  have hf_zero :
+      ∀ y ∈ S.topologicalClosure, f y = 0 := by
+    intro y hy
+    by_contra hre
+    let r : ℝ := (u + 1) / f y
+    have hlt := hleft ((r : ℂ) • y)
+      (S.topologicalClosure.smul_mem (r : ℂ) hy)
+    have hreval : f ((r : ℂ) • y) = u + 1 := by
+      calc
+        f ((r : ℂ) • y) = r * f y := by
+          rw [Complex.coe_smul]
+          simp [smul_eq_mul]
+        _ = u + 1 := by
+          dsimp [r]
+          field_simp [hre]
+    have : ¬ u + 1 < u := by linarith
+    exact this (hreval ▸ hlt)
+  let F : SchwartzMap ℝ ℂ →L[ℂ] ℂ :=
+    StrongDual.extendRCLike (𝕜 := ℂ) f
+  have hF_zero :
+      ∀ y ∈ S.topologicalClosure, F y = 0 := by
+    intro y hy
+    have hyI : (Complex.I : ℂ) • y ∈ S.topologicalClosure :=
+      S.topologicalClosure.smul_mem Complex.I hy
+    rw [StrongDual.extendRCLike_apply]
+    simp [hf_zero y hy, hf_zero ((Complex.I : ℂ) • y) hyI]
+  have hker :
+      section43PositiveEnergyVanishingSubmodule1D ≤
+        LinearMap.ker F.toLinearMap := by
+    intro φ hφ
+    rw [LinearMap.mem_ker]
+    have hφS : φ ∈ S := by
+      change q φ ∈ Mq
+      have hqzero : q φ = 0 := by
+        change (Submodule.Quotient.mk φ : Section43PositiveEnergy1D) = 0
+        exact (Submodule.Quotient.mk_eq_zero _).mpr hφ
+      rw [hqzero]
+      exact Mq.zero_mem
+    exact hF_zero φ (S.le_topologicalClosure hφS)
+  let A_lin : Section43PositiveEnergy1D →ₗ[ℂ] ℂ :=
+    section43PositiveEnergyVanishingSubmodule1D.liftQ F.toLinearMap hker
+  let A : Section43PositiveEnergy1D →L[ℂ] ℂ :=
+    ContinuousLinearMap.mk A_lin (by
+      refine
+        section43PositiveEnergyVanishingSubmodule1D.isOpenQuotientMap_mkQ.isQuotientMap.continuous_iff.2
+          ?_
+      simpa [A_lin, F, Function.comp] using F.continuous)
+  have hAq :
+      ∀ φ : SchwartzMap ℝ ℂ, A (q φ) = F φ := by
+    intro φ
+    change A_lin (Submodule.Quotient.mk φ) = F φ
+    simp [A_lin]
+  have hA_on_range :
+      ∀ g : Section43CompactPositiveTimeSource1D,
+        A (section43OneSidedLaplaceCompactTransform1D g) = 0 := by
+    intro g
+    let φ := section43OneSidedLaplaceSchwartzRepresentative1D g
+    have hφS : φ ∈ S := by
+      change q φ ∈ Mq
+      rw [← section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient g]
+      change L g ∈ LinearMap.range L
+      exact LinearMap.mem_range_self L g
+    calc
+      A (section43OneSidedLaplaceCompactTransform1D g)
+          = A (q φ) := by
+              rw [section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient]
+      _ = F φ := hAq φ
+      _ = 0 := hF_zero φ (S.le_topologicalClosure hφS)
+  have hA_zero : A = 0 :=
+    section43OneSidedLaplaceCompactTransform1D_dual_annihilator A hA_on_range
+  have hF_zero_all : F = 0 := by
+    ext φ
+    have h := hAq φ
+    rw [hA_zero] at h
+    simpa using h.symm
+  have hfx_zero : f x = 0 := by
+    have hre := StrongDual.re_extendRCLike_apply (𝕜 := ℂ) f x
+    simpa [F, hF_zero_all] using hre.symm
+  have : ¬ u < (0 : ℝ) := not_lt_of_ge hu_pos.le
+  apply this
+  simpa [hfx_zero] using hright
+
+theorem denseRange_section43OneSidedLaplaceCompactTransform1DLinearMap :
+    DenseRange section43OneSidedLaplaceCompactTransform1DLinearMap := by
+  have hq :
+      IsOpenQuotientMap
+        (section43PositiveEnergyQuotientMap1D :
+          SchwartzMap ℝ ℂ → Section43PositiveEnergy1D) := by
+    simpa [section43PositiveEnergyQuotientMap1D] using
+      section43PositiveEnergyVanishingSubmodule1D.isOpenQuotientMap_mkQ
+  have hdense_set : Dense (Set.range section43OneSidedLaplaceCompactTransform1D) :=
+    hq.dense_preimage_iff.mp
+      dense_section43OneSidedLaplaceCompactTransform1D_preimage
+  simpa [DenseRange, section43OneSidedLaplaceCompactTransform1DLinearMap] using
+    hdense_set
+
+end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceOrderedDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceOrderedDensity.lean
@@ -1,0 +1,217 @@
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceSpatialDensity
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceClosure
+
+/-!
+# Section 4.3 ordered-source density bridge
+
+This downstream companion transports the compiled time-Laplace /
+spatial-Fourier density packet from difference coordinates back to compact
+ordered Euclidean sources.
+-/
+
+noncomputable section
+
+open scoped Topology FourierTransform BoundedContinuousFunction BigOperators
+open Set MeasureTheory Filter
+
+namespace OSReconstruction
+
+/-- Positive time-difference coordinates give ordered positive Euclidean
+times after applying the inverse difference-coordinate map. -/
+theorem section43DiffCoordRealCLE_symm_mem_orderedPositiveTimeRegion_of_pos_time
+    (d n : ℕ) [NeZero d]
+    {δ : NPointDomain d n}
+    (hδ : ∀ i : Fin n, 0 < δ i 0) :
+    (section43DiffCoordRealCLE d n).symm δ ∈
+      OrderedPositiveTimeRegion d n := by
+  intro i
+  constructor
+  · rw [section43DiffCoordRealCLE_symm_apply]
+    rw [Finset.sum_fin_eq_sum_range]
+    have hnonempty : (Finset.range (i.val + 1)).Nonempty := by
+      exact ⟨0, by simp⟩
+    refine Finset.sum_pos ?_ hnonempty
+    intro r hr
+    have hrlt : r < i.val + 1 := Finset.mem_range.mp hr
+    simpa [hrlt] using hδ ⟨r, by
+        have hr' := Finset.mem_range.mp hr
+        omega⟩
+  · intro j hij
+    rw [section43DiffCoordRealCLE_symm_apply,
+      section43DiffCoordRealCLE_symm_apply]
+    rw [Finset.sum_fin_eq_sum_range, Finset.sum_fin_eq_sum_range]
+    have hijv : i.val < j.val := by exact hij
+    have hle : i.val + 1 ≤ j.val + 1 := Nat.succ_le_succ hijv.le
+    let fj : ℕ → ℝ := fun r =>
+      if h : r < j.val + 1 then
+        δ ⟨(⟨r, h⟩ : Fin (j.val + 1)).val, by
+          have hj := j.isLt
+          omega⟩ 0
+      else 0
+    have hblock_nonempty :
+        (Finset.Ico (i.val + 1) (j.val + 1)).Nonempty := by
+      refine ⟨i.val + 1, ?_⟩
+      exact Finset.mem_Ico.mpr ⟨le_rfl, Nat.succ_lt_succ hijv⟩
+    have hleft :
+        (∑ r ∈ Finset.range (i.val + 1),
+          if h : r < i.val + 1 then
+            δ ⟨(⟨r, h⟩ : Fin (i.val + 1)).val, by
+              have hi := i.isLt
+              omega⟩ 0
+          else 0) =
+        (∑ r ∈ Finset.range (i.val + 1), fj r) := by
+      refine Finset.sum_congr rfl ?_
+      intro r hr
+      have hri : r < i.val + 1 := Finset.mem_range.mp hr
+      have hrj : r < j.val + 1 := lt_of_lt_of_le hri hle
+      have hrjle : r ≤ j.val := Nat.lt_succ_iff.mp hrj
+      rw [dif_pos hri]
+      simp [fj, hrjle]
+    have hblock_pos :
+        0 < ∑ r ∈ Finset.Ico (i.val + 1) (j.val + 1), fj r := by
+      refine Finset.sum_pos ?_ hblock_nonempty
+      intro r hr
+      have hrj : r < j.val + 1 := (Finset.mem_Ico.mp hr).2
+      have hrjle : r ≤ j.val := Nat.lt_succ_iff.mp hrj
+      simpa [fj, hrjle] using hδ ⟨r, by
+        have hj := j.isLt
+        omega⟩
+    rw [hleft]
+    change (∑ r ∈ Finset.range (i.val + 1), fj r) <
+      ∑ r ∈ Finset.range (j.val + 1), fj r
+    rw [← Finset.sum_range_add_sum_Ico fj hle]
+    exact lt_add_of_pos_right _ hblock_pos
+
+/-- Push a compact strict-positive source in difference coordinates back to an
+ordered compact Euclidean source. -/
+noncomputable def section43OrderedSourceOfTimeSpatialSource
+    (d n : ℕ) [NeZero d]
+    (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+    Section43CompactOrderedSource d n where
+  f := SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+    (section43DiffCoordRealCLE d n) G.f
+  ordered := by
+    intro y hy
+    have hpre :
+        section43DiffCoordRealCLE d n y ∈
+          tsupport (G.f : NPointDomain d n → ℂ) := by
+      exact tsupport_comp_subset_preimage
+        (G.f : NPointDomain d n → ℂ)
+        (section43DiffCoordRealCLE d n).continuous hy
+    have hpos : ∀ i : Fin n, 0 < (section43DiffCoordRealCLE d n y) i 0 :=
+      G.positive hpre
+    have hy_ordered :=
+      section43DiffCoordRealCLE_symm_mem_orderedPositiveTimeRegion_of_pos_time
+        d n (δ := section43DiffCoordRealCLE d n y) hpos
+    simpa using hy_ordered
+  compact := by
+    let e := section43DiffCoordRealCLE d n
+    change HasCompactSupport
+      ((SchwartzMap.compCLMOfContinuousLinearEquiv ℂ e G.f :
+          SchwartzNPoint d n) : NPointDomain d n → ℂ)
+    have htsupport :
+        tsupport
+          ((SchwartzMap.compCLMOfContinuousLinearEquiv ℂ e G.f :
+              SchwartzNPoint d n) : NPointDomain d n → ℂ) =
+          e.toHomeomorph ⁻¹' tsupport (G.f : NPointDomain d n → ℂ) := by
+      simpa [SchwartzMap.compCLMOfContinuousLinearEquiv_apply, e] using
+        (tsupport_comp_eq_preimage
+          (g := (G.f : NPointDomain d n → ℂ)) e.toHomeomorph)
+    have hpre_eq :
+        e.toHomeomorph ⁻¹' tsupport (G.f : NPointDomain d n → ℂ) =
+          e.symm '' tsupport (G.f : NPointDomain d n → ℂ) := by
+      ext y
+      constructor
+      · intro hy
+        refine ⟨e y, hy, ?_⟩
+        simp [e]
+      · rintro ⟨δ, hδ, rfl⟩
+        simpa [e] using hδ
+    rw [HasCompactSupport, htsupport, hpre_eq]
+    exact G.compact.isCompact.image e.symm.continuous
+
+/-- Pulling back the ordered pushforward recovers the original
+difference-coordinate source. -/
+theorem section43DiffPullbackCLM_orderedSourceOfTimeSpatialSource
+    (d n : ℕ) [NeZero d]
+    (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+    section43DiffPullbackCLM d n
+      ⟨(section43OrderedSourceOfTimeSpatialSource d n G).f,
+        (section43OrderedSourceOfTimeSpatialSource d n G).ordered⟩ =
+      G.f := by
+  ext δ
+  rw [section43DiffPullbackCLM_apply]
+  change
+    (SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+      (section43DiffCoordRealCLE d n) G.f)
+        ((section43DiffCoordRealCLE d n).symm δ) =
+    G.f δ
+  simp [SchwartzMap.compCLMOfContinuousLinearEquiv_apply]
+
+/-- A time-Laplace / spatial-Fourier representative for a difference source is
+an OS-I Fourier-Laplace representative for its ordered pushforward. -/
+theorem section43FourierLaplaceRepresentative_of_timeSpatialRepresentative
+    (d n : ℕ) [NeZero d]
+    {G : Section43CompactStrictPositiveTimeSpatialSource d n}
+    {Ψ : SchwartzNPoint d n}
+    (hΨ : section43TimeLaplaceSpatialFourierRepresentative d n G Ψ) :
+    section43FourierLaplaceRepresentative d n
+      ⟨(section43OrderedSourceOfTimeSpatialSource d n G).f,
+        (section43OrderedSourceOfTimeSpatialSource d n G).ordered⟩ Ψ := by
+  intro q hq
+  rw [hΨ q hq]
+  rw [section43FourierLaplaceIntegral]
+  congr with τ
+  rw [section43DiffPullbackCLM_orderedSourceOfTimeSpatialSource]
+
+/-- The Layer-3 representative target lies in the preimage of the genuine
+compact ordered Fourier-Laplace transform component image. -/
+theorem section43TimeLaplaceSpatialFourierTarget_subset_component_preimage
+    (d n : ℕ) [NeZero d] :
+    section43TimeLaplaceSpatialFourierTarget d n ⊆
+      (section43PositiveEnergyQuotientMap (d := d) n) ⁻¹'
+        Set.range (section43FourierLaplaceTransformComponentMap d n) := by
+  intro Φ hΦ
+  rcases hΦ with ⟨G, Ψ, hΨrep, hΦq⟩
+  let src := section43OrderedSourceOfTimeSpatialSource d n G
+  have hΨFL :
+      section43FourierLaplaceRepresentative d n
+        ⟨src.f, src.ordered⟩ Ψ := by
+    simpa [src] using
+      section43FourierLaplaceRepresentative_of_timeSpatialRepresentative
+        d n hΨrep
+  rcases
+    section43FourierLaplaceTransformComponent_has_representative
+      d n src.f src.ordered src.compact with
+    ⟨Φc, hΦc_rep, hΦc_q⟩
+  have hΨΦc :
+      section43PositiveEnergyQuotientMap (d := d) n Ψ =
+        section43PositiveEnergyQuotientMap (d := d) n Φc := by
+    apply section43PositiveEnergyQuotientMap_eq_of_eqOn_region (d := d)
+    intro q hq
+    exact (hΨFL q hq).trans (hΦc_rep q hq).symm
+  have hΦ_component :
+      section43PositiveEnergyQuotientMap (d := d) n Φ =
+        section43FourierLaplaceTransformComponent d n
+          src.f src.ordered src.compact :=
+    hΦq.trans (hΨΦc.trans hΦc_q)
+  change
+    section43PositiveEnergyQuotientMap (d := d) n Φ ∈
+      Set.range (section43FourierLaplaceTransformComponentMap d n)
+  refine ⟨src, ?_⟩
+  simpa [section43FourierLaplaceTransformComponentMap, src] using hΦ_component.symm
+
+/-- The compact ordered Fourier-Laplace transform component image has dense
+ambient preimage under the positive-energy quotient map. -/
+theorem dense_section43FourierLaplace_compact_ordered_preimage_raw
+    (d n : ℕ) [NeZero d] :
+    Dense
+      ((section43PositiveEnergyQuotientMap (d := d) n) ⁻¹'
+        Set.range (section43FourierLaplaceTransformComponentMap d n)) :=
+  Dense.mono
+    (section43TimeLaplaceSpatialFourierTarget_subset_component_preimage d n)
+    (by
+      simpa [section43TimeLaplaceSpatialFourierTarget] using
+        dense_section43TimeLaplaceSpatialFourier_compact_preimage d n)
+
+end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
@@ -441,4 +441,105 @@ theorem dense_section43TimeSpatialTensor_span_compactLaplace_spatialFourier
     (hSt := dense_section43IteratedLaplaceCompactTransform_preimage n)
     (hSx := dense_section43SpatialFourierCompactRange d n)
 
+/-- The time/spatial tensor transported back to the `n`-point Schwartz space. -/
+noncomputable def section43NPointTimeSpatialTensor (d n : ℕ) [NeZero d]
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ) :
+    SchwartzNPoint d n :=
+  (nPointTimeSpatialSchwartzCLE (d := d) (n := n)).symm
+    (section43TimeSpatialTensor d n φ χ)
+
+@[simp] theorem section43NPointTimeSpatialTensor_apply
+    (d n : ℕ) [NeZero d]
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+    (q : NPointDomain d n) :
+    section43NPointTimeSpatialTensor d n φ χ q =
+      φ (section43QTime (d := d) (n := n) q) *
+        χ (section43QSpatial (d := d) (n := n) q) := by
+  change section43TimeSpatialTensor d n φ χ ((nPointTimeSpatialCLE (d := d) n) q) = _
+  rw [show ((nPointTimeSpatialCLE (d := d) n) q) =
+      (section43QTime (d := d) (n := n) q,
+        section43QSpatial (d := d) (n := n) q) by
+    simp [section43QTime, section43QSpatial]]
+  simp
+
+/-- The restricted time/spatial tensor-density theorem transported to
+`SchwartzNPoint d n`. -/
+theorem dense_section43NPointTimeSpatialTensor_span_of_factor_dense
+    {d n : ℕ} [NeZero d]
+    {St : Set (SchwartzMap (Fin n → ℝ) ℂ)}
+    {Sx : Set (SchwartzMap (Section43SpatialSpace d n) ℂ)}
+    (hSt : Dense St) (hSx : Dense Sx) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzNPoint d n |
+          ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+          φ ∈ St ∧
+          ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+          χ ∈ Sx ∧
+            F = section43NPointTimeSpatialTensor d n φ χ}) :
+        Submodule ℂ (SchwartzNPoint d n)) :
+        Set (SchwartzNPoint d n)) := by
+  let E := SchwartzNPoint d n
+  let A := SchwartzMap (Section43TimeSpatialSpace d n) ℂ
+  let e := nPointTimeSpatialSchwartzCLE (d := d) (n := n)
+  let PN : Set E :=
+    {F : E | ∃ φ : SchwartzMap (Fin n → ℝ) ℂ, φ ∈ St ∧
+      ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ, χ ∈ Sx ∧
+        F = section43NPointTimeSpatialTensor d n φ χ}
+  let MN : Submodule ℂ E := Submodule.span ℂ PN
+  let PP : Set A :=
+    {F : A | ∃ φ : SchwartzMap (Fin n → ℝ) ℂ, φ ∈ St ∧
+      ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ, χ ∈ Sx ∧
+        F = section43TimeSpatialTensor d n φ χ}
+  let MP : Submodule ℂ A := Submodule.span ℂ PP
+  change Dense (MN : Set E)
+  rw [Submodule.dense_iff_topologicalClosure_eq_top]
+  apply Submodule.eq_top_iff'.mpr
+  intro x
+  let preM : Submodule ℂ A := MN.topologicalClosure.comap e.symm.toLinearMap
+  have hMP_dense : Dense (MP : Set A) := by
+    simpa [MP, PP, A] using
+      dense_section43TimeSpatialTensor_span_of_factor_dense
+        (d := d) (n := n) (St := St) (Sx := Sx) hSt hSx
+  have hMP_le_preM : MP ≤ preM := by
+    refine Submodule.span_le.mpr ?_
+    intro F hF
+    rcases hF with ⟨φ, hφ, χ, hχ, rfl⟩
+    change e.symm (section43TimeSpatialTensor d n φ χ) ∈ MN.topologicalClosure
+    refine MN.le_topologicalClosure (Submodule.subset_span ?_)
+    exact ⟨φ, hφ, χ, hχ, rfl⟩
+  have hpre_closed : IsClosed (preM : Set A) := by
+    change IsClosed {y : A | e.symm y ∈ (MN.topologicalClosure : Set E)}
+    exact MN.isClosed_topologicalClosure.preimage e.symm.continuous
+  have htop_le_pre : (⊤ : Submodule ℂ A) ≤ preM := by
+    have hclosure : MP.topologicalClosure ≤ preM :=
+      MP.topologicalClosure_minimal hMP_le_preM hpre_closed
+    rwa [(Submodule.dense_iff_topologicalClosure_eq_top).mp hMP_dense] at hclosure
+  have hxpre : e x ∈ preM := htop_le_pre trivial
+  change e.symm (e x) ∈ MN.topologicalClosure at hxpre
+  simpa using hxpre
+
+/-- Route-relevant `SchwartzNPoint` density after transporting the product-space
+Layer-3 packet through the time/spatial split. -/
+theorem dense_section43NPointTimeSpatialTensor_span_compactLaplace_spatialFourier
+    (d n : ℕ) [NeZero d] :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzNPoint d n |
+          ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+          φ ∈
+            ((section43TimePositiveQuotientMap n) ⁻¹'
+              Set.range (section43IteratedLaplaceCompactTransform n)) ∧
+          ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+          χ ∈ section43SpatialFourierCompactRange d n ∧
+            F = section43NPointTimeSpatialTensor d n φ χ}) :
+        Submodule ℂ (SchwartzNPoint d n)) :
+        Set (SchwartzNPoint d n)) :=
+  dense_section43NPointTimeSpatialTensor_span_of_factor_dense
+    (d := d) (n := n)
+    (hSt := dense_section43IteratedLaplaceCompactTransform_preimage n)
+    (hSx := dense_section43SpatialFourierCompactRange d n)
+
 end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
@@ -695,4 +695,95 @@ theorem partialFourierSpatial_fun_section43TimeSpatialProductSource
   rw [(SchwartzMap.fourierTransformCLM ℂ).map_smul]
   simp [smul_eq_mul]
 
+/-- A difference-coordinate source `g` represents a time-Laplace /
+spatial-Fourier transform `Φ` on the Section 4.3 positive-energy surface. -/
+def section43TimeLaplaceSpatialFourierRepresentative
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSpatialSource d n)
+    (Φ : SchwartzNPoint d n) : Prop :=
+  ∀ q : NPointDomain d n, q ∈ section43PositiveEnergyRegion d n →
+    Φ q =
+      ∫ τ : Fin n → ℝ,
+        Complex.exp
+          (-(∑ i : Fin n,
+            (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ))) *
+          partialFourierSpatial_fun
+            (d := d) (n := n) g.f
+            (τ, section43QSpatial (d := d) (n := n) q)
+
+/-- Product sources represent the tensor product of the finite-time Laplace
+representative and the spatial Fourier transform of the compact spatial
+source. -/
+theorem section43TimeLaplaceSpatialFourierRepresentative_productSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n) :
+    section43TimeLaplaceSpatialFourierRepresentative d n
+      (section43TimeSpatialProductSource d n g κ)
+      (section43NPointTimeSpatialTensor d n
+        (section43IteratedLaplaceSchwartzRepresentative n g)
+        (SchwartzMap.fourierTransformCLM ℂ κ.1)) := by
+  intro q hq
+  have hσ :
+      section43QTime (d := d) (n := n) q ∈
+        section43TimePositiveRegion n := by
+    intro i
+    simpa [section43PositiveEnergyRegion, section43QTime, nPointTimeSpatialCLE] using hq i
+  rw [section43NPointTimeSpatialTensor_apply]
+  rw [section43IteratedLaplaceSchwartzRepresentative_apply_of_mem g hσ]
+  unfold section43IteratedLaplaceRaw
+  rw [show
+      (∫ τ : Fin n → ℝ,
+        Complex.exp
+          (-(∑ i : Fin n,
+            (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ))) *
+          partialFourierSpatial_fun
+            (d := d) (n := n)
+            (section43TimeSpatialProductSource d n g κ).f
+            (τ, section43QSpatial (d := d) (n := n) q)) =
+      (∫ τ : Fin n → ℝ,
+        Complex.exp
+          (-(∑ i : Fin n,
+            (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ))) *
+          g.f τ) *
+        (SchwartzMap.fourierTransformCLM ℂ κ.1)
+          (section43QSpatial (d := d) (n := n) q) by
+    calc
+      (∫ τ : Fin n → ℝ,
+        Complex.exp
+          (-(∑ i : Fin n,
+            (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ))) *
+          partialFourierSpatial_fun
+            (d := d) (n := n)
+            (section43TimeSpatialProductSource d n g κ).f
+            (τ, section43QSpatial (d := d) (n := n) q))
+          =
+        ∫ τ : Fin n → ℝ,
+          (Complex.exp
+            (-(∑ i : Fin n,
+              (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ))) *
+            g.f τ) *
+          (SchwartzMap.fourierTransformCLM ℂ κ.1)
+            (section43QSpatial (d := d) (n := n) q) := by
+            congr with τ
+            rw [partialFourierSpatial_fun_section43TimeSpatialProductSource]
+            ring
+      _ =
+        (∫ τ : Fin n → ℝ,
+          Complex.exp
+            (-(∑ i : Fin n,
+              (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ))) *
+            g.f τ) *
+          (SchwartzMap.fourierTransformCLM ℂ κ.1)
+            (section43QSpatial (d := d) (n := n) q) :=
+            MeasureTheory.integral_mul_const
+              ((SchwartzMap.fourierTransformCLM ℂ κ.1)
+                (section43QSpatial (d := d) (n := n) q))
+              (fun τ : Fin n → ℝ =>
+                Complex.exp
+                  (-(∑ i : Fin n,
+                    (τ i : ℂ) *
+                      (section43QTime (d := d) (n := n) q i : ℂ))) *
+                  g.f τ)]
+
 end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
@@ -630,6 +630,116 @@ structure Section43CompactStrictPositiveTimeSpatialSource
       {q | ∀ i : Fin n, 0 < section43QTime (d := d) (n := n) q i}
   compact : HasCompactSupport (f : NPointDomain d n → ℂ)
 
+namespace Section43CompactStrictPositiveTimeSpatialSource
+
+private theorem ext_f {d n : ℕ} [NeZero d]
+    {G H : Section43CompactStrictPositiveTimeSpatialSource d n}
+    (hf : G.f = H.f) : G = H := by
+  cases G
+  cases H
+  simp at hf
+  subst hf
+  rfl
+
+private theorem f_injective (d n : ℕ) [NeZero d] :
+    Function.Injective
+      (fun G : Section43CompactStrictPositiveTimeSpatialSource d n => G.f) := by
+  intro G H hf
+  exact ext_f hf
+
+instance (d n : ℕ) [NeZero d] :
+    Zero (Section43CompactStrictPositiveTimeSpatialSource d n) where
+  zero :=
+    { f := 0
+      positive := by
+        intro q hq
+        simp at hq
+      compact := by
+        simpa using
+          (HasCompactSupport.zero :
+            HasCompactSupport (0 : NPointDomain d n → ℂ)) }
+
+instance (d n : ℕ) [NeZero d] :
+    Add (Section43CompactStrictPositiveTimeSpatialSource d n) where
+  add G H :=
+    { f := G.f + H.f
+      positive := by
+        intro q hq
+        have hq' :=
+          tsupport_add (G.f : NPointDomain d n → ℂ)
+            (H.f : NPointDomain d n → ℂ) hq
+        exact hq'.elim (fun hG => G.positive hG) (fun hH => H.positive hH)
+      compact := by
+        simpa using HasCompactSupport.add G.compact H.compact }
+
+instance (d n : ℕ) [NeZero d] :
+    SMul ℕ (Section43CompactStrictPositiveTimeSpatialSource d n) where
+  smul m G :=
+    { f := (m : ℂ) • G.f
+      positive := by
+        exact
+          (tsupport_smul_subset_right
+            (fun _ : NPointDomain d n => (m : ℂ))
+            (G.f : NPointDomain d n → ℂ)).trans G.positive
+      compact := by
+        simpa using
+          (HasCompactSupport.smul_left
+            (f := fun _ : NPointDomain d n => (m : ℂ))
+            (f' := (G.f : NPointDomain d n → ℂ)) G.compact) }
+
+instance (d n : ℕ) [NeZero d] :
+    AddCommMonoid (Section43CompactStrictPositiveTimeSpatialSource d n) :=
+  Function.Injective.addCommMonoid
+    (fun G : Section43CompactStrictPositiveTimeSpatialSource d n => G.f)
+    (f_injective d n) rfl
+    (by intro G H; rfl)
+    (by
+      intro G m
+      change (m : ℂ) • G.f = m • G.f
+      rw [Nat.cast_smul_eq_nsmul ℂ])
+
+instance (d n : ℕ) [NeZero d] :
+    SMul ℂ (Section43CompactStrictPositiveTimeSpatialSource d n) where
+  smul c G :=
+    { f := c • G.f
+      positive := by
+        exact
+          (tsupport_smul_subset_right
+            (fun _ : NPointDomain d n => c)
+            (G.f : NPointDomain d n → ℂ)).trans G.positive
+      compact := by
+        simpa using
+          (HasCompactSupport.smul_left
+            (f := fun _ : NPointDomain d n => c)
+            (f' := (G.f : NPointDomain d n → ℂ)) G.compact) }
+
+private def fAddMonoidHom (d n : ℕ) [NeZero d] :
+    Section43CompactStrictPositiveTimeSpatialSource d n →+
+      SchwartzNPoint d n where
+  toFun := fun G => G.f
+  map_zero' := rfl
+  map_add' := by intro G H; rfl
+
+instance (d n : ℕ) [NeZero d] :
+    Module ℂ (Section43CompactStrictPositiveTimeSpatialSource d n) :=
+  Function.Injective.module ℂ (fAddMonoidHom d n)
+    (by
+      intro G H hf
+      exact (f_injective d n) hf)
+    (by intro c G; rfl)
+
+end Section43CompactStrictPositiveTimeSpatialSource
+
+/-- Strict support in the positive time orthant implies support in the closed
+Section 4.3 positive-energy region. -/
+theorem section43TimeSpatialSource_tsupport_subset_positiveEnergy
+    {d n : ℕ} [NeZero d]
+    (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+    tsupport (G.f : NPointDomain d n → ℂ) ⊆
+      section43PositiveEnergyRegion d n := by
+  intro q hq i
+  exact le_of_lt (G.positive hq i)
+
 /-- Product a compact strict-positive time source with a compact spatial source,
 then transport it to the `n`-point difference-coordinate Schwartz space. -/
 noncomputable def section43TimeSpatialProductSource
@@ -711,6 +821,68 @@ def section43TimeLaplaceSpatialFourierRepresentative
             (d := d) (n := n) g.f
             (τ, section43QSpatial (d := d) (n := n) q)
 
+/-- The time integrand in a time-Laplace / spatial-Fourier representative is
+integrable on the positive-energy surface. -/
+theorem integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+    (d n : ℕ) [NeZero d]
+    (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+    (q : NPointDomain d n)
+    (hq : q ∈ section43PositiveEnergyRegion d n) :
+    Integrable
+      (fun τ : Fin n → ℝ =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) * (section43QTime (d := d) (n := n) q k : ℂ))) *
+        partialFourierSpatial_fun
+          (d := d) (n := n) G.f
+          (τ, section43QSpatial (d := d) (n := n) q)) := by
+  let F : (Fin n → ℝ) → ℂ := fun τ =>
+    partialFourierSpatial_fun
+      (d := d) (n := n) G.f
+      (τ, section43QSpatial (d := d) (n := n) q)
+  let E : (Fin n → ℝ) → ℂ := fun τ =>
+    Complex.exp
+      (-(∑ k : Fin n,
+        (τ k : ℂ) * (section43QTime (d := d) (n := n) q k : ℂ)))
+  have hF_int : Integrable F (volume : Measure (Fin n → ℝ)) := by
+    simpa [F] using
+      integrable_partialFourierSpatial_timeSlice
+        (d := d) (n := n) G.f
+        (section43QSpatial (d := d) (n := n) q)
+  have hEF_meas : AEStronglyMeasurable
+      (fun τ : Fin n → ℝ => E τ * F τ)
+      (volume : Measure (Fin n → ℝ)) := by
+    have hE_cont : Continuous E := by
+      fun_prop
+    exact hE_cont.aestronglyMeasurable.mul hF_int.aestronglyMeasurable
+  have hbound : ∀ᵐ τ : Fin n → ℝ ∂(volume : Measure (Fin n → ℝ)),
+      ‖E τ * F τ‖ ≤ ‖F τ‖ := by
+    refine Filter.Eventually.of_forall ?_
+    intro τ
+    by_cases hneg : ∃ i : Fin n, τ i < 0
+    · rcases hneg with ⟨i, hi⟩
+      have hF_zero : F τ = 0 := by
+        simpa [F, Function.update_eq_self] using
+          section43PartialFourierSpatial_fun_eq_zero_of_neg_time_of_support_positiveEnergy
+            (d := d) (n := n) G.f
+            (section43TimeSpatialSource_tsupport_subset_positiveEnergy
+              (d := d) (n := n) G)
+            i τ (section43QSpatial (d := d) (n := n) q)
+            (s := τ i) hi
+      simp [hF_zero]
+    · have hτ_nonneg : ∀ i : Fin n, 0 ≤ τ i := by
+        intro i
+        exact le_of_not_gt fun hi => hneg ⟨i, hi⟩
+      have hE_le : ‖E τ‖ ≤ 1 := by
+        simpa [E] using
+          norm_exp_neg_section43_timePair_le_one
+            (d := d) (n := n) q τ hq hτ_nonneg
+      calc
+        ‖E τ * F τ‖ = ‖E τ‖ * ‖F τ‖ := norm_mul _ _
+        _ ≤ 1 * ‖F τ‖ := mul_le_mul_of_nonneg_right hE_le (norm_nonneg _)
+        _ = ‖F τ‖ := one_mul _
+  simpa [F, E] using hF_int.mono hEF_meas hbound
+
 /-- Product sources represent the tensor product of the finite-time Laplace
 representative and the spatial Fourier transform of the compact spatial
 source. -/
@@ -782,9 +954,203 @@ theorem section43TimeLaplaceSpatialFourierRepresentative_productSource
               (fun τ : Fin n → ℝ =>
                 Complex.exp
                   (-(∑ i : Fin n,
-                    (τ i : ℂ) *
+            (τ i : ℂ) *
                       (section43QTime (d := d) (n := n) q i : ℂ))) *
                   g.f τ)]
+
+/-- Time-Laplace / spatial-Fourier representatives are closed under addition. -/
+theorem section43TimeLaplaceSpatialFourierRepresentative_add
+    (d n : ℕ) [NeZero d]
+    {G H : Section43CompactStrictPositiveTimeSpatialSource d n}
+    {Φ Ψ : SchwartzNPoint d n}
+    (hΦ : section43TimeLaplaceSpatialFourierRepresentative d n G Φ)
+    (hΨ : section43TimeLaplaceSpatialFourierRepresentative d n H Ψ) :
+    section43TimeLaplaceSpatialFourierRepresentative d n (G + H) (Φ + Ψ) := by
+  intro q hq
+  let E : (Fin n → ℝ) → ℂ := fun τ =>
+    Complex.exp
+      (-(∑ i : Fin n,
+        (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ)))
+  let FG : (Fin n → ℝ) → ℂ := fun τ =>
+    partialFourierSpatial_fun
+      (d := d) (n := n) G.f
+      (τ, section43QSpatial (d := d) (n := n) q)
+  let FH : (Fin n → ℝ) → ℂ := fun τ =>
+    partialFourierSpatial_fun
+      (d := d) (n := n) H.f
+      (τ, section43QSpatial (d := d) (n := n) q)
+  have hGint :
+      Integrable (fun τ : Fin n → ℝ => E τ * FG τ)
+        (volume : Measure (Fin n → ℝ)) := by
+    simpa [E, FG] using
+      integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+        d n G q hq
+  have hHint :
+      Integrable (fun τ : Fin n → ℝ => E τ * FH τ)
+        (volume : Measure (Fin n → ℝ)) := by
+    simpa [E, FH] using
+      integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+        d n H q hq
+  calc
+    (Φ + Ψ) q = Φ q + Ψ q := rfl
+    _ =
+        (∫ τ : Fin n → ℝ, E τ * FG τ) +
+        (∫ τ : Fin n → ℝ, E τ * FH τ) := by
+          rw [hΦ q hq, hΨ q hq]
+    _ = ∫ τ : Fin n → ℝ, E τ * FG τ + E τ * FH τ := by
+          exact (MeasureTheory.integral_add hGint hHint).symm
+    _ = ∫ τ : Fin n → ℝ,
+        E τ *
+          partialFourierSpatial_fun
+            (d := d) (n := n) (G + H).f
+            (τ, section43QSpatial (d := d) (n := n) q) := by
+          congr with τ
+          change E τ * FG τ + E τ * FH τ =
+            E τ *
+              partialFourierSpatial_fun
+                (d := d) (n := n) (G.f + H.f)
+                (τ, section43QSpatial (d := d) (n := n) q)
+          rw [partialFourierSpatial_fun_add]
+          change E τ * FG τ + E τ * FH τ = E τ * (FG τ + FH τ)
+          ring
+
+/-- Time-Laplace / spatial-Fourier representatives are closed under scalar
+multiplication. -/
+theorem section43TimeLaplaceSpatialFourierRepresentative_smul
+    (d n : ℕ) [NeZero d]
+    (c : ℂ)
+    {G : Section43CompactStrictPositiveTimeSpatialSource d n}
+    {Φ : SchwartzNPoint d n}
+    (hΦ : section43TimeLaplaceSpatialFourierRepresentative d n G Φ) :
+    section43TimeLaplaceSpatialFourierRepresentative d n (c • G) (c • Φ) := by
+  intro q hq
+  let E : (Fin n → ℝ) → ℂ := fun τ =>
+    Complex.exp
+      (-(∑ i : Fin n,
+        (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ)))
+  let FG : (Fin n → ℝ) → ℂ := fun τ =>
+    partialFourierSpatial_fun
+      (d := d) (n := n) G.f
+      (τ, section43QSpatial (d := d) (n := n) q)
+  calc
+    (c • Φ) q = c * Φ q := by simp [smul_eq_mul]
+    _ = c * ∫ τ : Fin n → ℝ, E τ * FG τ := by
+          rw [hΦ q hq]
+    _ = ∫ τ : Fin n → ℝ, c * (E τ * FG τ) := by
+          exact
+            (MeasureTheory.integral_const_mul c
+              (fun τ : Fin n → ℝ => E τ * FG τ)).symm
+    _ = ∫ τ : Fin n → ℝ,
+        E τ *
+          partialFourierSpatial_fun
+            (d := d) (n := n) (c • G).f
+            (τ, section43QSpatial (d := d) (n := n) q) := by
+          congr with τ
+          change c * (E τ * FG τ) =
+            E τ *
+              partialFourierSpatial_fun
+                (d := d) (n := n) (c • G.f)
+                (τ, section43QSpatial (d := d) (n := n) q)
+          rw [partialFourierSpatial_fun_smul]
+          change c * (E τ * FG τ) = E τ * (c * FG τ)
+          ring
+
+/-- The quotient-side target represented by compact strict-positive
+time/spatial sources. -/
+def section43TimeLaplaceSpatialFourierTarget
+    (d n : ℕ) [NeZero d] : Set (SchwartzNPoint d n) :=
+  {Φ |
+    ∃ (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+      (Ψ : SchwartzNPoint d n),
+      section43TimeLaplaceSpatialFourierRepresentative d n G Ψ ∧
+      section43PositiveEnergyQuotientMap (d := d) n Φ =
+        section43PositiveEnergyQuotientMap (d := d) n Ψ}
+
+/-- The zero source represents the zero transform. -/
+theorem section43TimeLaplaceSpatialFourierRepresentative_zero
+    (d n : ℕ) [NeZero d] :
+    section43TimeLaplaceSpatialFourierRepresentative d n
+      (0 : Section43CompactStrictPositiveTimeSpatialSource d n)
+      (0 : SchwartzNPoint d n) := by
+  intro q hq
+  change (0 : ℂ) =
+    ∫ τ : Fin n → ℝ,
+      Complex.exp
+        (-(∑ i : Fin n,
+          (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ))) *
+      partialFourierSpatial_fun
+        (d := d) (n := n) (0 : SchwartzNPoint d n)
+        (τ, section43QSpatial (d := d) (n := n) q)
+  have hzero : ∀ τ : Fin n → ℝ,
+      partialFourierSpatial_fun
+        (d := d) (n := n) (0 : SchwartzNPoint d n)
+        (τ, section43QSpatial (d := d) (n := n) q) = 0 := by
+    intro τ
+    rw [partialFourierSpatial_fun]
+    have hslice :
+        SchwartzMap.partialEval₂
+            (nPointSpatialTimeSchwartzCLE (d := d) (n := n)
+              (0 : SchwartzNPoint d n)) τ = 0 := by
+      ext η
+      rfl
+    rw [hslice]
+    simp
+  have hfun :
+      (fun τ : Fin n → ℝ =>
+        Complex.exp
+          (-(∑ i : Fin n,
+            (τ i : ℂ) * (section43QTime (d := d) (n := n) q i : ℂ))) *
+        partialFourierSpatial_fun
+          (d := d) (n := n) (0 : SchwartzNPoint d n)
+          (τ, section43QSpatial (d := d) (n := n) q)) =
+        fun _ : Fin n → ℝ => 0 := by
+    funext τ
+    simp [hzero τ]
+  rw [hfun]
+  simp
+
+/-- The representative target contains zero. -/
+theorem section43TimeLaplaceSpatialFourierTarget_zero
+    (d n : ℕ) [NeZero d] :
+    (0 : SchwartzNPoint d n) ∈
+      section43TimeLaplaceSpatialFourierTarget d n := by
+  refine ⟨0, 0, section43TimeLaplaceSpatialFourierRepresentative_zero d n, ?_⟩
+  simp
+
+/-- The representative target is closed under addition. -/
+theorem section43TimeLaplaceSpatialFourierTarget_add
+    (d n : ℕ) [NeZero d]
+    {Φ Ψ : SchwartzNPoint d n}
+    (hΦ : Φ ∈ section43TimeLaplaceSpatialFourierTarget d n)
+    (hΨ : Ψ ∈ section43TimeLaplaceSpatialFourierTarget d n) :
+    Φ + Ψ ∈ section43TimeLaplaceSpatialFourierTarget d n := by
+  rcases hΦ with ⟨G, Φrep, hGrep, hΦq⟩
+  rcases hΨ with ⟨H, Ψrep, hHrep, hΨq⟩
+  refine ⟨G + H, Φrep + Ψrep,
+    section43TimeLaplaceSpatialFourierRepresentative_add d n hGrep hHrep, ?_⟩
+  let Q := section43PositiveEnergyQuotientMap (d := d) n
+  change Q (Φ + Ψ) = Q (Φrep + Ψrep)
+  calc
+    Q (Φ + Ψ) = Q Φ + Q Ψ := Q.map_add Φ Ψ
+    _ = Q Φrep + Q Ψrep := by rw [hΦq, hΨq]
+    _ = Q (Φrep + Ψrep) := (Q.map_add Φrep Ψrep).symm
+
+/-- The representative target is closed under scalar multiplication. -/
+theorem section43TimeLaplaceSpatialFourierTarget_smul
+    (d n : ℕ) [NeZero d]
+    (c : ℂ)
+    {Φ : SchwartzNPoint d n}
+    (hΦ : Φ ∈ section43TimeLaplaceSpatialFourierTarget d n) :
+    c • Φ ∈ section43TimeLaplaceSpatialFourierTarget d n := by
+  rcases hΦ with ⟨G, Φrep, hGrep, hΦq⟩
+  refine ⟨c • G, c • Φrep,
+    section43TimeLaplaceSpatialFourierRepresentative_smul d n c hGrep, ?_⟩
+  let Q := section43PositiveEnergyQuotientMap (d := d) n
+  change Q (c • Φ) = Q (c • Φrep)
+  calc
+    Q (c • Φ) = c • Q Φ := Q.map_smul c Φ
+    _ = c • Q Φrep := by rw [hΦq]
+    _ = Q (c • Φrep) := (Q.map_smul c Φrep).symm
 
 /-- If two time factors agree in the finite-time positive quotient, then their
 transported time/spatial tensors agree in the Section 4.3 positive-energy
@@ -855,5 +1221,79 @@ theorem section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget
       section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
         d n (SchwartzMap.fourierTransformCLM ℂ κ.1)
         (hg.symm.trans hcompact)
+
+/-- The dense restricted generator span is contained in the compact
+time-Laplace / spatial-Fourier representative target. -/
+theorem section43NPointTimeSpatialTensor_span_le_timeLaplaceSpatialFourierTarget
+    (d n : ℕ) [NeZero d] :
+    ((Submodule.span ℂ
+      {F : SchwartzNPoint d n |
+        ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+        φ ∈
+          ((section43TimePositiveQuotientMap n) ⁻¹'
+            Set.range (section43IteratedLaplaceCompactTransform n)) ∧
+        ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+        χ ∈ section43SpatialFourierCompactRange d n ∧
+          F = section43NPointTimeSpatialTensor d n φ χ}) :
+      Set (SchwartzNPoint d n)) ⊆
+      section43TimeLaplaceSpatialFourierTarget d n := by
+  let S : Set (SchwartzNPoint d n) :=
+    {F : SchwartzNPoint d n |
+      ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+      φ ∈
+        ((section43TimePositiveQuotientMap n) ⁻¹'
+          Set.range (section43IteratedLaplaceCompactTransform n)) ∧
+      ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+      χ ∈ section43SpatialFourierCompactRange d n ∧
+        F = section43NPointTimeSpatialTensor d n φ χ}
+  intro F hF
+  change F ∈ Submodule.span ℂ S at hF
+  refine Submodule.span_induction ?_ ?_ ?_ ?_ hF
+  · intro G hG
+    rcases hG with ⟨φ, hφ, χ, hχ, rfl⟩
+    simpa [section43TimeLaplaceSpatialFourierTarget] using
+      section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget
+        d n φ χ hφ hχ
+  · exact section43TimeLaplaceSpatialFourierTarget_zero d n
+  · intro G H _ _ hG hH
+    exact section43TimeLaplaceSpatialFourierTarget_add d n hG hH
+  · intro c G _ hG
+    exact section43TimeLaplaceSpatialFourierTarget_smul d n c hG
+
+/-- Compact strict-positive time/spatial sources give a dense set of
+positive-energy quotient representatives. -/
+theorem dense_section43TimeLaplaceSpatialFourier_compact_preimage
+    (d n : ℕ) [NeZero d] :
+    Dense
+      {Φ : SchwartzNPoint d n |
+        ∃ (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+          (Ψ : SchwartzNPoint d n),
+          section43TimeLaplaceSpatialFourierRepresentative d n G Ψ ∧
+          section43PositiveEnergyQuotientMap (d := d) n Φ =
+            section43PositiveEnergyQuotientMap (d := d) n Ψ} := by
+  let S : Set (SchwartzNPoint d n) :=
+    {F : SchwartzNPoint d n |
+      ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+      φ ∈
+        ((section43TimePositiveQuotientMap n) ⁻¹'
+          Set.range (section43IteratedLaplaceCompactTransform n)) ∧
+      ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+      χ ∈ section43SpatialFourierCompactRange d n ∧
+        F = section43NPointTimeSpatialTensor d n φ χ}
+  let M : Submodule ℂ (SchwartzNPoint d n) := Submodule.span ℂ S
+  have hM_dense : Dense (M : Set (SchwartzNPoint d n)) := by
+    simpa [M, S] using
+      dense_section43NPointTimeSpatialTensor_span_compactLaplace_spatialFourier
+        d n
+  have hM_le :
+      (M : Set (SchwartzNPoint d n)) ⊆
+        section43TimeLaplaceSpatialFourierTarget d n := by
+    simpa [M, S] using
+      section43NPointTimeSpatialTensor_span_le_timeLaplaceSpatialFourierTarget
+        d n
+  have htarget_dense :
+      Dense (section43TimeLaplaceSpatialFourierTarget d n) :=
+    Dense.mono hM_le hM_dense
+  simpa [section43TimeLaplaceSpatialFourierTarget] using htarget_dense
 
 end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
@@ -1,0 +1,444 @@
+import OSReconstruction.Wightman.Reconstruction.SchwartzDensity
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceTimeProductDensity
+
+/-!
+# Section 4.3 spatial Fourier density support
+
+This companion file starts Layer 3 of the Section 4.3 OS-route density proof.
+It keeps the finite-time compact-Laplace density file frozen and introduces the
+spatial-frequency compact-source interface needed for the next tensor-density
+step.
+-/
+
+noncomputable section
+
+open scoped Topology FourierTransform BoundedContinuousFunction
+open Set MeasureTheory Filter
+
+namespace OSReconstruction
+
+/-- The spatial block appearing after the standard time/spatial splitting. -/
+abbrev Section43SpatialSpace (d n : ℕ) :=
+  EuclideanSpace ℝ (Fin n × Fin d)
+
+/-- Flatten the spatial Euclidean block to ordinary finite real coordinates.
+This is the bridge to `SchwartzMap.dense_hasCompactSupport`, which is stated on
+`Fin m → ℝ`. -/
+noncomputable def section43SpatialFlatCLE (d n : ℕ) :
+    Section43SpatialSpace d n ≃L[ℝ] (Fin (n * d) → ℝ) :=
+  (EuclideanSpace.equiv (ι := Fin n × Fin d) (𝕜 := ℝ)).trans
+    ((LinearEquiv.funCongrLeft ℝ ℝ finProdFinEquiv.symm).toContinuousLinearEquiv)
+
+@[simp] theorem section43SpatialFlatCLE_apply
+    (d n : ℕ) (η : Section43SpatialSpace d n) (k : Fin (n * d)) :
+    section43SpatialFlatCLE d n η k =
+      (EuclideanSpace.equiv (ι := Fin n × Fin d) (𝕜 := ℝ) η)
+        (finProdFinEquiv.symm k) := rfl
+
+@[simp] theorem section43SpatialFlatCLE_symm_apply
+    (d n : ℕ) (x : Fin (n * d) → ℝ) (p : Fin n × Fin d) :
+    (EuclideanSpace.equiv (ι := Fin n × Fin d) (𝕜 := ℝ)
+      ((section43SpatialFlatCLE d n).symm x)) p =
+      x (finProdFinEquiv p) := rfl
+
+/-- The Schwartz-space lift of `section43SpatialFlatCLE`. -/
+noncomputable def section43SpatialFlatSchwartzCLE (d n : ℕ) :
+    SchwartzMap (Section43SpatialSpace d n) ℂ ≃L[ℂ]
+      SchwartzMap (Fin (n * d) → ℝ) ℂ := by
+  let e := section43SpatialFlatCLE d n
+  let toFwd :
+      SchwartzMap (Section43SpatialSpace d n) ℂ →L[ℂ]
+        SchwartzMap (Fin (n * d) → ℝ) ℂ :=
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ e.symm
+  let toInv :
+      SchwartzMap (Fin (n * d) → ℝ) ℂ →L[ℂ]
+        SchwartzMap (Section43SpatialSpace d n) ℂ :=
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ e
+  exact
+    { toLinearEquiv :=
+        { toFun := toFwd
+          map_add' := toFwd.map_add
+          map_smul' := toFwd.map_smul
+          invFun := toInv
+          left_inv := by
+            intro f
+            ext η
+            simp [toFwd, toInv, SchwartzMap.compCLMOfContinuousLinearEquiv_apply, e]
+          right_inv := by
+            intro f
+            ext x
+            simp [toFwd, toInv, SchwartzMap.compCLMOfContinuousLinearEquiv_apply, e] }
+      continuous_toFun := toFwd.continuous
+      continuous_invFun := toInv.continuous }
+
+@[simp] theorem section43SpatialFlatSchwartzCLE_apply
+    (d n : ℕ) (κ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+    (x : Fin (n * d) → ℝ) :
+    section43SpatialFlatSchwartzCLE d n κ x =
+      κ ((section43SpatialFlatCLE d n).symm x) := by
+  simp [section43SpatialFlatSchwartzCLE, SchwartzMap.compCLMOfContinuousLinearEquiv_apply]
+
+@[simp] theorem section43SpatialFlatSchwartzCLE_symm_apply
+    (d n : ℕ) (κ : SchwartzMap (Fin (n * d) → ℝ) ℂ)
+    (η : Section43SpatialSpace d n) :
+    (section43SpatialFlatSchwartzCLE d n).symm κ η =
+      κ (section43SpatialFlatCLE d n η) := by
+  change
+    (SchwartzMap.compCLMOfContinuousLinearEquiv ℂ (section43SpatialFlatCLE d n) κ) η =
+      κ (section43SpatialFlatCLE d n η)
+  rfl
+
+/-- Compactly supported spatial Schwartz sources in the spatial block. -/
+def Section43SpatialCompactSource (d n : ℕ) :=
+  {κ : SchwartzMap (Section43SpatialSpace d n) ℂ //
+    HasCompactSupport (κ : Section43SpatialSpace d n → ℂ)}
+
+/-- Compactly supported Schwartz functions are dense on the Section 4.3 spatial
+block.  This transports `SchwartzMap.dense_hasCompactSupport` from
+`Fin (n*d) → ℝ` through `section43SpatialFlatCLE`. -/
+theorem dense_section43Spatial_hasCompactSupport (d n : ℕ) :
+    Dense
+      {κ : SchwartzMap (Section43SpatialSpace d n) ℂ |
+        HasCompactSupport (κ : Section43SpatialSpace d n → ℂ)} := by
+  let E := Section43SpatialSpace d n
+  let P := Fin (n * d) → ℝ
+  let e := section43SpatialFlatCLE d n
+  let T := (section43SpatialFlatSchwartzCLE d n).symm
+  let Sflat : Set (SchwartzMap P ℂ) :=
+    {κ | HasCompactSupport (κ : P → ℂ)}
+  let Ssp : Set (SchwartzMap E ℂ) :=
+    {κ | HasCompactSupport (κ : E → ℂ)}
+  have hflat : Dense Sflat := by
+    simpa [Sflat, P] using
+      (SchwartzMap.dense_hasCompactSupport (m := n * d))
+  have hT_denseRange :
+      DenseRange (T : SchwartzMap P ℂ → SchwartzMap E ℂ) :=
+    (section43SpatialFlatSchwartzCLE d n).symm.surjective.denseRange
+  have himage_dense : Dense ((fun κ : SchwartzMap P ℂ => T κ) '' Sflat) :=
+    hT_denseRange.dense_image
+      ((section43SpatialFlatSchwartzCLE d n).symm.continuous) hflat
+  have hsubset :
+      ((fun κ : SchwartzMap P ℂ => T κ) '' Sflat) ⊆ Ssp := by
+    rintro _ ⟨κ, hκ, rfl⟩
+    have htsupport :
+        tsupport ((T κ : SchwartzMap E ℂ) : E → ℂ) =
+          e.toHomeomorph ⁻¹' tsupport (κ : P → ℂ) := by
+      simpa [T, E, P, e, section43SpatialFlatSchwartzCLE,
+        SchwartzMap.compCLMOfContinuousLinearEquiv_apply] using
+        (tsupport_comp_eq_preimage (g := (κ : P → ℂ)) e.toHomeomorph)
+    have hpre_eq :
+        e.toHomeomorph ⁻¹' tsupport (κ : P → ℂ) =
+          e.symm '' tsupport (κ : P → ℂ) := by
+      ext η
+      constructor
+      · intro hη
+        refine ⟨e η, hη, ?_⟩
+        simp [e]
+      · rintro ⟨x, hx, rfl⟩
+        simpa [e] using hx
+    have hcompact :
+        IsCompact (e.symm '' tsupport (κ : P → ℂ)) :=
+      hκ.isCompact.image e.symm.continuous
+    change HasCompactSupport ((T κ : SchwartzMap E ℂ) : E → ℂ)
+    rw [HasCompactSupport, htsupport, hpre_eq]
+    exact hcompact
+  exact Dense.mono hsubset himage_dense
+
+/-- Spatial-frequency functions obtained by Fourier-transforming compactly
+supported spatial Schwartz sources. -/
+noncomputable def section43SpatialFourierCompactRange (d n : ℕ) :
+    Set (SchwartzMap (Section43SpatialSpace d n) ℂ) :=
+  Set.range fun κ : Section43SpatialCompactSource d n =>
+    SchwartzMap.fourierTransformCLM ℂ κ.1
+
+/-- Fourier transforms of compactly supported spatial Schwartz sources are
+dense in the spatial-frequency Schwartz space. -/
+theorem dense_section43SpatialFourierCompactRange (d n : ℕ) :
+    Dense (section43SpatialFourierCompactRange d n) := by
+  let E := Section43SpatialSpace d n
+  let FT : SchwartzMap E ℂ →L[ℂ] SchwartzMap E ℂ :=
+    SchwartzMap.fourierTransformCLM ℂ
+  let Ssp : Set (SchwartzMap E ℂ) :=
+    {κ | HasCompactSupport (κ : E → ℂ)}
+  have hcompact_dense : Dense Ssp := by
+    simpa [Ssp, E] using dense_section43Spatial_hasCompactSupport d n
+  have hFT_denseRange : DenseRange (FT : SchwartzMap E ℂ → SchwartzMap E ℂ) := by
+    have hsurj : Function.Surjective (FT : SchwartzMap E ℂ → SchwartzMap E ℂ) := by
+      intro χ
+      refine ⟨FourierTransform.fourierInv χ, ?_⟩
+      simp [FT]
+    exact hsurj.denseRange
+  have himage_dense : Dense ((fun κ : SchwartzMap E ℂ => FT κ) '' Ssp) :=
+    hFT_denseRange.dense_image FT.continuous hcompact_dense
+  have hset :
+      section43SpatialFourierCompactRange d n =
+        (fun κ : SchwartzMap E ℂ => FT κ) '' Ssp := by
+    ext χ
+    constructor
+    · rintro ⟨κ, rfl⟩
+      exact ⟨κ.1, κ.2, rfl⟩
+    · rintro ⟨κ, hκ, rfl⟩
+      exact ⟨⟨κ, hκ⟩, rfl⟩
+  simpa [hset] using himage_dense
+
+/-- The product of the ordinary finite-time block and the Section 4.3 spatial
+block. -/
+abbrev Section43TimeSpatialSpace (d n : ℕ) :=
+  (Fin n → ℝ) × Section43SpatialSpace d n
+
+/-- Flatten the time/spatial product block to ordinary finite real coordinates:
+first the `n` time coordinates, then the `n*d` flattened spatial coordinates. -/
+noncomputable def section43TimeSpatialFlatCLE (d n : ℕ) :
+    Section43TimeSpatialSpace d n ≃L[ℝ] (Fin (n + n * d) → ℝ) :=
+  ((ContinuousLinearEquiv.refl ℝ (Fin n → ℝ)).prodCongr
+      (section43SpatialFlatCLE d n)).trans
+    ((ContinuousLinearEquiv.sumPiEquivProdPi ℝ
+        (Fin n) (Fin (n * d)) (fun _ => ℝ)).symm.trans
+      (ContinuousLinearEquiv.piCongrLeft ℝ
+        (fun _ : Fin (n + n * d) => ℝ) finSumFinEquiv))
+
+@[simp] theorem section43TimeSpatialFlatCLE_splitFirst
+    (d n : ℕ) (τ : Fin n → ℝ) (η : Section43SpatialSpace d n) :
+    splitFirst n (n * d) (section43TimeSpatialFlatCLE d n (τ, η)) = τ := by
+  ext i
+  change (Equiv.piCongrLeft (fun _ : Fin (n + n * d) => ℝ) finSumFinEquiv)
+      ((Equiv.sumPiEquivProdPi (fun _ : Fin n ⊕ Fin (n * d) => ℝ)).symm
+        (τ, (section43SpatialFlatCLE d n) η))
+      (Fin.castAdd (n * d) i) = τ i
+  rw [show Fin.castAdd (n * d) i = finSumFinEquiv (Sum.inl i) from
+    finSumFinEquiv_apply_left i]
+  exact Equiv.piCongrLeft_sumInl (fun _ : Fin (n + n * d) => ℝ)
+    finSumFinEquiv τ ((section43SpatialFlatCLE d n) η) i
+
+@[simp] theorem section43TimeSpatialFlatCLE_splitLast
+    (d n : ℕ) (τ : Fin n → ℝ) (η : Section43SpatialSpace d n) :
+    splitLast n (n * d) (section43TimeSpatialFlatCLE d n (τ, η)) =
+      section43SpatialFlatCLE d n η := by
+  ext i
+  change (Equiv.piCongrLeft (fun _ : Fin (n + n * d) => ℝ) finSumFinEquiv)
+      ((Equiv.sumPiEquivProdPi (fun _ : Fin n ⊕ Fin (n * d) => ℝ)).symm
+        (τ, (section43SpatialFlatCLE d n) η))
+      (Fin.natAdd n i) = section43SpatialFlatCLE d n η i
+  rw [show Fin.natAdd n i = finSumFinEquiv (Sum.inr i) from
+    finSumFinEquiv_apply_right i]
+  exact Equiv.piCongrLeft_sumInr (fun _ : Fin (n + n * d) => ℝ)
+    finSumFinEquiv τ ((section43SpatialFlatCLE d n) η) i
+
+/-- Tensor a finite-time Schwartz function with a spatial-frequency Schwartz
+function, after flattening the spatial block.  Pointwise this is just
+`φ τ * χ η`, but the definition is phrased through `SchwartzMap.tensorProduct`
+so it participates in the existing dense-product machinery. -/
+noncomputable def section43TimeSpatialTensor (d n : ℕ)
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ) :
+    SchwartzMap (Section43TimeSpatialSpace d n) ℂ :=
+  SchwartzMap.compCLMOfContinuousLinearEquiv ℂ (section43TimeSpatialFlatCLE d n)
+    (SchwartzMap.tensorProduct φ (section43SpatialFlatSchwartzCLE d n χ))
+
+@[simp] theorem section43TimeSpatialTensor_apply
+    (d n : ℕ)
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+    (τ : Fin n → ℝ) (η : Section43SpatialSpace d n) :
+    section43TimeSpatialTensor d n φ χ (τ, η) = φ τ * χ η := by
+  simp [section43TimeSpatialTensor, SchwartzMap.compCLMOfContinuousLinearEquiv_apply,
+    SchwartzMap.tensorProduct_apply]
+
+/-- Block tensors between `Fin n` and `Fin m` are dense in the flat
+`Fin (n+m)` Schwartz space.  This follows because coordinatewise product
+tensors are a subset of the block-tensor span. -/
+theorem dense_section43_flatBlockTensor_span (n m : ℕ) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzMap (Fin (n + m) → ℝ) ℂ |
+          ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+          ∃ ψ : SchwartzMap (Fin m → ℝ) ℂ,
+            F = SchwartzMap.tensorProduct φ ψ}) :
+        Submodule ℂ (SchwartzMap (Fin (n + m) → ℝ) ℂ)) :
+        Set (SchwartzMap (Fin (n + m) → ℝ) ℂ)) := by
+  let A := SchwartzMap (Fin (n + m) → ℝ) ℂ
+  let Pblock : Set A :=
+    {F : A | ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+      ∃ ψ : SchwartzMap (Fin m → ℝ) ℂ,
+        F = SchwartzMap.tensorProduct φ ψ}
+  let Mblock : Submodule ℂ A := Submodule.span ℂ Pblock
+  let Pall : Set A :=
+    {F : A | ∃ fs : Fin (n + m) → SchwartzMap ℝ ℂ,
+      F = section43TimeProductTensor fs}
+  let Mall : Submodule ℂ A := Submodule.span ℂ Pall
+  change Dense (Mblock : Set A)
+  have hMall_dense : Dense (Mall : Set A) := by
+    simpa [Mall, Pall, A] using section43_timeProductTensor_span_dense (n + m)
+  have hMall_le_Mblock : Mall ≤ Mblock := by
+    refine Submodule.span_le.mpr ?_
+    intro F hF
+    rcases hF with ⟨fs, rfl⟩
+    refine Submodule.subset_span ?_
+    refine ⟨section43TimeProductTensor (fun i : Fin n => fs (Fin.castAdd m i)),
+      section43TimeProductTensor (fun j : Fin m => fs (Fin.natAdd n j)), ?_⟩
+    ext x
+    rw [SchwartzMap.tensorProduct_apply]
+    simp [section43TimeProductTensor, splitFirst, splitLast, Fin.prod_univ_add]
+  exact Dense.mono (fun F hF => hMall_le_Mblock hF) hMall_dense
+
+/-- Unrestricted time/spatial block tensors are dense in the time/spatial
+Schwartz space. -/
+theorem dense_section43TimeSpatialTensor_span (d n : ℕ) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzMap (Section43TimeSpatialSpace d n) ℂ |
+          ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+          ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+            F = section43TimeSpatialTensor d n φ χ}) :
+        Submodule ℂ (SchwartzMap (Section43TimeSpatialSpace d n) ℂ)) :
+        Set (SchwartzMap (Section43TimeSpatialSpace d n) ℂ)) := by
+  let A := SchwartzMap (Section43TimeSpatialSpace d n) ℂ
+  let B := SchwartzMap (Fin (n + n * d) → ℝ) ℂ
+  let e := section43TimeSpatialFlatCLE d n
+  let toA : B →L[ℂ] A := SchwartzMap.compCLMOfContinuousLinearEquiv ℂ e
+  let toB : A →L[ℂ] B := SchwartzMap.compCLMOfContinuousLinearEquiv ℂ e.symm
+  let PA : Set A :=
+    {F : A | ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+      ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+        F = section43TimeSpatialTensor d n φ χ}
+  let MA : Submodule ℂ A := Submodule.span ℂ PA
+  let PB : Set B :=
+    {F : B | ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+      ∃ ψ : SchwartzMap (Fin (n * d) → ℝ) ℂ,
+        F = SchwartzMap.tensorProduct φ ψ}
+  let MB : Submodule ℂ B := Submodule.span ℂ PB
+  change Dense (MA : Set A)
+  rw [Submodule.dense_iff_topologicalClosure_eq_top]
+  apply Submodule.eq_top_iff'.mpr
+  intro x
+  let preM : Submodule ℂ B := MA.topologicalClosure.comap toA.toLinearMap
+  have hMB_dense : Dense (MB : Set B) := by
+    simpa [MB, PB, B] using dense_section43_flatBlockTensor_span n (n * d)
+  have hMB_le_preM : MB ≤ preM := by
+    refine Submodule.span_le.mpr ?_
+    intro F hF
+    rcases hF with ⟨φ, ψ, rfl⟩
+    change toA (SchwartzMap.tensorProduct φ ψ) ∈ MA.topologicalClosure
+    refine MA.le_topologicalClosure (Submodule.subset_span ?_)
+    refine ⟨φ, (section43SpatialFlatSchwartzCLE d n).symm ψ, ?_⟩
+    ext p
+    rcases p with ⟨τ, η⟩
+    change (φ.tensorProduct ψ) (e (τ, η)) =
+      section43TimeSpatialTensor d n φ
+        ((section43SpatialFlatSchwartzCLE d n).symm ψ) (τ, η)
+    rw [SchwartzMap.tensorProduct_apply]
+    simp [e, section43TimeSpatialTensor, SchwartzMap.compCLMOfContinuousLinearEquiv_apply]
+  have hpre_closed : IsClosed (preM : Set B) := by
+    change IsClosed {y : B | toA y ∈ (MA.topologicalClosure : Set A)}
+    exact MA.isClosed_topologicalClosure.preimage toA.continuous
+  have htop_le_pre : (⊤ : Submodule ℂ B) ≤ preM := by
+    have hclosure : MB.topologicalClosure ≤ preM :=
+      MB.topologicalClosure_minimal hMB_le_preM hpre_closed
+    rwa [(Submodule.dense_iff_topologicalClosure_eq_top).mp hMB_dense] at hclosure
+  have hxpre : toB x ∈ preM := htop_le_pre trivial
+  change toA (toB x) ∈ MA.topologicalClosure at hxpre
+  have hcomp : toA (toB x) = x := by
+    ext p
+    change x (e.symm (e p)) = x p
+    simp
+  simpa [hcomp] using hxpre
+
+/-- If the time factors and spatial factors are dense, then finite sums of
+time/spatial block tensors with factors in those dense sets are dense. -/
+theorem dense_section43TimeSpatialTensor_span_of_factor_dense
+    {d n : ℕ}
+    {St : Set (SchwartzMap (Fin n → ℝ) ℂ)}
+    {Sx : Set (SchwartzMap (Section43SpatialSpace d n) ℂ)}
+    (hSt : Dense St) (hSx : Dense Sx) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzMap (Section43TimeSpatialSpace d n) ℂ |
+          ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+          φ ∈ St ∧
+          ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+          χ ∈ Sx ∧
+            F = section43TimeSpatialTensor d n φ χ}) :
+        Submodule ℂ (SchwartzMap (Section43TimeSpatialSpace d n) ℂ)) :
+        Set (SchwartzMap (Section43TimeSpatialSpace d n) ℂ)) := by
+  let At := SchwartzMap (Fin n → ℝ) ℂ
+  let Ax := SchwartzMap (Section43SpatialSpace d n) ℂ
+  let A := SchwartzMap (Section43TimeSpatialSpace d n) ℂ
+  let PS : Set A :=
+    {F : A | ∃ φ : At, φ ∈ St ∧ ∃ χ : Ax, χ ∈ Sx ∧
+      F = section43TimeSpatialTensor d n φ χ}
+  let MS : Submodule ℂ A := Submodule.span ℂ PS
+  let Pall : Set A :=
+    {F : A | ∃ φ : At, ∃ χ : Ax,
+      F = section43TimeSpatialTensor d n φ χ}
+  let Mall : Submodule ℂ A := Submodule.span ℂ Pall
+  change Dense (MS : Set A)
+  let D : Set (At × Ax) := St ×ˢ Sx
+  let T : At × Ax → A := fun p => section43TimeSpatialTensor d n p.1 p.2
+  have hD : Dense D := hSt.prod hSx
+  have hTcont : Continuous T := by
+    let e := section43TimeSpatialFlatCLE d n
+    let toA : SchwartzMap (Fin (n + n * d) → ℝ) ℂ →L[ℂ] A :=
+      SchwartzMap.compCLMOfContinuousLinearEquiv ℂ e
+    let Tflat : At × SchwartzMap (Fin (n * d) → ℝ) ℂ →
+        SchwartzMap (Fin (n + n * d) → ℝ) ℂ :=
+      fun p => SchwartzMap.tensorProduct p.1 p.2
+    have hpair :
+        Continuous (fun p : At × Ax =>
+          (p.1, section43SpatialFlatSchwartzCLE d n p.2)) :=
+      Continuous.prodMk continuous_fst
+        ((section43SpatialFlatSchwartzCLE d n).continuous.comp continuous_snd)
+    have hflat : Continuous Tflat := by
+      simpa [Tflat] using
+        (SchwartzMap.tensorProduct_continuous (E := ℝ) (m := n) (k := n * d))
+    change Continuous
+      (fun p : At × Ax =>
+        toA (Tflat (p.1, section43SpatialFlatSchwartzCLE d n p.2)))
+    exact toA.continuous.comp (hflat.comp hpair)
+  have hMall_le_MSclosure : Mall ≤ MS.topologicalClosure := by
+    refine Submodule.span_le.mpr ?_
+    intro F hF
+    rcases hF with ⟨φ, χ, rfl⟩
+    have himage_subset : T '' D ⊆ (MS : Set A) := by
+      rintro _ ⟨p, hp, rfl⟩
+      rcases hp with ⟨hpSt, hpSx⟩
+      exact Submodule.subset_span ⟨p.1, hpSt, p.2, hpSx, rfl⟩
+    have hmem_image_closure :
+        section43TimeSpatialTensor d n φ χ ∈ closure (T '' D) := by
+      exact hTcont.range_subset_closure_image_dense hD ⟨(φ, χ), rfl⟩
+    change section43TimeSpatialTensor d n φ χ ∈ closure (MS : Set A)
+    exact closure_mono himage_subset hmem_image_closure
+  have hMall_dense : Dense (Mall : Set A) := by
+    simpa [Mall, Pall, A, At, Ax] using dense_section43TimeSpatialTensor_span d n
+  rw [Submodule.dense_iff_topologicalClosure_eq_top]
+  apply Submodule.eq_top_iff'.mpr
+  intro x
+  have hxMall : x ∈ Mall.topologicalClosure := by
+    rw [(Submodule.dense_iff_topologicalClosure_eq_top).mp hMall_dense]
+    trivial
+  have hclosure_le : Mall.topologicalClosure ≤ MS.topologicalClosure :=
+    Mall.topologicalClosure_minimal hMall_le_MSclosure MS.isClosed_topologicalClosure
+  exact hclosure_le hxMall
+
+/-- The route-relevant dense family: time factors whose positive-time quotient
+comes from a compact strict-positive Laplace source, paired with spatial
+Fourier transforms of compact spatial sources. -/
+theorem dense_section43TimeSpatialTensor_span_compactLaplace_spatialFourier
+    (d n : ℕ) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzMap (Section43TimeSpatialSpace d n) ℂ |
+          ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+          φ ∈
+            ((section43TimePositiveQuotientMap n) ⁻¹'
+              Set.range (section43IteratedLaplaceCompactTransform n)) ∧
+          ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+          χ ∈ section43SpatialFourierCompactRange d n ∧
+            F = section43TimeSpatialTensor d n φ χ}) :
+        Submodule ℂ (SchwartzMap (Section43TimeSpatialSpace d n) ℂ)) :
+        Set (SchwartzMap (Section43TimeSpatialSpace d n) ℂ)) :=
+  dense_section43TimeSpatialTensor_span_of_factor_dense
+    (d := d) (n := n)
+    (hSt := dense_section43IteratedLaplaceCompactTransform_preimage n)
+    (hSx := dense_section43SpatialFourierCompactRange d n)
+
+end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
@@ -786,4 +786,74 @@ theorem section43TimeLaplaceSpatialFourierRepresentative_productSource
                       (section43QTime (d := d) (n := n) q i : ℂ))) *
                   g.f τ)]
 
+/-- If two time factors agree in the finite-time positive quotient, then their
+transported time/spatial tensors agree in the Section 4.3 positive-energy
+quotient after pairing with any fixed spatial factor. -/
+theorem section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
+    (d n : ℕ) [NeZero d]
+    {φ ψ : SchwartzMap (Fin n → ℝ) ℂ}
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+    (hφψ :
+      section43TimePositiveQuotientMap n φ =
+        section43TimePositiveQuotientMap n ψ) :
+    section43PositiveEnergyQuotientMap (d := d) n
+      (section43NPointTimeSpatialTensor d n φ χ) =
+    section43PositiveEnergyQuotientMap (d := d) n
+      (section43NPointTimeSpatialTensor d n ψ χ) := by
+  apply section43PositiveEnergyQuotientMap_eq_of_eqOn_region (d := d)
+  intro q hq
+  have hσ :
+      section43QTime (d := d) (n := n) q ∈
+        section43TimePositiveRegion n := by
+    intro i
+    simpa [section43PositiveEnergyRegion, section43QTime, nPointTimeSpatialCLE] using hq i
+  have hφψ_point :
+      φ (section43QTime (d := d) (n := n) q) =
+        ψ (section43QTime (d := d) (n := n) q) :=
+    eqOn_region_of_section43TimePositiveQuotientMap_eq hφψ hσ
+  simp [section43NPointTimeSpatialTensor_apply, hφψ_point]
+
+/-- Each restricted time/spatial tensor generator has an explicit compact
+time/spatial source representative after passing to the positive-energy
+quotient. -/
+theorem section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget
+    (d n : ℕ) [NeZero d]
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+    (hφ :
+      φ ∈ ((section43TimePositiveQuotientMap n) ⁻¹'
+        Set.range (section43IteratedLaplaceCompactTransform n)))
+    (hχ : χ ∈ section43SpatialFourierCompactRange d n) :
+    ∃ (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+      (Ψ : SchwartzNPoint d n),
+      section43TimeLaplaceSpatialFourierRepresentative d n G Ψ ∧
+      section43PositiveEnergyQuotientMap (d := d) n
+        (section43NPointTimeSpatialTensor d n φ χ) =
+      section43PositiveEnergyQuotientMap (d := d) n Ψ := by
+  rcases hφ with ⟨g, hg⟩
+  rcases hχ with ⟨κ, rfl⟩
+  let Ψt := section43IteratedLaplaceSchwartzRepresentative n g
+  let Ψ : SchwartzNPoint d n :=
+    section43NPointTimeSpatialTensor d n Ψt
+      (SchwartzMap.fourierTransformCLM ℂ κ.1)
+  refine ⟨section43TimeSpatialProductSource d n g κ, Ψ, ?_, ?_⟩
+  · exact section43TimeLaplaceSpatialFourierRepresentative_productSource d n g κ
+  · have hΨt_rep : section43IteratedLaplaceRepresentative n g Ψt := by
+      intro σ hσ
+      exact section43IteratedLaplaceSchwartzRepresentative_apply_of_mem g hσ
+    have hcompact :
+        section43IteratedLaplaceCompactTransform n g =
+          section43TimePositiveQuotientMap n Ψt :=
+      section43IteratedLaplaceCompactTransform_eq_quotient n g Ψt hΨt_rep
+    change section43PositiveEnergyQuotientMap (d := d) n
+        (section43NPointTimeSpatialTensor d n φ
+          (SchwartzMap.fourierTransformCLM ℂ κ.1)) =
+      section43PositiveEnergyQuotientMap (d := d) n
+        (section43NPointTimeSpatialTensor d n Ψt
+          (SchwartzMap.fourierTransformCLM ℂ κ.1))
+    exact
+      section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
+        d n (SchwartzMap.fourierTransformCLM ℂ κ.1)
+        (hg.symm.trans hcompact)
+
 end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean
@@ -542,4 +542,157 @@ theorem dense_section43NPointTimeSpatialTensor_span_compactLaplace_spatialFourie
     (hSt := dense_section43IteratedLaplaceCompactTransform_preimage n)
     (hSx := dense_section43SpatialFourierCompactRange d n)
 
+/-- The topological support of a transported time/spatial tensor is controlled
+by the topological support of its time factor. -/
+theorem tsupport_section43NPointTimeSpatialTensor_subset_time_preimage
+    (d n : ℕ) [NeZero d]
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ) :
+    tsupport
+      ((section43NPointTimeSpatialTensor d n φ χ :
+          SchwartzNPoint d n) : NPointDomain d n → ℂ)
+      ⊆
+    (section43QTime (d := d) (n := n)) ⁻¹'
+      tsupport (φ : (Fin n → ℝ) → ℂ) := by
+  intro q hq
+  have hfun :
+      (((section43NPointTimeSpatialTensor d n φ χ :
+          SchwartzNPoint d n) : NPointDomain d n → ℂ)) =
+        fun q : NPointDomain d n =>
+          φ (section43QTime (d := d) (n := n) q) *
+            χ (section43QSpatial (d := d) (n := n) q) := by
+    funext q
+    simp
+  have hprod :
+      q ∈ tsupport
+        (fun q : NPointDomain d n =>
+          φ (section43QTime (d := d) (n := n) q) *
+            χ (section43QSpatial (d := d) (n := n) q)) := by
+    simpa [hfun] using hq
+  have ht_pullback :
+      q ∈ tsupport
+        (fun q : NPointDomain d n =>
+          φ (section43QTime (d := d) (n := n) q)) :=
+    (tsupport_mul_subset_left
+      (f := fun q : NPointDomain d n =>
+        φ (section43QTime (d := d) (n := n) q))
+      (g := fun q : NPointDomain d n =>
+        χ (section43QSpatial (d := d) (n := n) q))) hprod
+  exact
+    (tsupport_comp_subset_preimage
+      (φ : (Fin n → ℝ) → ℂ)
+      (f := section43QTime (d := d) (n := n))
+      (by
+        simpa [section43QTimeCLM_apply] using
+          (section43QTimeCLM d n).continuous)) ht_pullback
+
+/-- A transported time/spatial tensor is compactly supported if both factors
+are compactly supported. -/
+theorem hasCompactSupport_section43NPointTimeSpatialTensor
+    (d n : ℕ) [NeZero d]
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+    (hφ : HasCompactSupport (φ : (Fin n → ℝ) → ℂ))
+    (hχ : HasCompactSupport (χ : Section43SpatialSpace d n → ℂ)) :
+    HasCompactSupport
+      ((section43NPointTimeSpatialTensor d n φ χ :
+          SchwartzNPoint d n) : NPointDomain d n → ℂ) := by
+  let e := nPointTimeSpatialCLE (d := d) n
+  let K : Set (NPointDomain d n) :=
+    e.symm '' (tsupport (φ : (Fin n → ℝ) → ℂ) ×ˢ
+      tsupport (χ : Section43SpatialSpace d n → ℂ))
+  have hKcompact : IsCompact K := by
+    exact (hφ.isCompact.prod hχ.isCompact).image e.symm.continuous
+  refine HasCompactSupport.of_support_subset_isCompact hKcompact ?_
+  intro q hq
+  rw [Function.mem_support] at hq
+  have hφq : φ (section43QTime (d := d) (n := n) q) ≠ 0 := by
+    intro hzero
+    apply hq
+    simp [section43NPointTimeSpatialTensor_apply, hzero]
+  have hχq : χ (section43QSpatial (d := d) (n := n) q) ≠ 0 := by
+    intro hzero
+    apply hq
+    simp [section43NPointTimeSpatialTensor_apply, hzero]
+  refine ⟨(section43QTime (d := d) (n := n) q,
+      section43QSpatial (d := d) (n := n) q), ?_, ?_⟩
+  · exact ⟨subset_tsupport _ (Function.mem_support.mpr hφq),
+      subset_tsupport _ (Function.mem_support.mpr hχq)⟩
+  · simp [e, section43QTime, section43QSpatial]
+
+/-- Compact time/spatial sources in difference variables, supported in the
+strict positive time orthant. -/
+structure Section43CompactStrictPositiveTimeSpatialSource
+    (d n : ℕ) [NeZero d] where
+  f : SchwartzNPoint d n
+  positive :
+    tsupport (f : NPointDomain d n → ℂ) ⊆
+      {q | ∀ i : Fin n, 0 < section43QTime (d := d) (n := n) q i}
+  compact : HasCompactSupport (f : NPointDomain d n → ℂ)
+
+/-- Product a compact strict-positive time source with a compact spatial source,
+then transport it to the `n`-point difference-coordinate Schwartz space. -/
+noncomputable def section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n) :
+    Section43CompactStrictPositiveTimeSpatialSource d n where
+  f := section43NPointTimeSpatialTensor d n g.f κ.1
+  positive := by
+    intro q hq i
+    exact g.positive
+      (tsupport_section43NPointTimeSpatialTensor_subset_time_preimage
+        d n g.f κ.1 hq) i
+  compact :=
+    hasCompactSupport_section43NPointTimeSpatialTensor
+      d n g.f κ.1 g.compact κ.2
+
+/-- The fixed-time spatial slice of a product source is scalar multiplication
+of the spatial source by the time-source value. -/
+theorem partialEval₂_section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n)
+    (τ : Fin n → ℝ) :
+    SchwartzMap.partialEval₂
+      (nPointSpatialTimeSchwartzCLE (d := d) (n := n)
+        (section43TimeSpatialProductSource d n g κ).f) τ =
+    g.f τ • κ.1 := by
+  ext η
+  change
+    nPointSpatialTimeSchwartzCLE (d := d) (n := n)
+      (section43TimeSpatialProductSource d n g κ).f (η, τ) =
+    (g.f τ • κ.1) η
+  rw [nPointSpatialTimeSchwartzCLE_apply]
+  change
+    nPointTimeSpatialSchwartzCLE (d := d) (n := n)
+      (section43NPointTimeSpatialTensor d n g.f κ.1) (τ, η) =
+    (g.f τ • κ.1) η
+  change section43TimeSpatialTensor d n g.f κ.1 (τ, η) = (g.f τ • κ.1) η
+  simp [smul_eq_mul]
+
+/-- The partial spatial Fourier transform of a product source factorizes into
+the time source times the full spatial Fourier transform of the spatial
+source. -/
+theorem partialFourierSpatial_fun_section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n)
+    (τ : Fin n → ℝ) (ξ : Section43SpatialSpace d n) :
+    partialFourierSpatial_fun
+      (d := d) (n := n)
+      (section43TimeSpatialProductSource d n g κ).f
+      (τ, ξ) =
+    g.f τ * (SchwartzMap.fourierTransformCLM ℂ κ.1) ξ := by
+  rw [partialFourierSpatial_fun]
+  change
+    (SchwartzMap.fourierTransformCLM ℂ
+      (SchwartzMap.partialEval₂
+        (nPointSpatialTimeSchwartzCLE (d := d) (n := n)
+          (section43TimeSpatialProductSource d n g κ).f) τ)) ξ =
+      g.f τ * (SchwartzMap.fourierTransformCLM ℂ κ.1) ξ
+  rw [partialEval₂_section43TimeSpatialProductSource]
+  rw [(SchwartzMap.fourierTransformCLM ℂ).map_smul]
+  simp [smul_eq_mul]
+
 end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceTimeProduct.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceTimeProduct.lean
@@ -1,0 +1,901 @@
+import Mathlib.MeasureTheory.Integral.Pi
+import OSReconstruction.Wightman.Reconstruction.DenseCLM
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceFiniteProbe
+
+/-!
+# Section 4.3 finite time-product density support
+
+This file starts the finite-time product layer of the Section 4.3 OS-route
+density theorem.  It keeps the multitime quotient/source surface separate from
+the already-large one-variable and finite-probe files.
+-/
+
+noncomputable section
+
+open scoped Topology FourierTransform BoundedContinuousFunction
+open Set MeasureTheory Filter
+
+namespace OSReconstruction
+
+/-- Closed positive orthant in the finite Euclidean time variables. -/
+def section43TimePositiveRegion (n : ℕ) : Set (Fin n → ℝ) :=
+  {τ | ∀ i : Fin n, 0 ≤ τ i}
+
+/-- Strict positive orthant in the finite Euclidean time variables. -/
+def section43TimeStrictPositiveRegion (n : ℕ) : Set (Fin n → ℝ) :=
+  {τ | ∀ i : Fin n, 0 < τ i}
+
+/-- The one-sided collar around the finite-time positive orthant. -/
+def section43TimePositiveThickening (n : ℕ) (ε : ℝ) : Set (Fin n → ℝ) :=
+  {τ | ∀ i : Fin n, -ε ≤ τ i}
+
+/-- Product cutoff for the finite-time positive orthant.  It is one on the
+closed positive orthant and vanishes once any coordinate is at most `-1`. -/
+noncomputable def section43TimePositiveCutoff (n : ℕ) :
+    (Fin n → ℝ) → ℂ :=
+  fun τ => ∏ i : Fin n, (SCV.smoothCutoff (τ i) : ℂ)
+
+/-- The finite-time positive cutoff is exactly `1` on the closed positive
+orthant. -/
+theorem section43TimePositiveCutoff_eq_one_of_mem
+    {n : ℕ} {τ : Fin n → ℝ}
+    (hτ : τ ∈ section43TimePositiveRegion n) :
+    section43TimePositiveCutoff n τ = 1 := by
+  rw [section43TimePositiveCutoff]
+  apply Finset.prod_eq_one
+  intro i _hi
+  have hi : 0 ≤ τ i := hτ i
+  rw [SCV.smoothCutoff_one_of_nonneg hi]
+  simp
+
+/-- The finite-time positive cutoff vanishes when one coordinate lies at or
+below `-1`. -/
+theorem section43TimePositiveCutoff_eq_zero_of_time_le_neg_one
+    {n : ℕ} {τ : Fin n → ℝ} {i : Fin n}
+    (hi : τ i ≤ -1) :
+    section43TimePositiveCutoff n τ = 0 := by
+  rw [section43TimePositiveCutoff]
+  exact Finset.prod_eq_zero (Finset.mem_univ i) (by
+    rw [SCV.smoothCutoff_zero_of_le_neg_one hi]
+    simp)
+
+/-- The finite-time positive cutoff vanishes outside the unit one-sided
+collar. -/
+theorem section43TimePositiveCutoff_eq_zero_of_not_mem_thickening_one
+    {n : ℕ} {τ : Fin n → ℝ}
+    (hτ : τ ∉ section43TimePositiveThickening n 1) :
+    section43TimePositiveCutoff n τ = 0 := by
+  rw [section43TimePositiveThickening] at hτ
+  rcases not_forall.mp hτ with ⟨i, hi_not⟩
+  have hi : τ i < -1 := not_le.mp hi_not
+  exact section43TimePositiveCutoff_eq_zero_of_time_le_neg_one
+    (n := n) (τ := τ) (i := i) (le_of_lt hi)
+
+/-- The finite-time product cutoff is ambient smooth. -/
+theorem section43TimePositiveCutoff_contDiff
+    (n : ℕ) :
+    ContDiff ℝ (↑(⊤ : ℕ∞)) (section43TimePositiveCutoff n) := by
+  change ContDiff ℝ (↑(⊤ : ℕ∞))
+    (fun τ : Fin n → ℝ => ∏ i : Fin n, (SCV.smoothCutoff (τ i) : ℂ))
+  apply contDiff_prod
+  intro i _hi
+  have hcoord :
+      ContDiff ℝ (↑(⊤ : ℕ∞)) (fun τ : Fin n → ℝ => τ i) := by
+    simpa using
+      ((ContinuousLinearMap.proj (R := ℝ) (ι := Fin n) (φ := fun _ => ℝ) i).contDiff :
+        ContDiff ℝ (↑(⊤ : ℕ∞)) (fun τ : Fin n → ℝ =>
+          (ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+            (φ := fun _ => ℝ) i) τ))
+  exact Complex.ofRealCLM.contDiff.comp (SCV.smoothCutoff_contDiff.comp hcoord)
+
+/-- The finite-time product cutoff has temperate growth. -/
+theorem section43TimePositiveCutoff_hasTemperateGrowth
+    (n : ℕ) :
+    Function.HasTemperateGrowth (section43TimePositiveCutoff n) := by
+  classical
+  change Function.HasTemperateGrowth
+    (fun τ : Fin n → ℝ => ∏ i : Fin n, (SCV.smoothCutoff (τ i) : ℂ))
+  let factor : Fin n → (Fin n → ℝ) → ℂ := fun i τ =>
+    (SCV.smoothCutoff (τ i) : ℂ)
+  have hfactor : ∀ i : Fin n, Function.HasTemperateGrowth (factor i) := by
+    intro i
+    have hcoord : Function.HasTemperateGrowth (fun τ : Fin n → ℝ => τ i) := by
+      simpa using
+        ((ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+          (φ := fun _ => ℝ) i).hasTemperateGrowth :
+          Function.HasTemperateGrowth (fun τ : Fin n → ℝ =>
+            (ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+              (φ := fun _ => ℝ) i) τ))
+    simpa [factor, Function.comp_def] using
+      SCV.smoothCutoff_complex_hasTemperateGrowth.comp hcoord
+  have hprod : Function.HasTemperateGrowth
+      (fun τ : Fin n → ℝ => ∏ i : Fin n, factor i τ) := by
+    let P : Finset (Fin n) → Prop := fun s =>
+      Function.HasTemperateGrowth
+        (fun τ : Fin n → ℝ => ∏ i ∈ s, factor i τ)
+    change P Finset.univ
+    refine Finset.induction_on (Finset.univ : Finset (Fin n)) ?empty ?insert
+    · simp [P, Function.HasTemperateGrowth.const]
+    · intro a s has ih
+      have ha : Function.HasTemperateGrowth (factor a) := hfactor a
+      have hs : Function.HasTemperateGrowth
+          (fun τ : Fin n → ℝ => ∏ i ∈ s, factor i τ) := ih
+      simpa [P, Finset.prod_insert has] using ha.mul hs
+  simpa [factor] using hprod
+
+/-- Every derivative of the finite-time product cutoff vanishes outside the
+unit one-sided collar. -/
+theorem section43TimePositiveCutoff_iteratedFDeriv_eq_zero_of_not_mem_thickening_one
+    {n r : ℕ} {τ : Fin n → ℝ}
+    (hτ : τ ∉ section43TimePositiveThickening n 1) :
+    iteratedFDeriv ℝ r (section43TimePositiveCutoff n) τ = 0 := by
+  rw [section43TimePositiveThickening] at hτ
+  rcases not_forall.mp hτ with ⟨i, hi_not⟩
+  have hi : τ i < -1 := not_le.mp hi_not
+  have hcoord_cont : Continuous fun τ' : Fin n → ℝ => τ' i :=
+    continuous_apply i
+  have hlt_event : ∀ᶠ τ' in 𝓝 τ, τ' i < -1 :=
+    (isOpen_lt hcoord_cont continuous_const).mem_nhds hi
+  have hzero_event : section43TimePositiveCutoff n =ᶠ[𝓝 τ] 0 := by
+    filter_upwards [hlt_event] with τ' hτ'
+    exact section43TimePositiveCutoff_eq_zero_of_time_le_neg_one
+      (n := n) (τ := τ') (i := i) (le_of_lt hτ')
+  exact iteratedFDeriv_eq_zero_of_eventuallyEq_zero hzero_event r
+
+/-- The support of every derivative of the finite-time positive cutoff is
+contained in the unit one-sided collar. -/
+theorem section43TimePositiveCutoff_iteratedFDeriv_support_subset_thickening_one
+    (n r : ℕ) :
+    ∀ τ : Fin n → ℝ,
+      iteratedFDeriv ℝ r (section43TimePositiveCutoff n) τ ≠ 0 →
+        τ ∈ section43TimePositiveThickening n 1 := by
+  intro τ hτ_nonzero
+  by_contra hτ
+  exact hτ_nonzero
+    (section43TimePositiveCutoff_iteratedFDeriv_eq_zero_of_not_mem_thickening_one
+      (n := n) (r := r) (τ := τ) hτ)
+
+/-- Time-Schwartz tests that vanish on the closed positive orthant. -/
+def section43TimeVanishingSubmodule (n : ℕ) :
+    Submodule ℂ (SchwartzMap (Fin n → ℝ) ℂ) where
+  carrier := {f |
+    Set.EqOn (f : (Fin n → ℝ) → ℂ) 0 (section43TimePositiveRegion n)}
+  zero_mem' := by
+    intro x hx
+    simp
+  add_mem' := by
+    intro f g hf hg x hx
+    simp [hf hx, hg hx]
+  smul_mem' := by
+    intro c f hf x hx
+    simp [hf hx]
+
+/-- The finite-time positive-energy quotient before the spatial Fourier layer. -/
+abbrev Section43TimePositiveComponent (n : ℕ) :=
+  (SchwartzMap (Fin n → ℝ) ℂ) ⧸ section43TimeVanishingSubmodule n
+
+/-- The canonical quotient map onto the finite-time positive-energy component. -/
+noncomputable def section43TimePositiveQuotientMap (n : ℕ) :
+    SchwartzMap (Fin n → ℝ) ℂ →L[ℂ] Section43TimePositiveComponent n :=
+  ContinuousLinearMap.mk
+    (Submodule.mkQ (section43TimeVanishingSubmodule n))
+    ((section43TimeVanishingSubmodule n).isOpenQuotientMap_mkQ.continuous)
+
+/-- Equality on the closed positive orthant gives equality in the finite-time
+quotient. -/
+theorem section43TimePositiveQuotientMap_eq_of_eqOn_region
+    {n : ℕ} {f g : SchwartzMap (Fin n → ℝ) ℂ}
+    (hfg :
+      Set.EqOn (f : (Fin n → ℝ) → ℂ) (g : (Fin n → ℝ) → ℂ)
+        (section43TimePositiveRegion n)) :
+    section43TimePositiveQuotientMap n f =
+      section43TimePositiveQuotientMap n g := by
+  change (Submodule.Quotient.mk f : Section43TimePositiveComponent n) =
+    Submodule.Quotient.mk g
+  rw [Submodule.Quotient.eq]
+  change Set.EqOn ((f - g : SchwartzMap (Fin n → ℝ) ℂ) :
+      (Fin n → ℝ) → ℂ) 0 (section43TimePositiveRegion n)
+  intro x hx
+  have hEq : f x = g x := hfg hx
+  simp [hEq]
+
+/-- Quotient equality is equality on the closed positive orthant. -/
+theorem eqOn_region_of_section43TimePositiveQuotientMap_eq
+    {n : ℕ} {f g : SchwartzMap (Fin n → ℝ) ℂ}
+    (hfg :
+      section43TimePositiveQuotientMap n f =
+        section43TimePositiveQuotientMap n g) :
+    Set.EqOn (f : (Fin n → ℝ) → ℂ) (g : (Fin n → ℝ) → ℂ)
+      (section43TimePositiveRegion n) := by
+  change (Submodule.Quotient.mk f : Section43TimePositiveComponent n) =
+    Submodule.Quotient.mk g at hfg
+  rw [Submodule.Quotient.eq] at hfg
+  intro x hx
+  have hx0 : ((f - g : SchwartzMap (Fin n → ℝ) ℂ) :
+      (Fin n → ℝ) → ℂ) x = 0 := hfg hx
+  exact sub_eq_zero.mp <| by simpa using hx0
+
+/-- Pure tensor of one-variable time Schwartz functions. -/
+noncomputable def section43TimeProductTensor
+    {n : ℕ} (fs : Fin n → SchwartzMap ℝ ℂ) :
+    SchwartzMap (Fin n → ℝ) ℂ :=
+  SchwartzMap.productTensor fs
+
+/-- Identify finite time tuples with tuples of one-point time functions, so the
+existing product-tensor density theorem at `d = 0` can be transported to
+`SchwartzMap (Fin n → ℝ) ℂ`. -/
+noncomputable def section43TimeAsOnePointCLE (n : ℕ) :
+    (Fin n → ℝ) ≃L[ℝ] (Fin n → Fin 1 → ℝ) :=
+  ContinuousLinearEquiv.piCongrRight
+    (fun _ : Fin n => (ContinuousLinearEquiv.funUnique (Fin 1) ℝ ℝ).symm)
+
+@[simp] theorem section43TimeAsOnePointCLE_apply
+    (n : ℕ) (x : Fin n → ℝ) (i : Fin n) (j : Fin 1) :
+    section43TimeAsOnePointCLE n x i j = x i := by
+  simp [section43TimeAsOnePointCLE, ContinuousLinearEquiv.piCongrRight]
+
+@[simp] theorem section43TimeAsOnePointCLE_symm_apply
+    (n : ℕ) (x : Fin n → Fin 1 → ℝ) (i : Fin n) :
+    (section43TimeAsOnePointCLE n).symm x i = x i 0 := by
+  change (ContinuousLinearEquiv.funUnique (Fin 1) ℝ ℝ) (x i) = x i 0
+  simp [ContinuousLinearEquiv.coe_funUnique]
+
+/-- Transporting a time product tensor to one-point time coordinates is the
+product tensor of the transported one-variable factors. -/
+theorem section43TimeAsOnePoint_productTensor
+    {n : ℕ} (fs : Fin n → SchwartzMap ℝ ℂ) :
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+        (section43TimeAsOnePointCLE n).symm
+        (section43TimeProductTensor fs)
+      =
+    SchwartzMap.productTensor
+      (fun i : Fin n =>
+        SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+          (ContinuousLinearEquiv.funUnique (Fin 1) ℝ ℝ)
+          (fs i)) := by
+  ext x
+  simp [section43TimeProductTensor, SchwartzMap.compCLMOfContinuousLinearEquiv_apply,
+    SchwartzMap.productTensor_apply]
+
+/-- Pulling a one-point-coordinate product tensor back to ordinary time
+coordinates is the product tensor of the pulled-back one-variable factors. -/
+theorem section43TimeAsOnePoint_symm_productTensor
+    {n : ℕ} (fs : Fin n → SchwartzMap (Fin 1 → ℝ) ℂ) :
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+        (section43TimeAsOnePointCLE n)
+        (SchwartzMap.productTensor fs)
+      =
+    section43TimeProductTensor
+      (fun i : Fin n =>
+        SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+          (ContinuousLinearEquiv.funUnique (Fin 1) ℝ ℝ).symm
+          (fs i)) := by
+  ext x
+  simp only [section43TimeProductTensor, SchwartzMap.compCLMOfContinuousLinearEquiv_apply,
+    SchwartzMap.productTensor_apply, Function.comp_apply]
+  refine Finset.prod_congr rfl ?_
+  intro i _hi
+  congr 1
+
+@[simp] theorem section43TimeAsOnePoint_comp_symm
+    {n : ℕ} (f : SchwartzMap (Fin n → ℝ) ℂ) :
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ (section43TimeAsOnePointCLE n)
+        (SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+          (section43TimeAsOnePointCLE n).symm f) = f := by
+  ext x
+  simp [SchwartzMap.compCLMOfContinuousLinearEquiv_apply]
+
+@[simp] theorem section43TimeAsOnePoint_symm_comp
+    {n : ℕ} (f : SchwartzMap (Fin n → Fin 1 → ℝ) ℂ) :
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ (section43TimeAsOnePointCLE n).symm
+        (SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+          (section43TimeAsOnePointCLE n) f) = f := by
+  ext x
+  simp [SchwartzMap.compCLMOfContinuousLinearEquiv_apply]
+
+/-- The span of ordinary finite-time product tensors is dense in the finite-time
+Schwartz space.  This is `productTensor_span_dense 0 n` transported from
+one-point spacetime coordinates to ordinary real time coordinates. -/
+theorem section43_timeProductTensor_span_dense (n : ℕ) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzMap (Fin n → ℝ) ℂ |
+          ∃ fs : Fin n → SchwartzMap ℝ ℂ,
+            F = section43TimeProductTensor fs}) :
+        Submodule ℂ (SchwartzMap (Fin n → ℝ) ℂ)) :
+        Set (SchwartzMap (Fin n → ℝ) ℂ)) := by
+  let A := SchwartzMap (Fin n → ℝ) ℂ
+  let B := SchwartzMap (Fin n → Fin 1 → ℝ) ℂ
+  let P : Set A :=
+    {F : A | ∃ fs : Fin n → SchwartzMap ℝ ℂ,
+      F = section43TimeProductTensor fs}
+  let M : Submodule ℂ A := Submodule.span ℂ P
+  let P0 : Set B :=
+    {F : B | ∃ fs : Fin n → SchwartzMap (Fin 1 → ℝ) ℂ,
+      F = SchwartzMap.productTensor fs}
+  let M0 : Submodule ℂ B := Submodule.span ℂ P0
+  let toA : B →L[ℂ] A :=
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ (section43TimeAsOnePointCLE n)
+  let toB : A →L[ℂ] B :=
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ (section43TimeAsOnePointCLE n).symm
+  change Dense (M : Set A)
+  have hM0_dense : Dense (M0 : Set B) := by
+    simpa [M0, P0, B, SchwartzNPointSpace, NPointSpacetime] using
+      productTensor_span_dense 0 n
+  rw [Submodule.dense_iff_topologicalClosure_eq_top]
+  apply Submodule.eq_top_iff'.mpr
+  intro x
+  let preM : Submodule ℂ B := M.topologicalClosure.comap toA.toLinearMap
+  have hM0_le : M0 ≤ preM := by
+    refine Submodule.span_le.mpr ?_
+    intro y hy
+    rcases hy with ⟨fs, rfl⟩
+    change toA (SchwartzMap.productTensor fs) ∈ M.topologicalClosure
+    have hP : toA (SchwartzMap.productTensor fs) ∈ P := by
+      refine ⟨fun i : Fin n =>
+        SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+          (ContinuousLinearEquiv.funUnique (Fin 1) ℝ ℝ).symm (fs i), ?_⟩
+      exact section43TimeAsOnePoint_symm_productTensor fs
+    exact M.le_topologicalClosure (Submodule.subset_span hP)
+  have hpre_closed : IsClosed (preM : Set B) := by
+    change IsClosed {y : B | toA y ∈ (M.topologicalClosure : Set A)}
+    exact M.isClosed_topologicalClosure.preimage toA.continuous
+  have htop_le_pre : (⊤ : Submodule ℂ B) ≤ preM := by
+    have hclosure : M0.topologicalClosure ≤ preM :=
+      M0.topologicalClosure_minimal hM0_le hpre_closed
+    rwa [(Submodule.dense_iff_topologicalClosure_eq_top).mp hM0_dense] at hclosure
+  have hxpre : toB x ∈ preM := htop_le_pre trivial
+  change toA (toB x) ∈ M.topologicalClosure at hxpre
+  simpa [toA, toB] using hxpre
+
+/-- If a one-variable set of Schwartz functions is dense, then finite sums of
+time product tensors with all factors in that set are dense in finite-time
+Schwartz space. -/
+theorem section43_timeProductTensor_span_dense_of_factor_dense
+    {S : Set (SchwartzMap ℝ ℂ)}
+    (hS : Dense S) (n : ℕ) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzMap (Fin n → ℝ) ℂ |
+          ∃ fs : Fin n → SchwartzMap ℝ ℂ,
+            (∀ i : Fin n, fs i ∈ S) ∧
+            F = section43TimeProductTensor fs}) :
+        Submodule ℂ (SchwartzMap (Fin n → ℝ) ℂ)) :
+        Set (SchwartzMap (Fin n → ℝ) ℂ)) := by
+  let E := SchwartzMap ℝ ℂ
+  let A := SchwartzMap (Fin n → ℝ) ℂ
+  let PS : Set A :=
+    {F : A | ∃ fs : Fin n → E,
+      (∀ i : Fin n, fs i ∈ S) ∧ F = section43TimeProductTensor fs}
+  let MS : Submodule ℂ A := Submodule.span ℂ PS
+  let Pall : Set A :=
+    {F : A | ∃ fs : Fin n → E, F = section43TimeProductTensor fs}
+  let Mall : Submodule ℂ A := Submodule.span ℂ Pall
+  change Dense (MS : Set A)
+  let D : Set (Fin n → E) := {fs | ∀ i : Fin n, fs i ∈ S}
+  have hD : Dense D := by
+    have hD' : Dense (Set.pi (Set.univ : Set (Fin n)) (fun _ : Fin n => S)) :=
+      dense_pi (I := (Set.univ : Set (Fin n)))
+        (s := fun _ : Fin n => S) (fun i _hi => hS)
+    simpa [D, Set.pi] using hD'
+  have hTcont :
+      Continuous (fun fs : Fin n → E => section43TimeProductTensor fs) := by
+    simpa [section43TimeProductTensor, E] using
+      (SchwartzMap.productTensor_continuous (E := ℝ) (n := n))
+  have hPall_le_MSclosure : Mall ≤ MS.topologicalClosure := by
+    refine Submodule.span_le.mpr ?_
+    intro F hF
+    rcases hF with ⟨fs, rfl⟩
+    have himage_subset :
+        (fun gs : Fin n → E => section43TimeProductTensor gs) '' D ⊆
+          (MS : Set A) := by
+      rintro _ ⟨gs, hgs, rfl⟩
+      exact Submodule.subset_span ⟨gs, hgs, rfl⟩
+    have hmem_image_closure :
+        section43TimeProductTensor fs ∈
+          closure ((fun gs : Fin n → E => section43TimeProductTensor gs) '' D) := by
+      exact hTcont.range_subset_closure_image_dense hD ⟨fs, rfl⟩
+    change section43TimeProductTensor fs ∈ closure (MS : Set A)
+    exact closure_mono himage_subset hmem_image_closure
+  have hMall_dense : Dense (Mall : Set A) := by
+    simpa [Mall, Pall, A, E] using section43_timeProductTensor_span_dense n
+  rw [Submodule.dense_iff_topologicalClosure_eq_top]
+  apply Submodule.eq_top_iff'.mpr
+  intro x
+  have hxMall : x ∈ Mall.topologicalClosure := by
+    rw [(Submodule.dense_iff_topologicalClosure_eq_top).mp hMall_dense]
+    trivial
+  have hclosure_le : Mall.topologicalClosure ≤ MS.topologicalClosure :=
+    Mall.topologicalClosure_minimal hPall_le_MSclosure MS.isClosed_topologicalClosure
+  exact hclosure_le hxMall
+
+/-- A compact subset of the strict positive half-line has a positive lower
+margin from the boundary. -/
+theorem exists_positive_margin_of_isCompact_subset_Ioi
+    {K : Set ℝ} (hK_compact : IsCompact K) (hK_pos : K ⊆ Set.Ioi (0 : ℝ)) :
+    ∃ δ > 0, K ⊆ Set.Ici δ := by
+  classical
+  by_cases hne : K.Nonempty
+  · obtain ⟨x0, hx0, hx0_min⟩ :=
+      hK_compact.exists_isMinOn hne continuous_id.continuousOn
+    have hx0_pos : 0 < x0 := hK_pos hx0
+    refine ⟨x0 / 2, by linarith, ?_⟩
+    intro x hx
+    have hle : x0 ≤ x := isMinOn_iff.mp hx0_min x hx
+    exact Set.mem_Ici.mpr (by linarith)
+  · refine ⟨1, by norm_num, ?_⟩
+    intro x hx
+    exact False.elim (hne ⟨x, hx⟩)
+
+/-- A compact Schwartz source supported in the strict positive time orthant. -/
+structure Section43CompactStrictPositiveTimeSource (n : ℕ) where
+  f : SchwartzMap (Fin n → ℝ) ℂ
+  positive :
+    tsupport (f : (Fin n → ℝ) → ℂ) ⊆
+      section43TimeStrictPositiveRegion n
+  compact : HasCompactSupport (f : (Fin n → ℝ) → ℂ)
+
+namespace Section43CompactStrictPositiveTimeSource
+
+private theorem ext_f {n : ℕ}
+    {g h : Section43CompactStrictPositiveTimeSource n}
+    (hf : g.f = h.f) : g = h := by
+  cases g
+  cases h
+  simp at hf
+  subst hf
+  rfl
+
+private theorem f_injective (n : ℕ) :
+    Function.Injective
+      (fun g : Section43CompactStrictPositiveTimeSource n => g.f) := by
+  intro g h hf
+  exact ext_f hf
+
+instance (n : ℕ) : Zero (Section43CompactStrictPositiveTimeSource n) where
+  zero :=
+    { f := 0
+      positive := by
+        intro t ht
+        simp at ht
+      compact := by
+        simpa using
+          (HasCompactSupport.zero :
+            HasCompactSupport (0 : (Fin n → ℝ) → ℂ)) }
+
+instance (n : ℕ) : Add (Section43CompactStrictPositiveTimeSource n) where
+  add g h :=
+    { f := g.f + h.f
+      positive := by
+        intro t ht
+        have ht' := tsupport_add (g.f : (Fin n → ℝ) → ℂ)
+          (h.f : (Fin n → ℝ) → ℂ) ht
+        exact ht'.elim (fun hg => g.positive hg) (fun hh => h.positive hh)
+      compact := by
+        simpa using HasCompactSupport.add g.compact h.compact }
+
+instance (n : ℕ) : SMul ℕ (Section43CompactStrictPositiveTimeSource n) where
+  smul m g :=
+    { f := (m : ℂ) • g.f
+      positive := by
+        exact
+          (tsupport_smul_subset_right
+            (fun _ : Fin n → ℝ => (m : ℂ))
+            (g.f : (Fin n → ℝ) → ℂ)).trans g.positive
+      compact := by
+        simpa using
+          (HasCompactSupport.smul_left
+            (f := fun _ : Fin n → ℝ => (m : ℂ))
+            (f' := (g.f : (Fin n → ℝ) → ℂ)) g.compact) }
+
+instance (n : ℕ) : AddCommMonoid (Section43CompactStrictPositiveTimeSource n) :=
+  Function.Injective.addCommMonoid
+    (fun g : Section43CompactStrictPositiveTimeSource n => g.f)
+    (f_injective n) rfl
+    (by intro g h; rfl)
+    (by
+      intro g m
+      change (m : ℂ) • g.f = m • g.f
+      rw [Nat.cast_smul_eq_nsmul ℂ])
+
+instance (n : ℕ) : SMul ℂ (Section43CompactStrictPositiveTimeSource n) where
+  smul c g :=
+    { f := c • g.f
+      positive := by
+        exact
+          (tsupport_smul_subset_right
+            (fun _ : Fin n → ℝ => c)
+            (g.f : (Fin n → ℝ) → ℂ)).trans g.positive
+      compact := by
+        simpa using
+          (HasCompactSupport.smul_left
+            (f := fun _ : Fin n → ℝ => c)
+            (f' := (g.f : (Fin n → ℝ) → ℂ)) g.compact) }
+
+private def fAddMonoidHom (n : ℕ) :
+    Section43CompactStrictPositiveTimeSource n →+
+      SchwartzMap (Fin n → ℝ) ℂ where
+  toFun := fun g => g.f
+  map_zero' := rfl
+  map_add' := by intro g h; rfl
+
+instance (n : ℕ) : Module ℂ (Section43CompactStrictPositiveTimeSource n) :=
+  Function.Injective.module ℂ (fAddMonoidHom n)
+    (by
+      intro g h hf
+      exact (f_injective n) hf)
+    (by intro c g; rfl)
+
+end Section43CompactStrictPositiveTimeSource
+
+/-- Compact strict-positive finite-time support has a uniform positive margin
+from every time wall. -/
+theorem exists_positive_margin_of_compact_time_tsupport_subset_strictPositive
+    {n : ℕ} (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ δ, 0 < δ ∧
+      tsupport (g.f : (Fin n → ℝ) → ℂ) ⊆
+        {τ | ∀ i : Fin n, δ ≤ τ i} := by
+  classical
+  let K : Set (Fin n → ℝ) := tsupport (g.f : (Fin n → ℝ) → ℂ)
+  have hK_compact : IsCompact K := by
+    simpa [K, HasCompactSupport] using g.compact
+  by_cases hnonempty : Nonempty (Fin n)
+  · letI : Nonempty (Fin n) := hnonempty
+    have hcoord_margin :
+        ∀ i : Fin n,
+          ∃ δ > 0, ((fun τ : Fin n → ℝ => τ i) '' K) ⊆ Set.Ici δ := by
+      intro i
+      have himage_compact :
+          IsCompact ((fun τ : Fin n → ℝ => τ i) '' K) :=
+        hK_compact.image (continuous_apply i)
+      have himage_pos :
+          ((fun τ : Fin n → ℝ => τ i) '' K) ⊆ Set.Ioi (0 : ℝ) := by
+        rintro _ ⟨τ, hτ, rfl⟩
+        exact g.positive hτ i
+      exact exists_positive_margin_of_isCompact_subset_Ioi himage_compact himage_pos
+    choose δ hδ_pos hδ_supp using hcoord_margin
+    let δmin : ℝ := Finset.univ.inf' Finset.univ_nonempty δ
+    have hδmin_pos : 0 < δmin := by
+      obtain ⟨i, _hi, hmin⟩ := Finset.exists_mem_eq_inf' Finset.univ_nonempty δ
+      dsimp [δmin]
+      rw [hmin]
+      exact hδ_pos i
+    refine ⟨δmin, hδmin_pos, ?_⟩
+    intro τ hτ i
+    have hδmin_le : δmin ≤ δ i := by
+      dsimp [δmin]
+      exact Finset.inf'_le δ (Finset.mem_univ i)
+    have hcoord : τ i ∈ ((fun τ : Fin n → ℝ => τ i) '' K) :=
+      ⟨τ, hτ, rfl⟩
+    exact hδmin_le.trans (hδ_supp i hcoord)
+  · refine ⟨1, by norm_num, ?_⟩
+    intro τ _hτ i
+    exact False.elim (hnonempty ⟨i⟩)
+
+/-- Compact finite-time support is contained in some closed ball centered at
+zero. -/
+theorem exists_time_closedBall_of_compact_tsupport
+    {n : ℕ} (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ R, 0 ≤ R ∧
+      tsupport (g.f : (Fin n → ℝ) → ℂ) ⊆
+        Metric.closedBall (0 : Fin n → ℝ) R := by
+  let K : Set (Fin n → ℝ) := tsupport (g.f : (Fin n → ℝ) → ℂ)
+  have hK_compact : IsCompact K := by
+    simpa [K, HasCompactSupport] using g.compact
+  obtain ⟨B, hB⟩ :=
+    hK_compact.exists_bound_of_continuousOn
+      (f := fun τ : Fin n → ℝ => ‖τ‖) continuous_norm.continuousOn
+  refine ⟨max B 0, le_max_right B 0, ?_⟩
+  intro τ hτ
+  have hτB : ‖τ‖ ≤ B := by
+    have h := hB τ hτ
+    simpa [Real.norm_eq_abs, norm_nonneg] using h
+  have hτR : ‖τ‖ ≤ max B 0 := hτB.trans (le_max_left B 0)
+  simpa [Metric.mem_closedBall, dist_eq_norm, sub_zero] using hτR
+
+/-- In finite-dimensional time domain, continuity of a family of continuous
+multilinear maps is equivalent to continuity of all applied scalar families. -/
+theorem continuous_cmlm_apply_time
+    (n r : ℕ)
+    {X : Type*} [TopologicalSpace X]
+    {L : X →
+      ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ} :
+    Continuous L ↔
+      ∀ m : Fin r → (Fin n → ℝ), Continuous fun x => L x m := by
+  induction r generalizing X with
+  | zero =>
+      constructor
+      · intro hL m
+        exact
+          (ContinuousMultilinearMap.apply ℝ
+            (fun _ : Fin 0 => Fin n → ℝ) ℂ m).continuous.comp hL
+      · intro h
+        let e :=
+          continuousMultilinearCurryFin0 ℝ (Fin n → ℝ) ℂ
+        have he : Continuous fun x => e (L x) := by
+          simpa [e] using h (0 : Fin 0 → (Fin n → ℝ))
+        have hback : Continuous fun x => e.symm (e (L x)) :=
+          e.symm.continuous.comp he
+        simpa [e] using hback
+  | succ r ih =>
+      constructor
+      · intro hL m
+        exact
+          (ContinuousMultilinearMap.apply ℝ
+            (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ m).continuous.comp hL
+      · intro h
+        let e :=
+          continuousMultilinearCurryLeftEquiv ℝ
+            (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ
+        have hcurry : Continuous fun x => e (L x) := by
+          refine (continuous_clm_apply
+            (𝕜 := ℝ) (E := Fin n → ℝ)).2 ?_
+          intro head
+          refine (ih (L := fun x => e (L x) head)).2 ?_
+          intro tail
+          simpa [e, ContinuousMultilinearMap.curryLeft_apply] using
+            h (Fin.cons head tail)
+        have hback : Continuous fun x => e.symm (e (L x)) :=
+          e.symm.continuous.comp hcurry
+        simpa [e] using hback
+
+/-- The topological support of a product tensor is contained in the product of
+the topological supports of its one-variable compact factors. -/
+theorem tsupport_section43TimeProductTensor_subset_pi_tsupport
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    tsupport
+      ((section43TimeProductTensor (fun i : Fin n => (gs i).f) :
+          SchwartzMap (Fin n → ℝ) ℂ) : (Fin n → ℝ) → ℂ)
+      ⊆ {x | ∀ i : Fin n, x i ∈ tsupport ((gs i).f : ℝ → ℂ)} := by
+  intro x hx i
+  by_contra hxi
+  have hlocal :
+      ((gs i).f : ℝ → ℂ) =ᶠ[𝓝 (x i)] 0 :=
+    notMem_tsupport_iff_eventuallyEq.mp hxi
+  have hcoord :
+      Tendsto (fun y : Fin n → ℝ => y i) (𝓝 x) (𝓝 (x i)) :=
+    (continuous_apply i).continuousAt
+  have hlocal_pi :
+      ∀ᶠ y in 𝓝 x, (gs i).f (y i) = 0 :=
+    hcoord.eventually hlocal
+  have hprod_zero :
+      ((section43TimeProductTensor (fun i : Fin n => (gs i).f) :
+          SchwartzMap (Fin n → ℝ) ℂ) : (Fin n → ℝ) → ℂ) =ᶠ[𝓝 x] 0 := by
+    filter_upwards [hlocal_pi] with y hy
+    rw [section43TimeProductTensor, SchwartzMap.productTensor_apply]
+    exact Finset.prod_eq_zero (Finset.mem_univ i) hy
+  exact (notMem_tsupport_iff_eventuallyEq.mpr hprod_zero) hx
+
+/-- A product tensor of compact one-variable strict-positive time sources has
+compact support in finite time space. -/
+theorem hasCompactSupport_section43TimeProductTensor
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    HasCompactSupport
+      ((section43TimeProductTensor (fun i : Fin n => (gs i).f) :
+          SchwartzMap (Fin n → ℝ) ℂ) : (Fin n → ℝ) → ℂ) := by
+  let K : Set (Fin n → ℝ) :=
+    Set.pi Set.univ (fun i : Fin n => tsupport ((gs i).f : ℝ → ℂ))
+  have hKcompact : IsCompact K := by
+    exact isCompact_univ_pi (fun i => (gs i).compact.isCompact)
+  refine HasCompactSupport.of_support_subset_isCompact hKcompact ?_
+  intro x hx
+  have hx_tsupport :
+      x ∈ tsupport
+        ((section43TimeProductTensor (fun i : Fin n => (gs i).f) :
+            SchwartzMap (Fin n → ℝ) ℂ) : (Fin n → ℝ) → ℂ) :=
+    subset_tsupport _ hx
+  have hxKset :
+      x ∈ {x | ∀ i : Fin n, x i ∈ tsupport ((gs i).f : ℝ → ℂ)} :=
+    tsupport_section43TimeProductTensor_subset_pi_tsupport gs hx_tsupport
+  simpa [K, Set.pi] using hxKset
+
+/-- The product of one-variable compact strict-positive time sources is a
+compact strict-positive source in the finite time variables. -/
+noncomputable def section43TimeProductSource
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    Section43CompactStrictPositiveTimeSource n :=
+  { f := section43TimeProductTensor (fun i : Fin n => (gs i).f)
+    positive := by
+      intro x hx i
+      exact (gs i).positive
+        (tsupport_section43TimeProductTensor_subset_pi_tsupport gs hx i)
+    compact := hasCompactSupport_section43TimeProductTensor gs }
+
+/-- The raw multitime one-sided Laplace scalar of a compact strict-positive
+finite-time source. -/
+noncomputable def section43IteratedLaplaceRaw
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) : ℂ :=
+  ∫ τ : Fin n → ℝ,
+    Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+      g.f τ
+
+/-- The cutoff version of the raw multitime Laplace scalar. -/
+noncomputable def section43IteratedLaplaceCutoffFun
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) : ℂ :=
+  section43TimePositiveCutoff n σ * section43IteratedLaplaceRaw n g σ
+
+/-- On the closed positive orthant the cutoff multitime Laplace scalar agrees
+with the raw scalar. -/
+theorem section43IteratedLaplaceCutoffFun_eq_raw_of_mem
+    {n : ℕ} (g : Section43CompactStrictPositiveTimeSource n)
+    {σ : Fin n → ℝ} (hσ : σ ∈ section43TimePositiveRegion n) :
+    section43IteratedLaplaceCutoffFun n g σ =
+      section43IteratedLaplaceRaw n g σ := by
+  rw [section43IteratedLaplaceCutoffFun,
+    section43TimePositiveCutoff_eq_one_of_mem hσ]
+  simp
+
+/-- For fixed source time `τ`, the finite-time Laplace integrand is smooth in
+the positive-energy variable `σ`. -/
+theorem contDiff_section43IteratedLaplaceRaw_integrand_sigma
+    {n : ℕ} (g : Section43CompactStrictPositiveTimeSource n)
+    (τ : Fin n → ℝ) :
+    ContDiff ℝ (⊤ : ℕ∞)
+      (fun σ : Fin n → ℝ =>
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+          g.f τ) := by
+  have harg : ContDiff ℝ (⊤ : ℕ∞)
+      (fun σ : Fin n → ℝ => -(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) := by
+    apply ContDiff.neg
+    apply ContDiff.sum
+    intro i _hi
+    have hcoord :
+        ContDiff ℝ (⊤ : ℕ∞) (fun σ : Fin n → ℝ => (σ i : ℂ)) := by
+      have hreal :
+          ContDiff ℝ (⊤ : ℕ∞) (fun σ : Fin n → ℝ => σ i) := by
+        simpa using
+          ((ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+            (φ := fun _ => ℝ) i).contDiff :
+            ContDiff ℝ (⊤ : ℕ∞) (fun σ : Fin n → ℝ =>
+              (ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+                (φ := fun _ => ℝ) i) σ))
+      exact Complex.ofRealCLM.contDiff.comp hreal
+    exact contDiff_const.mul hcoord
+  exact (Complex.contDiff_exp.comp harg).mul contDiff_const
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The pointwise all-order derivative of the finite-time Laplace integrand has
+derivative given by curry-left of the next pointwise derivative. -/
+theorem hasFDerivAt_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft
+    {n r : ℕ} (g : Section43CompactStrictPositiveTimeSource n)
+    (σ τ : Fin n → ℝ) :
+    HasFDerivAt
+      (fun σ' : Fin n → ℝ =>
+        iteratedFDeriv ℝ r
+          (fun σ'' : Fin n → ℝ =>
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+              g.f τ)
+          σ')
+      ((iteratedFDeriv ℝ (r + 1)
+        (fun σ'' : Fin n → ℝ =>
+          Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+            g.f τ)
+        σ).curryLeft)
+      σ := by
+  let G : (Fin n → ℝ) → ℂ := fun σ' =>
+    Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+      g.f τ
+  have hGsmooth : ContDiff ℝ (⊤ : ℕ∞) G := by
+    simpa [G] using contDiff_section43IteratedLaplaceRaw_integrand_sigma g τ
+  have hdiff : DifferentiableAt ℝ (iteratedFDeriv ℝ r G) σ := by
+    exact hGsmooth.contDiffAt.differentiableAt_iteratedFDeriv
+      (WithTop.coe_lt_coe.2 (ENat.coe_lt_top r))
+  have hderiv_eq :
+      fderiv ℝ (iteratedFDeriv ℝ r G) σ =
+        (iteratedFDeriv ℝ (r + 1) G σ).curryLeft := by
+    ext v mtail
+    rfl
+  simpa [G, hderiv_eq] using hdiff.hasFDerivAt
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Integrated candidate for the `r`-th Fréchet derivative of the raw
+multitime Laplace scalar.  The next estimates prove this integral is
+integrable and equals the actual iterated derivative. -/
+noncomputable def section43IteratedLaplaceRaw_iteratedFDerivCandidate
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ :=
+  ∫ τ : Fin n → ℝ,
+    (iteratedFDeriv ℝ r
+        (fun σ' : Fin n → ℝ =>
+          Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+            g.f τ)
+        σ :
+      ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ)
+
+/-- A finite-time ambient Schwartz representative of the multitime
+one-sided Laplace transform, modulo equality on the closed positive orthant. -/
+def section43IteratedLaplaceRepresentative
+    (n : ℕ)
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (Φ : SchwartzMap (Fin n → ℝ) ℂ) : Prop :=
+  ∀ σ : Fin n → ℝ, σ ∈ section43TimePositiveRegion n →
+    Φ σ = section43IteratedLaplaceRaw n g σ
+
+/-- The multitime Laplace integrand of a product source factors coordinatewise.
+This is the finite-product Fubini calculation needed for the product-source
+representative theorem. -/
+theorem section43TimeProductSource_integral_eq_product_raw
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D)
+    (σ : Fin n → ℝ) :
+    (∫ τ : Fin n → ℝ,
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        (section43TimeProductSource gs).f τ) =
+      ∏ i : Fin n,
+        ∫ t : ℝ, Complex.exp (-(t : ℂ) * (σ i : ℂ)) * (gs i).f t := by
+  have hpoint :
+      (fun τ : Fin n → ℝ =>
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+          (section43TimeProductSource gs).f τ)
+        =
+      (fun τ : Fin n → ℝ =>
+        ∏ i : Fin n,
+          Complex.exp (-(τ i : ℂ) * (σ i : ℂ)) * (gs i).f (τ i)) := by
+    funext τ
+    have hexp :
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) =
+          ∏ i : Fin n, Complex.exp (-(τ i : ℂ) * (σ i : ℂ)) := by
+      calc
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)))
+            = Complex.exp (∑ i : Fin n, -(τ i : ℂ) * (σ i : ℂ)) := by
+                congr 1
+                rw [← Finset.sum_neg_distrib]
+                exact Finset.sum_congr rfl (fun i _hi => by ring)
+        _ = ∏ i : Fin n, Complex.exp (-(τ i : ℂ) * (σ i : ℂ)) := by
+                exact Complex.exp_sum Finset.univ
+                  (fun i : Fin n => -(τ i : ℂ) * (σ i : ℂ))
+    change
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+          ((SchwartzMap.productTensor (fun i : Fin n => (gs i).f) :
+              SchwartzMap (Fin n → ℝ) ℂ) τ) =
+        ∏ i : Fin n, Complex.exp (-(τ i : ℂ) * (σ i : ℂ)) * (gs i).f (τ i)
+    rw [SchwartzMap.productTensor_apply, hexp, Finset.prod_mul_distrib]
+  rw [hpoint]
+  exact integral_fintype_prod_volume_eq_prod
+    (fun i : Fin n => fun t : ℝ =>
+      Complex.exp (-(t : ℂ) * (σ i : ℂ)) * (gs i).f t)
+
+/-- On the closed positive orthant, the product tensor of the one-variable
+cutoff Laplace representatives is the multitime Laplace integral of the product
+source. -/
+theorem section43TimeProductTensor_oneSidedLaplaceRepresentative_eq_integral
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D)
+    {σ : Fin n → ℝ} (hσ : σ ∈ section43TimePositiveRegion n) :
+    (section43TimeProductTensor
+      (fun i : Fin n => section43OneSidedLaplaceSchwartzRepresentative1D (gs i)) :
+        SchwartzMap (Fin n → ℝ) ℂ) σ =
+    ∫ τ : Fin n → ℝ,
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        (section43TimeProductSource gs).f τ := by
+  rw [section43TimeProductSource_integral_eq_product_raw]
+  rw [section43TimeProductTensor, SchwartzMap.productTensor_apply]
+  refine Finset.prod_congr rfl ?_
+  intro i _hi
+  rw [section43OneSidedLaplaceSchwartzRepresentative1D_apply,
+    section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg (gs i) (hσ i)]
+  rfl
+
+/-- Product sources have the product tensor of the one-variable compact
+Laplace representatives as their finite-time multitime representative. -/
+theorem section43TimeProductTensor_oneSidedLaplaceRepresentative
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    section43IteratedLaplaceRepresentative n (section43TimeProductSource gs)
+      (section43TimeProductTensor
+        (fun i : Fin n => section43OneSidedLaplaceSchwartzRepresentative1D (gs i))) := by
+  intro σ hσ
+  simpa [section43IteratedLaplaceRaw] using
+    section43TimeProductTensor_oneSidedLaplaceRepresentative_eq_integral gs hσ
+
+/-- Product-source representative existence, isolated from the harder
+arbitrary-source representative theorem. -/
+theorem exists_section43IteratedLaplaceRepresentative_productSource
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    ∃ Φ : SchwartzMap (Fin n → ℝ) ℂ,
+      section43IteratedLaplaceRepresentative n (section43TimeProductSource gs) Φ :=
+  ⟨section43TimeProductTensor
+      (fun i : Fin n => section43OneSidedLaplaceSchwartzRepresentative1D (gs i)),
+    section43TimeProductTensor_oneSidedLaplaceRepresentative gs⟩
+
+end OSReconstruction

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceTimeProduct.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceTimeProduct.lean
@@ -15,6 +15,8 @@ noncomputable section
 open scoped Topology FourierTransform BoundedContinuousFunction
 open Set MeasureTheory Filter
 
+attribute [local instance 101] secondCountableTopologyEither_of_left
+
 namespace OSReconstruction
 
 /-- Closed positive orthant in the finite Euclidean time variables. -/
@@ -593,6 +595,173 @@ theorem exists_time_closedBall_of_compact_tsupport
   have hτR : ‖τ‖ ≤ max B 0 := hτB.trans (le_max_left B 0)
   simpa [Metric.mem_closedBall, dist_eq_norm, sub_zero] using hτR
 
+/-- The real-linear functional whose exponential gives the finite-time
+Laplace kernel for a fixed source-time vector `τ`. -/
+noncomputable def section43TimeLaplaceLinearMap
+    (n : ℕ) (τ : Fin n → ℝ) : (Fin n → ℝ) →ₗ[ℝ] ℂ where
+  toFun := fun σ => -(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))
+  map_add' := by
+    intro σ σ'
+    simp only [Pi.add_apply, Complex.ofReal_add, mul_add]
+    rw [Finset.sum_add_distrib]
+    ring
+  map_smul' := by
+    intro c σ
+    simp only [Pi.smul_apply, smul_eq_mul, Complex.ofReal_mul]
+    calc
+      -(∑ i : Fin n, (τ i : ℂ) * ((c : ℂ) * (σ i : ℂ)))
+          = -(∑ i : Fin n, (c : ℂ) * ((τ i : ℂ) * (σ i : ℂ))) := by
+              congr 1
+              exact Finset.sum_congr rfl (fun i _hi => by ring)
+      _ = (RingHom.id ℝ) c • -(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)) := by
+              simp [Finset.mul_sum]
+
+/-- Continuous version of the finite-time Laplace linear functional. -/
+noncomputable def section43TimeLaplaceLinearCLM
+    (n : ℕ) (τ : Fin n → ℝ) : (Fin n → ℝ) →L[ℝ] ℂ :=
+  ContinuousLinearMap.mk (section43TimeLaplaceLinearMap n τ) (by
+    have hcont :
+        Continuous fun σ : Fin n → ℝ =>
+          -(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)) := by
+      fun_prop
+    simpa [section43TimeLaplaceLinearMap] using hcont)
+
+@[simp] theorem section43TimeLaplaceLinearCLM_apply
+    (n : ℕ) (τ σ : Fin n → ℝ) :
+    section43TimeLaplaceLinearCLM n τ σ =
+      -(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)) := rfl
+
+/-- A point in the unit closed ball around a finite-time vector has norm at
+most `‖σ‖ + 1`. -/
+theorem norm_time_le_norm_add_one_of_mem_closedBall
+    (n : ℕ) (σ σ' : Fin n → ℝ)
+    (hσ' : σ' ∈ Metric.closedBall σ (1 : ℝ)) :
+    ‖σ'‖ ≤ ‖σ‖ + 1 := by
+  have hdist : dist σ' σ ≤ (1 : ℝ) := by
+    simpa [Metric.mem_closedBall] using hσ'
+  have hsub : ‖σ' - σ‖ ≤ (1 : ℝ) := by
+    simpa [dist_eq_norm] using hdist
+  have htri : ‖σ'‖ ≤ ‖σ' - σ‖ + ‖σ‖ := by
+    calc
+      ‖σ'‖ = ‖(σ' - σ) + σ‖ := by
+        simp
+      _ ≤ ‖σ' - σ‖ + ‖σ‖ := norm_add_le _ _
+  linarith
+
+set_option backward.isDefEq.respectTransparency false in
+/-- On a compact time ball, the explicit Laplace linear functional has
+operator norm bounded by the coordinate-sum radius. -/
+theorem norm_section43TimeLaplaceLinearCLM_le
+    (n : ℕ) (τ : Fin n → ℝ) {R : ℝ}
+    (hR_nonneg : 0 ≤ R)
+    (hτ : τ ∈ Metric.closedBall (0 : Fin n → ℝ) R) :
+    ‖section43TimeLaplaceLinearCLM n τ‖ ≤ ∑ _ : Fin n, R := by
+  have hτ_norm : ‖τ‖ ≤ R :=
+    norm_le_of_mem_time_closedBall_zero n τ hτ
+  refine ContinuousLinearMap.opNorm_le_bound _ ?_ ?_
+  · exact Finset.sum_nonneg fun _ _ => hR_nonneg
+  · intro σ
+    have hsum :
+        ‖∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)‖ ≤
+          ∑ _ : Fin n, R * ‖σ‖ := by
+      calc
+        ‖∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)‖
+            ≤ ∑ i : Fin n, ‖(τ i : ℂ) * (σ i : ℂ)‖ := norm_sum_le _ _
+        _ ≤ ∑ _ : Fin n, R * ‖σ‖ := by
+              refine Finset.sum_le_sum ?_
+              intro i _hi
+              have hτi : |τ i| ≤ R := by
+                have hcoord : ‖τ i‖ ≤ ‖τ‖ := norm_le_pi_norm τ i
+                have hcoord_abs : |τ i| ≤ ‖τ‖ := by
+                  simpa [Real.norm_eq_abs] using hcoord
+                exact hcoord_abs.trans hτ_norm
+              have hσi : |σ i| ≤ ‖σ‖ := by
+                have hcoord : ‖σ i‖ ≤ ‖σ‖ := norm_le_pi_norm σ i
+                simpa [Real.norm_eq_abs] using hcoord
+              calc
+                ‖(τ i : ℂ) * (σ i : ℂ)‖ = |τ i| * |σ i| := by
+                  rw [norm_mul]
+                  simp [Real.norm_eq_abs]
+                _ ≤ R * ‖σ‖ := by
+                  exact mul_le_mul hτi hσi (abs_nonneg _) hR_nonneg
+    calc
+      ‖section43TimeLaplaceLinearCLM n τ σ‖ =
+          ‖∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)‖ := by
+            rw [section43TimeLaplaceLinearCLM_apply, norm_neg]
+      _ ≤ ∑ _ : Fin n, R * ‖σ‖ := hsum
+      _ = (∑ _ : Fin n, R) * ‖σ‖ := by
+            rw [Finset.sum_mul]
+
+/-- On a compact product of a source-time ball and a unit σ-ball, the finite
+time Laplace exponential is uniformly bounded. -/
+theorem norm_exp_neg_timePair_le_local_time_closedBall
+    (n : ℕ) (σ σ' τ : Fin n → ℝ)
+    {R : ℝ} (hR_nonneg : 0 ≤ R)
+    (hτ : τ ∈ Metric.closedBall (0 : Fin n → ℝ) R)
+    (hσ' : σ' ∈ Metric.closedBall σ (1 : ℝ)) :
+    ‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ)))‖ ≤
+      Real.exp (∑ _ : Fin n, R * (‖σ‖ + 1)) := by
+  rw [Complex.norm_exp]
+  apply Real.exp_le_exp.mpr
+  have hτ_norm : ‖τ‖ ≤ R :=
+    norm_le_of_mem_time_closedBall_zero n τ hτ
+  have hσ_norm : ‖σ'‖ ≤ ‖σ‖ + 1 :=
+    norm_time_le_norm_add_one_of_mem_closedBall n σ σ' hσ'
+  have hterm :
+      ∀ i : Fin n, |τ i * σ' i| ≤ R * (‖σ‖ + 1) := by
+    intro i
+    have hτi : |τ i| ≤ R := by
+      have hcoord : ‖τ i‖ ≤ ‖τ‖ := norm_le_pi_norm τ i
+      have hcoord_abs : |τ i| ≤ ‖τ‖ := by
+        simpa [Real.norm_eq_abs] using hcoord
+      exact hcoord_abs.trans hτ_norm
+    have hσi : |σ' i| ≤ ‖σ‖ + 1 := by
+      have hcoord : ‖σ' i‖ ≤ ‖σ'‖ := norm_le_pi_norm σ' i
+      have hcoord_abs : |σ' i| ≤ ‖σ'‖ := by
+        simpa [Real.norm_eq_abs] using hcoord
+      exact hcoord_abs.trans hσ_norm
+    calc
+      |τ i * σ' i| = |τ i| * |σ' i| := by rw [abs_mul]
+      _ ≤ R * (‖σ‖ + 1) := by
+            exact mul_le_mul hτi hσi (abs_nonneg _) hR_nonneg
+  have hsum_abs :
+      -(∑ i : Fin n, τ i * σ' i) ≤
+        ∑ i : Fin n, |τ i * σ' i| := by
+    calc
+      -(∑ i : Fin n, τ i * σ' i)
+          ≤ |∑ i : Fin n, τ i * σ' i| := neg_le_abs _
+      _ ≤ ∑ i : Fin n, |τ i * σ' i| := Finset.abs_sum_le_sum_abs _ _
+  have hsum_bound :
+      ∑ i : Fin n, |τ i * σ' i| ≤
+        ∑ _ : Fin n, R * (‖σ‖ + 1) := by
+    exact Finset.sum_le_sum fun i _hi => hterm i
+  have hre :
+      (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))).re =
+        -(∑ i : Fin n, τ i * σ' i) := by
+    simp
+  rw [hre]
+  exact hsum_abs.trans hsum_bound
+
+/-- A compact strict-positive finite-time source is uniformly bounded on every
+closed time ball. -/
+theorem exists_norm_bound_section43CompactStrictPositiveTimeSource_on_time_closedBall
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) (R : ℝ) :
+    ∃ Cg : ℝ, 0 ≤ Cg ∧
+      ∀ τ ∈ Metric.closedBall (0 : Fin n → ℝ) R, ‖g.f τ‖ ≤ Cg := by
+  let K : Set (Fin n → ℝ) := Metric.closedBall (0 : Fin n → ℝ) R
+  have hK_compact : IsCompact K := isCompact_closedBall (0 : Fin n → ℝ) R
+  have hcont : Continuous fun τ : Fin n → ℝ => ‖g.f τ‖ :=
+    continuous_norm.comp g.f.continuous
+  obtain ⟨B, hB⟩ :=
+    hK_compact.exists_bound_of_continuousOn
+      (f := fun τ : Fin n → ℝ => ‖g.f τ‖) hcont.continuousOn
+  refine ⟨max B 0, le_max_right B 0, ?_⟩
+  intro τ hτ
+  have hτB : ‖g.f τ‖ ≤ B := by
+    have h := hB τ hτ
+    simpa [Real.norm_eq_abs, norm_nonneg] using h
+  exact hτB.trans (le_max_left B 0)
+
 /-- In finite-dimensional time domain, continuity of a family of continuous
 multilinear maps is equivalent to continuity of all applied scalar families. -/
 theorem continuous_cmlm_apply_time
@@ -710,6 +879,423 @@ noncomputable def section43IteratedLaplaceRaw
     Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
       g.f τ
 
+set_option backward.isDefEq.respectTransparency false in
+/-- For a smooth function of two variables, iterated derivatives of the partial
+evaluation in the first variable are obtained by composing the full derivative
+with the left injection. -/
+theorem iteratedFDeriv_partialEval_eq_compContinuousLinearMap_inl_of_contDiff
+    {E₁ E₂ F : Type*}
+    [NormedAddCommGroup E₁] [NormedSpace ℝ E₁]
+    [NormedAddCommGroup E₂] [NormedSpace ℝ E₂]
+    [NormedAddCommGroup F] [NormedSpace ℝ F]
+    (f : E₁ × E₂ → F) (hf : ContDiff ℝ (⊤ : ℕ∞) f) (y : E₂) (l : ℕ)
+    (x : E₁) :
+    iteratedFDeriv ℝ l (fun x' => f (x', y)) x =
+      (iteratedFDeriv ℝ l f (x, y)).compContinuousLinearMap
+        (fun _ => ContinuousLinearMap.inl ℝ E₁ E₂) := by
+  have htranslate : ∀ x',
+      iteratedFDeriv ℝ l (fun z : E₁ × E₂ => f (z + (0, y))) (x', (0 : E₂)) =
+        iteratedFDeriv ℝ l f (x' + 0, (0 : E₂) + y) := by
+    intro x'
+    rw [iteratedFDeriv_comp_add_right' l (0, y)]
+    simp [Prod.add_def]
+  have hcomp : ContDiff ℝ (⊤ : ℕ∞)
+      (fun z : E₁ × E₂ => f (z + ((0 : E₁), y))) :=
+    hf.comp ((contDiff_id.add contDiff_const).of_le le_top)
+  have hinl_comp := ContinuousLinearMap.iteratedFDeriv_comp_right
+    (ContinuousLinearMap.inl ℝ E₁ E₂) hcomp x
+      (by exact_mod_cast le_top (a := (l : ℕ∞)))
+  have hlhs :
+      (fun x' => f (x', y)) =
+        (fun z : E₁ × E₂ => f (z + (0, y))) ∘
+          (ContinuousLinearMap.inl ℝ E₁ E₂) := by
+    ext x'
+    simp [ContinuousLinearMap.inl_apply]
+  rw [hlhs, hinl_comp]
+  exact congrArg
+    (fun A : ContinuousMultilinearMap ℝ (fun _ : Fin l => E₁ × E₂) F =>
+      A.compContinuousLinearMap (fun _ => ContinuousLinearMap.inl ℝ E₁ E₂))
+    (by simpa [ContinuousLinearMap.inl_apply] using htranslate x)
+
+/-- For fixed `σ`, the raw finite-time Laplace integrand is continuous in the
+source time variable. -/
+theorem continuous_section43IteratedLaplaceRaw_integrand_tau
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    Continuous fun τ : Fin n → ℝ =>
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        g.f τ := by
+  have harg : Continuous fun τ : Fin n → ℝ =>
+      -(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)) := by
+    fun_prop
+  exact (Complex.continuous_exp.comp harg).mul g.f.continuous
+
+/-- For fixed `σ`, the raw finite-time Laplace integrand is compactly supported
+in the source time variable. -/
+theorem hasCompactSupport_section43IteratedLaplaceRaw_integrand_of_compact
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    HasCompactSupport fun τ : Fin n → ℝ =>
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        g.f τ := by
+  rcases exists_time_closedBall_of_compact_tsupport g with
+    ⟨R, _hR_nonneg, hR_supp⟩
+  refine HasCompactSupport.of_support_subset_isCompact
+    (isCompact_closedBall (0 : Fin n → ℝ) R) ?_
+  intro τ hτ_support
+  by_contra hτ_ball
+  have hnot_tsupport :
+      τ ∉ tsupport (g.f : (Fin n → ℝ) → ℂ) := by
+    intro hτ_tsupport
+    exact hτ_ball (hR_supp hτ_tsupport)
+  have hnot_support : τ ∉ Function.support (g.f : (Fin n → ℝ) → ℂ) := by
+    intro hsupport
+    exact hnot_tsupport (subset_tsupport _ hsupport)
+  have hzero : g.f τ = 0 := by
+    by_contra hne
+    exact hnot_support hne
+  exact hτ_support (by simp [hzero])
+
+/-- For fixed `σ`, the raw finite-time Laplace integrand is integrable in the
+source time variable. -/
+theorem integrable_section43IteratedLaplaceRaw_integrand_of_compact
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    Integrable fun τ : Fin n → ℝ =>
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        g.f τ :=
+  (continuous_section43IteratedLaplaceRaw_integrand_tau n g σ).integrable_of_hasCompactSupport
+    (hasCompactSupport_section43IteratedLaplaceRaw_integrand_of_compact n g σ)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- For fixed `σ`, every pointwise σ-derivative of the raw finite-time
+Laplace integrand is continuous in the source time variable. -/
+theorem continuous_section43IteratedLaplaceRaw_integrand_iteratedFDeriv
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    Continuous fun τ : Fin n → ℝ =>
+      iteratedFDeriv ℝ r
+        (fun σ' : Fin n → ℝ =>
+          Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+            g.f τ)
+        σ := by
+  let F : (Fin n → ℝ) × (Fin n → ℝ) → ℂ := fun p =>
+    Complex.exp (-(∑ i : Fin n, (p.2 i : ℂ) * (p.1 i : ℂ))) *
+      g.f p.2
+  have hF : ContDiff ℝ (⊤ : ℕ∞) F := by
+    have harg : ContDiff ℝ (⊤ : ℕ∞)
+        (fun p : (Fin n → ℝ) × (Fin n → ℝ) =>
+          -(∑ i : Fin n, (p.2 i : ℂ) * (p.1 i : ℂ))) := by
+      apply ContDiff.neg
+      apply ContDiff.sum
+      intro i _hi
+      have hτcoord : ContDiff ℝ (⊤ : ℕ∞)
+          (fun p : (Fin n → ℝ) × (Fin n → ℝ) => (p.2 i : ℂ)) := by
+        have hreal : ContDiff ℝ (⊤ : ℕ∞)
+            (fun p : (Fin n → ℝ) × (Fin n → ℝ) => p.2 i) := by
+          simpa using
+            (((ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+              (φ := fun _ => ℝ) i).contDiff :
+                ContDiff ℝ (⊤ : ℕ∞) (fun τ : Fin n → ℝ =>
+                  (ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+                    (φ := fun _ => ℝ) i) τ)).comp contDiff_snd)
+        exact Complex.ofRealCLM.contDiff.comp hreal
+      have hσcoord : ContDiff ℝ (⊤ : ℕ∞)
+          (fun p : (Fin n → ℝ) × (Fin n → ℝ) => (p.1 i : ℂ)) := by
+        have hreal : ContDiff ℝ (⊤ : ℕ∞)
+            (fun p : (Fin n → ℝ) × (Fin n → ℝ) => p.1 i) := by
+          simpa using
+            (((ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+              (φ := fun _ => ℝ) i).contDiff :
+                ContDiff ℝ (⊤ : ℕ∞) (fun σ : Fin n → ℝ =>
+                  (ContinuousLinearMap.proj (R := ℝ) (ι := Fin n)
+                    (φ := fun _ => ℝ) i) σ)).comp contDiff_fst)
+        exact Complex.ofRealCLM.contDiff.comp hreal
+      exact hτcoord.mul hσcoord
+    have hg : ContDiff ℝ (⊤ : ℕ∞)
+        (fun p : (Fin n → ℝ) × (Fin n → ℝ) => g.f p.2) := by
+      exact g.f.smooth'.comp contDiff_snd
+    exact (Complex.contDiff_exp.comp harg).mul hg
+  let A :
+      ContinuousMultilinearMap ℝ
+          (fun _ : Fin r => (Fin n → ℝ) × (Fin n → ℝ)) ℂ →L[ℝ]
+        ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ :=
+    ContinuousMultilinearMap.compContinuousLinearMapL (F := _)
+      (fun _ => ContinuousLinearMap.inl ℝ (Fin n → ℝ) (Fin n → ℝ))
+  have hfull : Continuous fun τ : Fin n → ℝ =>
+      iteratedFDeriv ℝ r F (σ, τ) := by
+    have hderiv_cont : Continuous (iteratedFDeriv ℝ r F) := by
+      exact hF.continuous_iteratedFDeriv
+        (by exact_mod_cast le_top (a := (r : ℕ∞)))
+    exact hderiv_cont.comp (continuous_const.prodMk continuous_id)
+  have hA : Continuous fun τ : Fin n → ℝ =>
+      A (iteratedFDeriv ℝ r F (σ, τ)) := A.continuous.comp hfull
+  have heq :
+      (fun τ : Fin n → ℝ =>
+        iteratedFDeriv ℝ r
+          (fun σ' : Fin n → ℝ =>
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+              g.f τ)
+          σ)
+        =
+        fun τ : Fin n → ℝ => A (iteratedFDeriv ℝ r F (σ, τ)) := by
+    funext τ
+    simp [A, F,
+      iteratedFDeriv_partialEval_eq_compContinuousLinearMap_inl_of_contDiff F hF τ r σ]
+  rw [heq]
+  exact hA
+
+/-- If the source time variable lies outside the topological support of the
+compact source, then every σ-derivative of the pointwise Laplace integrand is
+zero. -/
+theorem section43IteratedLaplaceRaw_integrand_iteratedFDeriv_eq_zero_of_not_mem_tsupport
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    {τ : Fin n → ℝ}
+    (hτ : τ ∉ tsupport (g.f : (Fin n → ℝ) → ℂ)) :
+    iteratedFDeriv ℝ r
+      (fun σ : Fin n → ℝ =>
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+          g.f τ) =
+      0 := by
+  have hnot_support : τ ∉ Function.support (g.f : (Fin n → ℝ) → ℂ) := by
+    intro hsupport
+    exact hτ (subset_tsupport _ hsupport)
+  have hzero : g.f τ = 0 := by
+    by_contra hne
+    exact hnot_support hne
+  have hfun :
+      (fun σ : Fin n → ℝ =>
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+          g.f τ) =
+        fun _ => 0 := by
+    funext σ
+    simp [hzero]
+  rw [hfun]
+  funext σ
+  simp
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Explicit norm bound for every σ-derivative of the pointwise finite-time
+Laplace integrand. -/
+theorem norm_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_le
+    (n r : ℕ) (τ σ : Fin n → ℝ) (c : ℂ) :
+    ‖iteratedFDeriv ℝ r
+      (fun σ' : Fin n → ℝ =>
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) * c)
+      σ‖ ≤
+      r.factorial *
+        ‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)))‖ *
+        ‖section43TimeLaplaceLinearCLM n τ‖ ^ r * ‖c‖ := by
+  let L : (Fin n → ℝ) →L[ℝ] ℂ := section43TimeLaplaceLinearCLM n τ
+  let f : (Fin n → ℝ) → ℂ := fun x => Complex.exp (L x)
+  have hf_cont : ContDiffAt ℝ (r : ℕ) f σ := by
+    have hf : ContDiff ℝ (⊤ : ℕ∞) f := by
+      simpa [f] using (Complex.contDiff_exp.comp L.contDiff)
+    exact hf.contDiffAt.of_le (by exact mod_cast le_top)
+  have hfun :
+      (fun σ' : Fin n → ℝ =>
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) * c)
+        = fun σ' : Fin n → ℝ => f σ' • c := by
+    funext σ'
+    simp [f, L, section43TimeLaplaceLinearCLM_apply, smul_eq_mul]
+  rw [hfun]
+  rw [iteratedFDeriv_smul_const_apply (v := c) hf_cont]
+  have hcomp :=
+    ((ContinuousLinearMap.id ℝ ℂ).smulRight c).norm_compContinuousMultilinearMap_le
+      (iteratedFDeriv ℝ r f σ)
+  have hf_bound :
+      ‖iteratedFDeriv ℝ r f σ‖ ≤
+        r.factorial * ‖Complex.exp (L σ)‖ * ‖L‖ ^ r := by
+    simpa [f] using norm_iteratedFDeriv_cexp_comp_clm_le L σ r
+  have hsmul_norm_le :
+      ‖((ContinuousLinearMap.id ℝ ℂ).smulRight c)‖ ≤ ‖c‖ := by
+    refine ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg c) ?_
+    intro z
+    simp [ContinuousLinearMap.smulRight_apply, mul_comm]
+  calc
+    ‖((ContinuousLinearMap.id ℝ ℂ).smulRight c).compContinuousMultilinearMap
+        (iteratedFDeriv ℝ r f σ)‖
+        ≤ ‖((ContinuousLinearMap.id ℝ ℂ).smulRight c)‖ *
+            ‖iteratedFDeriv ℝ r f σ‖ := hcomp
+    _ ≤ ‖c‖ * ‖iteratedFDeriv ℝ r f σ‖ := by
+          exact mul_le_mul_of_nonneg_right hsmul_norm_le (norm_nonneg _)
+    _ ≤ ‖c‖ * (r.factorial * ‖Complex.exp (L σ)‖ * ‖L‖ ^ r) := by
+          exact mul_le_mul_of_nonneg_left hf_bound (norm_nonneg c)
+    _ =
+        r.factorial *
+          ‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)))‖ *
+          ‖section43TimeLaplaceLinearCLM n τ‖ ^ r * ‖c‖ := by
+          simp [L]
+          ring
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Compact local domination for the curry-left pointwise derivative of the
+raw finite-time Laplace integrand. -/
+theorem section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    ∃ bound : (Fin n → ℝ) → ℝ,
+      Integrable bound ∧
+      ∀ᵐ τ, ∀ σ' ∈ Metric.closedBall σ (1 : ℝ),
+        ‖(iteratedFDeriv ℝ (r + 1)
+          (fun σ'' : Fin n → ℝ =>
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+              g.f τ)
+          σ').curryLeft‖ ≤ bound τ := by
+  classical
+  rcases exists_time_closedBall_of_compact_tsupport g with
+    ⟨R, hR_nonneg, hR_supp⟩
+  let Kτ : Set (Fin n → ℝ) := Metric.closedBall (0 : Fin n → ℝ) R
+  rcases exists_norm_bound_section43CompactStrictPositiveTimeSource_on_time_closedBall
+    n g R with ⟨Cg, hCg_nonneg, hCg_bound⟩
+  let Cexp : ℝ := Real.exp (∑ _ : Fin n, R * (‖σ‖ + 1))
+  let CL : ℝ := ∑ _ : Fin n, R
+  let C : ℝ := (r + 1).factorial * Cexp * CL ^ (r + 1) * Cg
+  refine ⟨Set.indicator Kτ (fun _ => C), ?_, ?_⟩
+  · simpa [Kτ, C] using integrable_indicator_time_closedBall_const n R C
+  · filter_upwards with τ σ' hσ'
+    by_cases hτ_mem : τ ∈ Kτ
+    · rw [Set.indicator_of_mem hτ_mem]
+      have hExp :
+          ‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ)))‖ ≤
+            Cexp := by
+        simpa [Cexp, Kτ] using
+          norm_exp_neg_timePair_le_local_time_closedBall
+            n σ σ' τ hR_nonneg hτ_mem hσ'
+      have hL :
+          ‖section43TimeLaplaceLinearCLM n τ‖ ≤ CL := by
+        simpa [CL, Kτ] using
+          norm_section43TimeLaplaceLinearCLM_le
+            n τ hR_nonneg hτ_mem
+      have hLpow :
+          ‖section43TimeLaplaceLinearCLM n τ‖ ^ (r + 1) ≤
+            CL ^ (r + 1) := by
+        exact pow_le_pow_left₀ (norm_nonneg _) hL (r + 1)
+      have hSrc : ‖g.f τ‖ ≤ Cg := hCg_bound τ (by simpa [Kτ] using hτ_mem)
+      have hmain :=
+        norm_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_le
+          n (r + 1) τ σ' (g.f τ)
+      have hbase :
+          ‖(iteratedFDeriv ℝ (r + 1)
+            (fun σ'' : Fin n → ℝ =>
+              Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+                g.f τ)
+            σ').curryLeft‖ ≤
+            (r + 1).factorial * Cexp * CL ^ (r + 1) * Cg := by
+        calc
+          ‖(iteratedFDeriv ℝ (r + 1)
+            (fun σ'' : Fin n → ℝ =>
+              Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+                g.f τ)
+            σ').curryLeft‖ =
+              ‖iteratedFDeriv ℝ (r + 1)
+                (fun σ'' : Fin n → ℝ =>
+                  Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+                    g.f τ)
+                σ'‖ := by
+                rw [ContinuousMultilinearMap.curryLeft_norm]
+          _ ≤
+              (r + 1).factorial *
+                ‖Complex.exp
+                  (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ)))‖ *
+                ‖section43TimeLaplaceLinearCLM n τ‖ ^ (r + 1) *
+                ‖g.f τ‖ := hmain
+          _ ≤ (r + 1).factorial * Cexp *
+              CL ^ (r + 1) * Cg := by
+                have hEL :
+                    ‖Complex.exp
+                      (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ)))‖ *
+                      ‖section43TimeLaplaceLinearCLM n τ‖ ^ (r + 1) ≤
+                      Cexp * CL ^ (r + 1) := by
+                  exact mul_le_mul hExp hLpow
+                    (pow_nonneg (norm_nonneg _) _)
+                    (Real.exp_pos _).le
+                have hELS :
+                    ‖Complex.exp
+                      (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ)))‖ *
+                      ‖section43TimeLaplaceLinearCLM n τ‖ ^ (r + 1) *
+                      ‖g.f τ‖ ≤
+                      Cexp * CL ^ (r + 1) * Cg := by
+                  exact mul_le_mul hEL hSrc (norm_nonneg _)
+                    (mul_nonneg (Real.exp_pos _).le
+                      (pow_nonneg (Finset.sum_nonneg fun _ _ => hR_nonneg) _))
+                have hA_nonneg : 0 ≤ ((r + 1).factorial : ℝ) :=
+                  Nat.cast_nonneg _
+                simpa [mul_assoc] using
+                  mul_le_mul_of_nonneg_left hELS hA_nonneg
+      simpa [C, mul_assoc] using hbase
+    · rw [Set.indicator_of_notMem hτ_mem]
+      have hnot_tsupport :
+          τ ∉ tsupport (g.f : (Fin n → ℝ) → ℂ) := by
+        intro hτ_support
+        exact hτ_mem (by simpa [Kτ] using hR_supp hτ_support)
+      have hzero_fun :=
+        section43IteratedLaplaceRaw_integrand_iteratedFDeriv_eq_zero_of_not_mem_tsupport
+          n (r + 1) g hnot_tsupport
+      have hzero_at :
+          iteratedFDeriv ℝ (r + 1)
+            (fun σ'' : Fin n → ℝ =>
+              Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+                g.f τ)
+            σ' = 0 := by
+        simpa using congrFun hzero_fun σ'
+      simp [hzero_at]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Under compact source support, every pointwise σ-derivative of the raw
+finite-time Laplace integrand is Bochner-integrable in the source time
+variable. -/
+theorem integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    Integrable
+      (fun τ : Fin n → ℝ =>
+        iteratedFDeriv ℝ r
+          (fun σ' : Fin n → ℝ =>
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+              g.f τ)
+          σ) := by
+  have hmeas : AEStronglyMeasurable
+      (fun τ : Fin n → ℝ =>
+        iteratedFDeriv ℝ r
+          (fun σ' : Fin n → ℝ =>
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+              g.f τ)
+          σ) :=
+    (continuous_section43IteratedLaplaceRaw_integrand_iteratedFDeriv
+      n r g σ).aestronglyMeasurable
+  cases r with
+  | zero =>
+      let e :=
+        continuousMultilinearCurryFin0 ℝ (Fin n → ℝ) ℂ
+      have hbase :
+          Integrable
+            (fun τ : Fin n → ℝ =>
+              Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+                g.f τ) :=
+        integrable_section43IteratedLaplaceRaw_integrand_of_compact n g σ
+      have hcomp :
+          Integrable
+            (fun τ : Fin n → ℝ =>
+              e.symm
+                (Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+                  g.f τ)) :=
+        (e.symm : ℂ →L[ℝ]
+          ContinuousMultilinearMap ℝ (fun _ : Fin 0 => Fin n → ℝ) ℂ).integrable_comp hbase
+      convert hcomp using 1
+  | succ r =>
+      rcases
+        section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+          n r g σ with
+        ⟨bound, hbound_int, hbound⟩
+      have hσ_self : σ ∈ Metric.closedBall σ (1 : ℝ) := by
+        simp [Metric.mem_closedBall]
+      refine Integrable.mono' hbound_int ?_ ?_
+      · simpa using hmeas
+      · exact hbound.mono fun τ hτ => by
+          have hτσ := hτ σ hσ_self
+          simpa [ContinuousMultilinearMap.curryLeft_norm] using hτσ
+
 /-- The cutoff version of the raw multitime Laplace scalar. -/
 noncomputable def section43IteratedLaplaceCutoffFun
     (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
@@ -805,6 +1391,403 @@ noncomputable def section43IteratedLaplaceRaw_iteratedFDerivCandidate
         σ :
       ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ)
 
+set_option backward.isDefEq.respectTransparency false in
+/-- The integrated all-order derivative candidate has derivative given by the
+curry-left of the next integrated candidate. -/
+theorem section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    HasFDerivAt
+      (fun σ' : Fin n → ℝ =>
+        section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ')
+      ((section43IteratedLaplaceRaw_iteratedFDerivCandidate n (r + 1) g σ).curryLeft)
+      σ := by
+  classical
+  let Fint : (Fin n → ℝ) → (Fin n → ℝ) →
+      ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ :=
+    fun σ' τ =>
+      iteratedFDeriv ℝ r
+        (fun σ'' : Fin n → ℝ =>
+          Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+            g.f τ)
+        σ'
+  let Fderiv : (Fin n → ℝ) → (Fin n → ℝ) →
+      (Fin n → ℝ) →L[ℝ]
+        ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ :=
+    fun σ' τ =>
+      (iteratedFDeriv ℝ (r + 1)
+        (fun σ'' : Fin n → ℝ =>
+          Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+            g.f τ)
+        σ').curryLeft
+  rcases
+    section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+      n r g σ with
+    ⟨bound, hbound_int, hbound⟩
+  have hs : Metric.closedBall σ (1 : ℝ) ∈ 𝓝 σ :=
+    Metric.closedBall_mem_nhds σ zero_lt_one
+  have hF_meas : ∀ᶠ σ' in 𝓝 σ, AEStronglyMeasurable (Fint σ') := by
+    exact Filter.Eventually.of_forall fun σ' =>
+      (integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+        n r g σ').aestronglyMeasurable
+  have hF_int : Integrable (Fint σ) := by
+    simpa [Fint] using
+      integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+        n r g σ
+  have hbound' : ∀ᵐ τ : Fin n → ℝ, ∀ σ' ∈ Metric.closedBall σ (1 : ℝ),
+      ‖Fderiv σ' τ‖ ≤ bound τ := by
+    simpa [Fderiv] using hbound
+  let Phi : (Fin n → ℝ) →
+      ContinuousMultilinearMap ℝ
+        (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ :=
+    fun τ =>
+      iteratedFDeriv ℝ (r + 1)
+        (fun σ'' : Fin n → ℝ =>
+          Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+            g.f τ)
+        σ
+  have hnext_int :
+      @Integrable
+        (ContinuousMultilinearMap ℝ
+          (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ)
+        PseudoMetricSpace.toUniformSpace.toTopologicalSpace
+        SeminormedAddGroup.toContinuousENorm
+        (Fin n → ℝ) _ Phi volume := by
+    simpa [Phi] using
+      integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+        n (r + 1) g σ
+  have hcurry_lipschitz :
+      LipschitzWith 1
+        (fun L : ContinuousMultilinearMap ℝ
+            (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ =>
+          L.curryLeft) := by
+    refine LipschitzWith.of_dist_le_mul ?_
+    intro L M
+    simp only [NNReal.coe_one, one_mul]
+    rw [dist_eq_norm, dist_eq_norm]
+    have hsub : L.curryLeft - M.curryLeft = (L - M).curryLeft := by
+      ext v mtail
+      simp [ContinuousMultilinearMap.curryLeft_apply]
+    rw [hsub, ContinuousMultilinearMap.curryLeft_norm]
+  have hFderiv_int :
+      @Integrable
+        ((Fin n → ℝ) →L[ℝ]
+          ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ)
+        PseudoMetricSpace.toUniformSpace.toTopologicalSpace
+        SeminormedAddGroup.toContinuousENorm
+        (Fin n → ℝ) _ (Fderiv σ) volume := by
+    refine Integrable.mono
+      (f := Fderiv σ)
+      (g := Phi)
+      hnext_int ?_ ?_
+    · have hmeas :
+          AEStronglyMeasurable
+            (fun τ : Fin n → ℝ => (Phi τ).curryLeft) :=
+          hcurry_lipschitz.continuous.comp_aestronglyMeasurable
+            hnext_int.aestronglyMeasurable
+      simpa [Fderiv, Phi] using hmeas
+    · filter_upwards with τ
+      simp [Fderiv, Phi, ContinuousMultilinearMap.curryLeft_norm]
+  have hFderiv_meas := hFderiv_int.aestronglyMeasurable
+  have hdiff : ∀ᵐ τ : Fin n → ℝ, ∀ σ' ∈ Metric.closedBall σ (1 : ℝ),
+      HasFDerivAt (Fint · τ) (Fderiv σ' τ) σ' := by
+    filter_upwards with τ σ' _hσ'
+    simpa [Fint, Fderiv] using
+      hasFDerivAt_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft
+        (r := r) g σ' τ
+  have hmain :=
+    hasFDerivAt_integral_of_dominated_of_fderiv_le
+      (𝕜 := ℝ) (μ := volume)
+      (F := Fint) (F' := Fderiv) (x₀ := σ)
+      (s := Metric.closedBall σ (1 : ℝ)) (bound := bound)
+      hs hF_meas hF_int hFderiv_meas hbound' hbound_int hdiff
+  have hderivIntegral :
+      (∫ τ : Fin n → ℝ, Fderiv σ τ) =
+        ((∫ τ : Fin n → ℝ, Phi τ).curryLeft) := by
+    letI : SeminormedAddCommGroup
+        (ContinuousMultilinearMap ℝ
+          (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ) :=
+      NormedAddCommGroup.toSeminormedAddCommGroup
+    letI : SeminormedAddCommGroup
+        ((Fin n → ℝ) →L[ℝ]
+          ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ) :=
+      NormedAddCommGroup.toSeminormedAddCommGroup
+    let curryLI :
+        ContinuousMultilinearMap ℝ
+            (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ →ₗᵢ[ℝ]
+          ((Fin n → ℝ) →L[ℝ]
+            ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ) :=
+      { toLinearMap :=
+          { toFun := fun L => L.curryLeft
+            map_add' := by
+              intro L M
+              rfl
+            map_smul' := by
+              intro c L
+              rfl }
+        norm_map' := by
+          intro L
+          exact ContinuousMultilinearMap.curryLeft_norm L }
+    haveI : CompleteSpace
+        (ContinuousMultilinearMap ℝ
+          (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ) := inferInstance
+    change (∫ τ : Fin n → ℝ, curryLI (Phi τ)) =
+      curryLI (∫ τ : Fin n → ℝ, Phi τ)
+    exact
+      (ContinuousLinearMap.integral_comp_comm
+          (𝕜 := ℝ)
+          (E := ContinuousMultilinearMap ℝ
+            (fun _ : Fin (r + 1) => Fin n → ℝ) ℂ)
+          (Fₗ := (Fin n → ℝ) →L[ℝ]
+            ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ)
+          (X := Fin n → ℝ)
+          (μ := volume)
+          curryLI.toContinuousLinearMap hnext_int)
+  rw [hderivIntegral] at hmain
+  simpa [section43IteratedLaplaceRaw_iteratedFDerivCandidate,
+    Fint, Fderiv] using hmain
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The iterated derivatives of the raw finite-time Laplace scalar are the
+integrated pointwise derivative candidates. -/
+theorem section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    iteratedFDeriv ℝ r (section43IteratedLaplaceRaw n g) σ =
+      section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ := by
+  classical
+  let G : (Fin n → ℝ) → ℂ := fun σ' =>
+    section43IteratedLaplaceRaw n g σ'
+  induction r generalizing σ with
+  | zero =>
+      ext m
+      have hint :
+          Integrable
+            (fun τ : Fin n → ℝ =>
+              iteratedFDeriv ℝ 0
+                (fun σ' : Fin n → ℝ =>
+                  Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+                    g.f τ)
+                σ) := by
+        simpa using
+          integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+            n 0 g σ
+      change
+        section43IteratedLaplaceRaw n g σ =
+          (∫ τ : Fin n → ℝ,
+            iteratedFDeriv ℝ 0
+              (fun σ' : Fin n → ℝ =>
+                Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+                  g.f τ)
+              σ) m
+      rw [ContinuousMultilinearMap.integral_apply hint m]
+      simp [section43IteratedLaplaceRaw, iteratedFDeriv_zero_apply]
+  | succ r ih =>
+      have hfun :
+          iteratedFDeriv ℝ r G =
+          fun σ' : Fin n → ℝ =>
+            section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ' := by
+        funext σ'
+        simpa [G] using ih σ'
+      have hfd :
+          fderiv ℝ (iteratedFDeriv ℝ r G) σ =
+            (section43IteratedLaplaceRaw_iteratedFDerivCandidate
+              n (r + 1) g σ).curryLeft := by
+        have hderiv :=
+          section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt
+            n r g σ
+        rw [hfun]
+        exact hderiv.fderiv
+      rw [iteratedFDeriv_succ_eq_comp_left, Function.comp_apply, hfd]
+      exact ContinuousMultilinearMap.uncurry_curryLeft _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The raw finite-time Laplace scalar is ambient smooth in the finite-time
+positive-energy variable. -/
+theorem section43IteratedLaplaceRaw_contDiff
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    ContDiff ℝ (↑(⊤ : ℕ∞)) (section43IteratedLaplaceRaw n g) := by
+  classical
+  let G : (Fin n → ℝ) → ℂ := fun σ =>
+    section43IteratedLaplaceRaw n g σ
+  change ContDiff ℝ (↑(⊤ : ℕ∞)) G
+  refine contDiff_of_differentiable_iteratedFDeriv
+    (𝕜 := ℝ) (E := Fin n → ℝ) (F := ℂ) (f := G) (n := (⊤ : ℕ∞)) ?_
+  intro r _hr
+  have hfun :
+      iteratedFDeriv ℝ r G =
+      fun σ : Fin n → ℝ =>
+        section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ := by
+    funext σ
+    simpa [G] using
+      section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate n r g σ
+  rw [hfun]
+  intro σ
+  exact
+    (section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt
+      n r g σ).differentiableAt
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Rapid decay of the actual all-order derivatives of the raw finite-time
+Laplace scalar on the unit one-sided time collar. -/
+theorem section43IteratedLaplaceRaw_iteratedFDeriv_rapid_on_timeThickening
+    (n r s : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ C : ℝ, 0 ≤ C ∧
+      ∀ σ ∈ section43TimePositiveThickening n 1,
+        (1 + ‖σ‖) ^ s *
+          ‖iteratedFDeriv ℝ r (section43IteratedLaplaceRaw n g) σ‖ ≤ C := by
+  classical
+  rcases exists_positive_margin_of_compact_time_tsupport_subset_strictPositive g with
+    ⟨δ, hδ_pos, hδ_supp⟩
+  rcases exists_time_closedBall_of_compact_tsupport g with
+    ⟨R, hR_nonneg, hR_supp⟩
+  rcases exists_norm_bound_section43CompactStrictPositiveTimeSource_on_time_closedBall
+    n g R with ⟨Cg, hCg_nonneg, hCg_bound⟩
+  let Kτ : Set (Fin n → ℝ) := Metric.closedBall (0 : Fin n → ℝ) R
+  let CL : ℝ := ∑ _ : Fin n, R
+  let Cderiv : ℝ := r.factorial * CL ^ r * Cg
+  let M : ℝ := ∫ τ : Fin n → ℝ, Set.indicator Kτ (fun _ : Fin n → ℝ => Cderiv) τ
+  rcases exp_margin_sum_controls_thickened_time_polynomial
+      (n := n) (δ := δ) (ε := (1 : ℝ)) (R := R)
+      hδ_pos zero_le_one hR_nonneg s with
+    ⟨Ct, hCt_nonneg, hCt_bound⟩
+  let C : ℝ := Ct * M
+  have hCL_nonneg : 0 ≤ CL := by
+    exact Finset.sum_nonneg fun _ _ => hR_nonneg
+  have hCderiv_nonneg : 0 ≤ Cderiv := by
+    dsimp [Cderiv]
+    positivity
+  have hM_nonneg : 0 ≤ M := by
+    dsimp [M]
+    exact integral_nonneg fun τ => by
+      by_cases hτ : τ ∈ Kτ
+      · simp [Set.indicator_of_mem hτ, hCderiv_nonneg]
+      · simp [Set.indicator_of_notMem hτ]
+  refine ⟨C, mul_nonneg hCt_nonneg hM_nonneg, ?_⟩
+  intro σ hσ
+  let Eσ : ℝ :=
+    Real.exp (∑ _ : Fin n, R * (1 : ℝ)) *
+      Real.exp (-(δ * ∑ i : Fin n, (σ i + 1)))
+  let G : (Fin n → ℝ) →
+      ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ :=
+    fun τ =>
+      iteratedFDeriv ℝ r
+        (fun σ' : Fin n → ℝ =>
+          Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+            g.f τ)
+        σ
+  have hE_nonneg : 0 ≤ Eσ := by
+    dsimp [Eσ]
+    positivity
+  have hbound_int :
+      Integrable
+        (fun τ : Fin n → ℝ =>
+          Eσ * Set.indicator Kτ (fun _ : Fin n → ℝ => Cderiv) τ) :=
+    (integrable_indicator_time_closedBall_const n R Cderiv).const_mul Eσ
+  have hpoint : ∀ τ : Fin n → ℝ,
+      ‖G τ‖ ≤ Eσ * Set.indicator Kτ (fun _ : Fin n → ℝ => Cderiv) τ := by
+    intro τ
+    by_cases hτK : τ ∈ Kτ
+    · rw [Set.indicator_of_mem hτK]
+      by_cases hτ_supp : τ ∈ tsupport (g.f : (Fin n → ℝ) → ℂ)
+      · have hτ_low : ∀ i : Fin n, δ ≤ τ i := hδ_supp hτ_supp
+        have hτ_norm : ‖τ‖ ≤ R := by
+          simpa [Kτ] using norm_le_of_mem_time_closedBall_zero n τ hτK
+        have hExp :
+            ‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)))‖ ≤ Eσ := by
+          simpa [Eσ] using
+            norm_exp_neg_timePair_le_exp_thickened_margin_sum
+              n hδ_pos zero_le_one hR_nonneg σ τ hσ hτ_low hτ_norm
+        have hL :
+            ‖section43TimeLaplaceLinearCLM n τ‖ ≤ CL := by
+          simpa [CL, Kτ] using
+            norm_section43TimeLaplaceLinearCLM_le n τ hR_nonneg hτK
+        have hLpow :
+            ‖section43TimeLaplaceLinearCLM n τ‖ ^ r ≤ CL ^ r := by
+          exact pow_le_pow_left₀ (norm_nonneg _) hL r
+        have hSrc : ‖g.f τ‖ ≤ Cg := hCg_bound τ (by simpa [Kτ] using hτK)
+        have hmain :=
+          norm_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_le
+            n r τ σ (g.f τ)
+        have hLCg :
+            ‖section43TimeLaplaceLinearCLM n τ‖ ^ r * ‖g.f τ‖ ≤
+              CL ^ r * Cg := by
+          exact mul_le_mul hLpow hSrc (norm_nonneg _)
+            (pow_nonneg hCL_nonneg _)
+        have hExpLCg :
+            ‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)))‖ *
+                (‖section43TimeLaplaceLinearCLM n τ‖ ^ r * ‖g.f τ‖) ≤
+              Eσ * (CL ^ r * Cg) := by
+          exact mul_le_mul hExp hLCg
+            (mul_nonneg (pow_nonneg (norm_nonneg _) _) (norm_nonneg _))
+            hE_nonneg
+        calc
+          ‖G τ‖ ≤
+              r.factorial *
+                ‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)))‖ *
+                ‖section43TimeLaplaceLinearCLM n τ‖ ^ r * ‖g.f τ‖ := by
+                simpa [G] using hmain
+          _ = r.factorial *
+                (‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)))‖ *
+                  (‖section43TimeLaplaceLinearCLM n τ‖ ^ r * ‖g.f τ‖)) := by
+                ring
+          _ ≤ r.factorial * (Eσ * (CL ^ r * Cg)) := by
+                exact mul_le_mul_of_nonneg_left hExpLCg (Nat.cast_nonneg _)
+          _ = Eσ * Cderiv := by
+                simp [Cderiv]
+                ring
+      · have hzero_fun :=
+          section43IteratedLaplaceRaw_integrand_iteratedFDeriv_eq_zero_of_not_mem_tsupport
+            n r g hτ_supp
+        have hzero : G τ = 0 := by
+          simpa [G] using congrFun hzero_fun σ
+        calc
+          ‖G τ‖ = 0 := by simp [hzero]
+          _ ≤ Eσ * Cderiv := mul_nonneg hE_nonneg hCderiv_nonneg
+    · rw [Set.indicator_of_notMem hτK]
+      have hnot_tsupport :
+          τ ∉ tsupport (g.f : (Fin n → ℝ) → ℂ) := by
+        intro hτ_supp
+        exact hτK (by simpa [Kτ] using hR_supp hτ_supp)
+      have hzero_fun :=
+        section43IteratedLaplaceRaw_integrand_iteratedFDeriv_eq_zero_of_not_mem_tsupport
+          n r g hnot_tsupport
+      have hzero : G τ = 0 := by
+        simpa [G] using congrFun hzero_fun σ
+      simp [hzero]
+  have hcandidate_norm :
+      ‖section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ‖ ≤
+        Eσ * M := by
+    calc
+      ‖section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ‖ =
+          ‖∫ τ : Fin n → ℝ, G τ‖ := by
+            simp [section43IteratedLaplaceRaw_iteratedFDerivCandidate, G]
+      _ ≤ ∫ τ : Fin n → ℝ, ‖G τ‖ :=
+          MeasureTheory.norm_integral_le_integral_norm _
+      _ ≤ ∫ τ : Fin n → ℝ,
+            Eσ * Set.indicator Kτ (fun _ : Fin n → ℝ => Cderiv) τ := by
+          exact MeasureTheory.integral_mono_of_nonneg
+            (Filter.Eventually.of_forall fun τ => norm_nonneg (G τ))
+            hbound_int
+            (Filter.Eventually.of_forall hpoint)
+      _ = Eσ * M := by
+          rw [MeasureTheory.integral_const_mul]
+  have htime :
+      (1 + ‖σ‖) ^ s * Eσ ≤ Ct := by
+    simpa [Eσ] using hCt_bound σ hσ
+  calc
+    (1 + ‖σ‖) ^ s *
+        ‖iteratedFDeriv ℝ r (section43IteratedLaplaceRaw n g) σ‖ =
+        (1 + ‖σ‖) ^ s *
+          ‖section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ‖ := by
+          rw [section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate]
+    _ ≤ (1 + ‖σ‖) ^ s * (Eσ * M) := by
+          exact mul_le_mul_of_nonneg_left hcandidate_norm (pow_nonneg (by positivity) s)
+    _ = ((1 + ‖σ‖) ^ s * Eσ) * M := by ring
+    _ ≤ Ct * M := by
+          exact mul_le_mul_of_nonneg_right htime hM_nonneg
+    _ = C := rfl
+
 /-- A finite-time ambient Schwartz representative of the multitime
 one-sided Laplace transform, modulo equality on the closed positive orthant. -/
 def section43IteratedLaplaceRepresentative
@@ -813,6 +1796,81 @@ def section43IteratedLaplaceRepresentative
     (Φ : SchwartzMap (Fin n → ℝ) ℂ) : Prop :=
   ∀ σ : Fin n → ℝ, σ ∈ section43TimePositiveRegion n →
     Φ σ = section43IteratedLaplaceRaw n g σ
+
+/-- Ambient Schwartz representative obtained by cutting off the raw multitime
+Laplace scalar on the positive time orthant. -/
+noncomputable def section43IteratedLaplaceSchwartzRepresentative
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    SchwartzMap (Fin n → ℝ) ℂ :=
+  schwartzMap_of_temperate_mul_rapid_on_derivSupport
+    (χ := section43TimePositiveCutoff n)
+    (F := section43IteratedLaplaceRaw n g)
+    (S := section43TimePositiveThickening n 1)
+    (section43TimePositiveCutoff_hasTemperateGrowth n)
+    (fun r σ hne =>
+      section43TimePositiveCutoff_iteratedFDeriv_support_subset_thickening_one
+        (n := n) (r := r) (τ := σ) hne)
+    (section43IteratedLaplaceRaw_contDiff n g)
+    (by
+      intro r s
+      exact section43IteratedLaplaceRaw_iteratedFDeriv_rapid_on_timeThickening
+        n r s g)
+
+/-- On the closed positive orthant, the cutoff Schwartz representative agrees
+with the raw multitime Laplace scalar. -/
+theorem section43IteratedLaplaceSchwartzRepresentative_apply_of_mem
+    {n : ℕ} (g : Section43CompactStrictPositiveTimeSource n)
+    {σ : Fin n → ℝ} (hσ : σ ∈ section43TimePositiveRegion n) :
+    section43IteratedLaplaceSchwartzRepresentative n g σ =
+      section43IteratedLaplaceRaw n g σ := by
+  change section43TimePositiveCutoff n σ *
+      section43IteratedLaplaceRaw n g σ =
+    section43IteratedLaplaceRaw n g σ
+  rw [section43TimePositiveCutoff_eq_one_of_mem hσ]
+  simp
+
+/-- Every compact strict-positive finite-time source has an ambient Schwartz
+representative of its multitime one-sided Laplace transform. -/
+theorem exists_section43IteratedLaplaceRepresentative
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ Φ : SchwartzMap (Fin n → ℝ) ℂ,
+      section43IteratedLaplaceRepresentative n g Φ :=
+  ⟨section43IteratedLaplaceSchwartzRepresentative n g, by
+    intro σ hσ
+    exact section43IteratedLaplaceSchwartzRepresentative_apply_of_mem g hσ⟩
+
+/-- The compact strict-positive multitime Laplace transform, valued in the
+finite-time positive-energy quotient. -/
+noncomputable def section43IteratedLaplaceCompactTransform
+    (n : ℕ) :
+    Section43CompactStrictPositiveTimeSource n →
+      Section43TimePositiveComponent n :=
+  fun g =>
+    section43TimePositiveQuotientMap n
+      (Classical.choose (exists_section43IteratedLaplaceRepresentative n g))
+
+theorem section43IteratedLaplaceCompactTransform_choose_spec
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    section43IteratedLaplaceRepresentative n g
+      (Classical.choose (exists_section43IteratedLaplaceRepresentative n g)) :=
+  Classical.choose_spec (exists_section43IteratedLaplaceRepresentative n g)
+
+/-- Any representative of the raw multitime Laplace scalar gives the same
+compact transform quotient class. -/
+theorem section43IteratedLaplaceCompactTransform_eq_quotient
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (Φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (hΦ : section43IteratedLaplaceRepresentative n g Φ) :
+    section43IteratedLaplaceCompactTransform n g =
+      section43TimePositiveQuotientMap n Φ := by
+  dsimp [section43IteratedLaplaceCompactTransform]
+  apply section43TimePositiveQuotientMap_eq_of_eqOn_region
+  intro σ hσ
+  calc
+    Classical.choose (exists_section43IteratedLaplaceRepresentative n g) σ
+        = section43IteratedLaplaceRaw n g σ :=
+          section43IteratedLaplaceCompactTransform_choose_spec n g σ hσ
+    _ = Φ σ := (hΦ σ hσ).symm
 
 /-- The multitime Laplace integrand of a product source factors coordinatewise.
 This is the finite-product Fubini calculation needed for the product-source
@@ -887,6 +1945,20 @@ theorem section43TimeProductTensor_oneSidedLaplaceRepresentative
   intro σ hσ
   simpa [section43IteratedLaplaceRaw] using
     section43TimeProductTensor_oneSidedLaplaceRepresentative_eq_integral gs hσ
+
+/-- For product sources, the compact multitime transform is represented by the
+product tensor of the one-dimensional compact Laplace representatives. -/
+theorem section43IteratedLaplaceCompactTransform_productSource
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    section43IteratedLaplaceCompactTransform n (section43TimeProductSource gs) =
+      section43TimePositiveQuotientMap n
+        (section43TimeProductTensor
+          (fun i : Fin n => section43OneSidedLaplaceSchwartzRepresentative1D (gs i))) :=
+  section43IteratedLaplaceCompactTransform_eq_quotient
+    n (section43TimeProductSource gs)
+    (section43TimeProductTensor
+      (fun i : Fin n => section43OneSidedLaplaceSchwartzRepresentative1D (gs i)))
+    (section43TimeProductTensor_oneSidedLaplaceRepresentative gs)
 
 /-- Product-source representative existence, isolated from the harder
 arbitrary-source representative theorem. -/

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceTimeProductDensity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceTimeProductDensity.lean
@@ -1,0 +1,306 @@
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceTimeProduct
+
+/-!
+# Section 4.3 finite time-product density
+
+This file contains the finite-product density step for the Section 4.3
+Fourier-Laplace OS route.  The analytic construction of the multitime compact
+Laplace transform lives in `Section43FourierLaplaceTimeProduct`; here we only
+package its linearity and use the one-variable density theorem coordinatewise.
+-/
+
+noncomputable section
+
+open scoped Topology FourierTransform BoundedContinuousFunction
+open Set MeasureTheory Filter
+
+namespace OSReconstruction
+
+/-- Quotient equality in the one-variable positive-energy codomain is equality
+on the closed nonnegative half-line. -/
+theorem eqOn_nonneg_of_section43PositiveEnergyQuotientMap1D_eq
+    {f g : SchwartzMap ℝ ℂ}
+    (hfg :
+      section43PositiveEnergyQuotientMap1D f =
+        section43PositiveEnergyQuotientMap1D g) :
+    Set.EqOn (f : ℝ → ℂ) (g : ℝ → ℂ) (Set.Ici (0 : ℝ)) := by
+  change (Submodule.Quotient.mk f : Section43PositiveEnergy1D) =
+    Submodule.Quotient.mk g at hfg
+  rw [Submodule.Quotient.eq] at hfg
+  intro x hx
+  have hx0 : ((f - g : SchwartzMap ℝ ℂ) : ℝ → ℂ) x = 0 := hfg hx
+  exact sub_eq_zero.mp <| by simpa using hx0
+
+/-- The raw finite-time Laplace scalar is additive in the compact source. -/
+theorem section43IteratedLaplaceRaw_add
+    (n : ℕ) (g h : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    section43IteratedLaplaceRaw n (g + h) σ =
+      section43IteratedLaplaceRaw n g σ +
+        section43IteratedLaplaceRaw n h σ := by
+  unfold section43IteratedLaplaceRaw
+  calc
+    (∫ τ : Fin n → ℝ,
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        (g + h).f τ)
+        =
+      ∫ τ : Fin n → ℝ,
+        (Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * g.f τ +
+          Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * h.f τ) := by
+          refine integral_congr_ae ?_
+          filter_upwards with τ
+          change
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+                (g.f τ + h.f τ) =
+              Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * g.f τ +
+                Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * h.f τ
+          ring
+    _ =
+      (∫ τ : Fin n → ℝ,
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * g.f τ) +
+      (∫ τ : Fin n → ℝ,
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * h.f τ) := by
+          rw [integral_add
+            (integrable_section43IteratedLaplaceRaw_integrand_of_compact n g σ)
+            (integrable_section43IteratedLaplaceRaw_integrand_of_compact n h σ)]
+
+/-- The raw finite-time Laplace scalar is homogeneous in the compact source. -/
+theorem section43IteratedLaplaceRaw_smul
+    (n : ℕ) (c : ℂ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    section43IteratedLaplaceRaw n (c • g) σ =
+      c * section43IteratedLaplaceRaw n g σ := by
+  unfold section43IteratedLaplaceRaw
+  calc
+    (∫ τ : Fin n → ℝ,
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        (c • g).f τ)
+        =
+      ∫ τ : Fin n → ℝ,
+        c * (Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * g.f τ) := by
+          refine integral_congr_ae ?_
+          filter_upwards with τ
+          change
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+                (c * g.f τ) =
+              c * (Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * g.f τ)
+          ring
+    _ =
+      c * ∫ τ : Fin n → ℝ,
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * g.f τ := by
+          simpa using
+            (integral_const_mul c
+              (fun τ : Fin n → ℝ =>
+                Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) * g.f τ))
+
+/-- Representatives of multitime Laplace transforms add pointwise on the
+positive finite-time quotient surface. -/
+theorem section43IteratedLaplaceRepresentative_add
+    {n : ℕ} {g h : Section43CompactStrictPositiveTimeSource n}
+    {Φ Ψ : SchwartzMap (Fin n → ℝ) ℂ}
+    (hΦ : section43IteratedLaplaceRepresentative n g Φ)
+    (hΨ : section43IteratedLaplaceRepresentative n h Ψ) :
+    section43IteratedLaplaceRepresentative n (g + h) (Φ + Ψ) := by
+  intro σ hσ
+  calc
+    (Φ + Ψ) σ = Φ σ + Ψ σ := by simp
+    _ = section43IteratedLaplaceRaw n g σ +
+        section43IteratedLaplaceRaw n h σ := by
+          rw [hΦ σ hσ, hΨ σ hσ]
+    _ = section43IteratedLaplaceRaw n (g + h) σ := by
+          rw [section43IteratedLaplaceRaw_add]
+
+/-- Representatives of multitime Laplace transforms are homogeneous pointwise
+on the positive finite-time quotient surface. -/
+theorem section43IteratedLaplaceRepresentative_smul
+    {n : ℕ} (c : ℂ) {g : Section43CompactStrictPositiveTimeSource n}
+    {Φ : SchwartzMap (Fin n → ℝ) ℂ}
+    (hΦ : section43IteratedLaplaceRepresentative n g Φ) :
+    section43IteratedLaplaceRepresentative n (c • g) (c • Φ) := by
+  intro σ hσ
+  calc
+    (c • Φ) σ = c * Φ σ := by simp
+    _ = c * section43IteratedLaplaceRaw n g σ := by
+          rw [hΦ σ hσ]
+    _ = section43IteratedLaplaceRaw n (c • g) σ := by
+          rw [section43IteratedLaplaceRaw_smul]
+
+/-- The compact multitime Laplace transform is additive in its compact source. -/
+theorem section43IteratedLaplaceCompactTransform_map_add
+    {n : ℕ} (g h : Section43CompactStrictPositiveTimeSource n) :
+    section43IteratedLaplaceCompactTransform n (g + h) =
+      section43IteratedLaplaceCompactTransform n g +
+        section43IteratedLaplaceCompactTransform n h := by
+  let Φg := section43IteratedLaplaceSchwartzRepresentative n g
+  let Φh := section43IteratedLaplaceSchwartzRepresentative n h
+  have hΦg : section43IteratedLaplaceRepresentative n g Φg := by
+    intro σ hσ
+    exact section43IteratedLaplaceSchwartzRepresentative_apply_of_mem g hσ
+  have hΦh : section43IteratedLaplaceRepresentative n h Φh := by
+    intro σ hσ
+    exact section43IteratedLaplaceSchwartzRepresentative_apply_of_mem h hσ
+  have hsum : section43IteratedLaplaceRepresentative n (g + h) (Φg + Φh) :=
+    section43IteratedLaplaceRepresentative_add hΦg hΦh
+  calc
+    section43IteratedLaplaceCompactTransform n (g + h)
+        = section43TimePositiveQuotientMap n (Φg + Φh) :=
+            section43IteratedLaplaceCompactTransform_eq_quotient n (g + h)
+              (Φg + Φh) hsum
+    _ = section43TimePositiveQuotientMap n Φg +
+        section43TimePositiveQuotientMap n Φh := by
+          rw [map_add]
+    _ = section43IteratedLaplaceCompactTransform n g +
+        section43IteratedLaplaceCompactTransform n h := by
+          rw [← section43IteratedLaplaceCompactTransform_eq_quotient n g Φg hΦg,
+            ← section43IteratedLaplaceCompactTransform_eq_quotient n h Φh hΦh]
+
+/-- The compact multitime Laplace transform is homogeneous in its compact
+source. -/
+theorem section43IteratedLaplaceCompactTransform_map_smul
+    {n : ℕ} (c : ℂ) (g : Section43CompactStrictPositiveTimeSource n) :
+    section43IteratedLaplaceCompactTransform n (c • g) =
+      c • section43IteratedLaplaceCompactTransform n g := by
+  let Φg := section43IteratedLaplaceSchwartzRepresentative n g
+  have hΦg : section43IteratedLaplaceRepresentative n g Φg := by
+    intro σ hσ
+    exact section43IteratedLaplaceSchwartzRepresentative_apply_of_mem g hσ
+  have hsmul : section43IteratedLaplaceRepresentative n (c • g) (c • Φg) :=
+    section43IteratedLaplaceRepresentative_smul c hΦg
+  calc
+    section43IteratedLaplaceCompactTransform n (c • g)
+        = section43TimePositiveQuotientMap n (c • Φg) :=
+            section43IteratedLaplaceCompactTransform_eq_quotient n (c • g)
+              (c • Φg) hsmul
+    _ = c • section43TimePositiveQuotientMap n Φg := by
+          rw [map_smul]
+    _ = c • section43IteratedLaplaceCompactTransform n g := by
+          rw [← section43IteratedLaplaceCompactTransform_eq_quotient n g Φg hΦg]
+
+/-- The compact strict-positive multitime Laplace transform as a linear map.
+This exposes its range as the submodule needed for the finite-product density
+argument. -/
+noncomputable def section43IteratedLaplaceCompactTransformLinearMap
+    (n : ℕ) :
+    Section43CompactStrictPositiveTimeSource n →ₗ[ℂ]
+      Section43TimePositiveComponent n where
+  toFun := section43IteratedLaplaceCompactTransform n
+  map_add' := section43IteratedLaplaceCompactTransform_map_add
+  map_smul' := section43IteratedLaplaceCompactTransform_map_smul
+
+/-- A product tensor whose one-variable factors lie in the one-sided compact
+Laplace preimage lies in the finite-time compact transform preimage. -/
+theorem section43TimeProductTensor_mem_iteratedLaplaceCompactTransform_preimage
+    {n : ℕ} {fs : Fin n → SchwartzMap ℝ ℂ}
+    (hfs :
+      ∀ i : Fin n,
+        fs i ∈
+          section43PositiveEnergyQuotientMap1D ⁻¹'
+            Set.range section43OneSidedLaplaceCompactTransform1D) :
+    section43TimeProductTensor fs ∈
+      (section43TimePositiveQuotientMap n) ⁻¹'
+        Set.range (section43IteratedLaplaceCompactTransform n) := by
+  classical
+  have hEx :
+      ∀ i : Fin n,
+        ∃ g : Section43CompactPositiveTimeSource1D,
+          section43OneSidedLaplaceCompactTransform1D g =
+            section43PositiveEnergyQuotientMap1D (fs i) := by
+    intro i
+    exact hfs i
+  choose gs hgs using hEx
+  refine ⟨section43TimeProductSource gs, ?_⟩
+  calc
+    section43IteratedLaplaceCompactTransform n (section43TimeProductSource gs)
+        =
+      section43TimePositiveQuotientMap n
+        (section43TimeProductTensor
+          (fun i : Fin n => section43OneSidedLaplaceSchwartzRepresentative1D (gs i))) :=
+          section43IteratedLaplaceCompactTransform_productSource gs
+    _ = section43TimePositiveQuotientMap n (section43TimeProductTensor fs) := by
+          apply section43TimePositiveQuotientMap_eq_of_eqOn_region
+          intro σ hσ
+          rw [section43TimeProductTensor, section43TimeProductTensor]
+          rw [SchwartzMap.productTensor_apply, SchwartzMap.productTensor_apply]
+          refine Finset.prod_congr rfl ?_
+          intro i _hi
+          have hq :
+              section43PositiveEnergyQuotientMap1D (fs i) =
+                section43PositiveEnergyQuotientMap1D
+                  (section43OneSidedLaplaceSchwartzRepresentative1D (gs i)) := by
+            calc
+              section43PositiveEnergyQuotientMap1D (fs i)
+                  = section43OneSidedLaplaceCompactTransform1D (gs i) :=
+                    (hgs i).symm
+              _ = section43PositiveEnergyQuotientMap1D
+                    (section43OneSidedLaplaceSchwartzRepresentative1D (gs i)) :=
+                    section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient (gs i)
+          have heqOn :=
+            eqOn_nonneg_of_section43PositiveEnergyQuotientMap1D_eq hq
+          exact (heqOn (hσ i)).symm
+
+/-- Finite-time compact strict-positive Laplace transforms have dense preimage
+under the positive-time quotient map. -/
+theorem dense_section43IteratedLaplaceCompactTransform_preimage
+    (n : ℕ) :
+    Dense
+      ((section43TimePositiveQuotientMap n) ⁻¹'
+        Set.range (section43IteratedLaplaceCompactTransform n)) := by
+  let A := SchwartzMap (Fin n → ℝ) ℂ
+  let E := SchwartzMap ℝ ℂ
+  let S1 : Set E :=
+    section43PositiveEnergyQuotientMap1D ⁻¹'
+      Set.range section43OneSidedLaplaceCompactTransform1D
+  let PS : Set A :=
+    {F : A | ∃ fs : Fin n → E,
+      (∀ i : Fin n, fs i ∈ S1) ∧ F = section43TimeProductTensor fs}
+  let MS : Submodule ℂ A := Submodule.span ℂ PS
+  let qn := section43TimePositiveQuotientMap n
+  let L := section43IteratedLaplaceCompactTransformLinearMap n
+  let Mq : Submodule ℂ (Section43TimePositiveComponent n) := LinearMap.range L
+  let target : Submodule ℂ A := Mq.comap qn.toLinearMap
+  have htarget :
+      (section43TimePositiveQuotientMap n) ⁻¹'
+          Set.range (section43IteratedLaplaceCompactTransform n) =
+        (target : Set A) := by
+    ext F
+    simp [target, Mq, L, qn, section43IteratedLaplaceCompactTransformLinearMap]
+  have hMS_dense : Dense (MS : Set A) := by
+    simpa [MS, PS, S1, A, E] using
+      section43_timeProductTensor_span_dense_of_factor_dense
+        (S := S1)
+        dense_section43OneSidedLaplaceCompactTransform1D_preimage n
+  have hMS_le_target_sub : MS ≤ target := by
+    refine Submodule.span_le.mpr ?_
+    intro F hF
+    rcases hF with ⟨fs, hfs, rfl⟩
+    change qn (section43TimeProductTensor fs) ∈ Mq
+    have hprod :=
+      section43TimeProductTensor_mem_iteratedLaplaceCompactTransform_preimage
+        (n := n) (fs := fs) hfs
+    change section43TimePositiveQuotientMap n (section43TimeProductTensor fs) ∈
+      Set.range (section43IteratedLaplaceCompactTransform n) at hprod
+    rcases hprod with ⟨g, hg⟩
+    exact ⟨g, by
+      simpa [Mq, L, section43IteratedLaplaceCompactTransformLinearMap] using hg⟩
+  rw [htarget]
+  exact Dense.mono (fun F hF => hMS_le_target_sub hF) hMS_dense
+
+/-- The finite-time compact strict-positive Laplace transform has dense range
+in the finite-time positive-energy quotient. -/
+theorem denseRange_section43IteratedLaplaceCompactTransformLinearMap
+    (n : ℕ) :
+    DenseRange (section43IteratedLaplaceCompactTransformLinearMap n) := by
+  have hq :
+      IsOpenQuotientMap
+        (section43TimePositiveQuotientMap n :
+          SchwartzMap (Fin n → ℝ) ℂ → Section43TimePositiveComponent n) := by
+    simpa [section43TimePositiveQuotientMap] using
+      (section43TimeVanishingSubmodule n).isOpenQuotientMap_mkQ
+  have hdense_set :
+      Dense (Set.range (section43IteratedLaplaceCompactTransform n)) :=
+    hq.dense_preimage_iff.mp
+      (dense_section43IteratedLaplaceCompactTransform_preimage n)
+  simpa [DenseRange, section43IteratedLaplaceCompactTransformLinearMap] using
+    hdense_set
+
+end OSReconstruction

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -3111,13 +3111,93 @@ Proof:
    section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
    section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget
    ```
-   Linear-closure packet needed next:
+   Linear-closure packet needed next.  This is the finite-span bridge from the
+   compiled generator containment theorem to the dense restricted span theorem.
    1. Give `Section43CompactStrictPositiveTimeSpatialSource d n` the same
       `Zero`, `Add`, `SMul ℂ`, `AddCommMonoid`, and `Module ℂ` structure as
       `Section43CompactStrictPositiveTimeSource n`, using `f` as the injective
       carrier map.  The support proofs are exactly:
       `tsupport_add`, `tsupport_smul_subset_right`, `HasCompactSupport.add`,
       and `HasCompactSupport.smul_left`.
+      The implementation should be a direct copy of the existing namespace:
+      ```lean
+      namespace Section43CompactStrictPositiveTimeSpatialSource
+
+      private theorem ext_f
+          {G H : Section43CompactStrictPositiveTimeSpatialSource d n}
+          (hf : G.f = H.f) : G = H := by
+        cases G
+        cases H
+        simp at hf
+        subst hf
+        rfl
+
+      private theorem f_injective (d n : ℕ) [NeZero d] :
+          Function.Injective
+            (fun G : Section43CompactStrictPositiveTimeSpatialSource d n => G.f) := by
+        intro G H hf
+        exact ext_f hf
+
+      instance (d n : ℕ) [NeZero d] :
+          Zero (Section43CompactStrictPositiveTimeSpatialSource d n) := ...
+      instance (d n : ℕ) [NeZero d] :
+          Add (Section43CompactStrictPositiveTimeSpatialSource d n) := ...
+      instance (d n : ℕ) [NeZero d] :
+          SMul ℕ (Section43CompactStrictPositiveTimeSpatialSource d n) := ...
+      instance (d n : ℕ) [NeZero d] :
+          AddCommMonoid (Section43CompactStrictPositiveTimeSpatialSource d n) :=
+        Function.Injective.addCommMonoid
+          (fun G : Section43CompactStrictPositiveTimeSpatialSource d n => G.f)
+          (f_injective d n) rfl
+          (by intro G H; rfl)
+          (by
+            intro G m
+            change (m : ℂ) • G.f = m • G.f
+            rw [Nat.cast_smul_eq_nsmul ℂ])
+      instance (d n : ℕ) [NeZero d] :
+          SMul ℂ (Section43CompactStrictPositiveTimeSpatialSource d n) := ...
+
+      private def fAddMonoidHom (d n : ℕ) [NeZero d] :
+          Section43CompactStrictPositiveTimeSpatialSource d n →+
+            SchwartzNPoint d n where
+        toFun := fun G => G.f
+        map_zero' := rfl
+        map_add' := by intro G H; rfl
+
+      instance (d n : ℕ) [NeZero d] :
+          Module ℂ (Section43CompactStrictPositiveTimeSpatialSource d n) :=
+        Function.Injective.module ℂ (fAddMonoidHom d n)
+          (by
+            intro G H hf
+            exact (f_injective d n) hf)
+          (by intro c G; rfl)
+
+      end Section43CompactStrictPositiveTimeSpatialSource
+      ```
+      The `Zero`, `Add`, and scalar cases are literally:
+      ```lean
+      positive := by
+        intro q hq
+        simp at hq
+
+      positive := by
+        intro q hq
+        have hq' :=
+          tsupport_add (G.f : NPointDomain d n → ℂ)
+            (H.f : NPointDomain d n → ℂ) hq
+        exact hq'.elim (fun hG => G.positive hG) (fun hH => H.positive hH)
+
+      positive := by
+        exact
+          (tsupport_smul_subset_right
+            (fun _ : NPointDomain d n => c)
+            (G.f : NPointDomain d n → ℂ)).trans G.positive
+      compact := by
+        simpa using
+          (HasCompactSupport.smul_left
+            (f := fun _ : NPointDomain d n => c)
+            (f' := (G.f : NPointDomain d n → ℂ)) G.compact)
+      ```
    2. Prove strict support implies closed positive-energy support:
       ```lean
       theorem section43TimeSpatialSource_tsupport_subset_positiveEnergy
@@ -3149,6 +3229,56 @@ Proof:
       with `section43TimeSpatialSource_tsupport_subset_positiveEnergy G`.
       The base integrability is `integrable_partialFourierSpatial_timeSlice`;
       on nonnegative `τ`, use `norm_exp_neg_section43_timePair_le_one`.
+      The Lean skeleton is:
+      ```lean
+      let F : (Fin n → ℝ) → ℂ := fun τ =>
+        partialFourierSpatial_fun
+          (d := d) (n := n) G.f
+          (τ, section43QSpatial (d := d) (n := n) q)
+      let E : (Fin n → ℝ) → ℂ := fun τ =>
+        Complex.exp
+          (-(∑ k : Fin n,
+            (τ k : ℂ) * (section43QTime (d := d) (n := n) q k : ℂ)))
+      have hF_int : Integrable F (volume : Measure (Fin n → ℝ)) := by
+        simpa [F] using
+          integrable_partialFourierSpatial_timeSlice
+            (d := d) (n := n) G.f
+            (section43QSpatial (d := d) (n := n) q)
+      have hEF_meas : AEStronglyMeasurable
+          (fun τ : Fin n → ℝ => E τ * F τ)
+          (volume : Measure (Fin n → ℝ)) := by
+        have hE_cont : Continuous E := by
+          fun_prop
+        exact hE_cont.aestronglyMeasurable.mul hF_int.aestronglyMeasurable
+      have hbound : ∀ᵐ τ : Fin n → ℝ ∂(volume : Measure (Fin n → ℝ)),
+          ‖E τ * F τ‖ ≤ ‖F τ‖ := by
+        refine Filter.Eventually.of_forall ?_
+        intro τ
+        by_cases hneg : ∃ i : Fin n, τ i < 0
+        · rcases hneg with ⟨i, hi⟩
+          have hF_zero : F τ = 0 := by
+            simpa [F, Function.update_eq_self] using
+              section43PartialFourierSpatial_fun_eq_zero_of_neg_time_of_support_positiveEnergy
+                (d := d) (n := n) G.f
+                (section43TimeSpatialSource_tsupport_subset_positiveEnergy
+                  (d := d) (n := n) G)
+                i τ (section43QSpatial (d := d) (n := n) q)
+                (s := τ i) hi
+          simp [hF_zero]
+        · have hτ_nonneg : ∀ i : Fin n, 0 ≤ τ i := by
+            intro i
+            exact le_of_not_gt fun hi => hneg ⟨i, hi⟩
+          have hE_le : ‖E τ‖ ≤ 1 := by
+            simpa [E] using
+              norm_exp_neg_section43_timePair_le_one
+                (d := d) (n := n) q τ hq hτ_nonneg
+          calc
+            ‖E τ * F τ‖ = ‖E τ‖ * ‖F τ‖ := norm_mul _ _
+            _ ≤ 1 * ‖F τ‖ :=
+              mul_le_mul_of_nonneg_right hE_le (norm_nonneg _)
+            _ = ‖F τ‖ := one_mul _
+      simpa [F, E] using hF_int.mono hEF_meas hbound
+      ```
    4. Prove representative linearity:
       ```lean
       theorem section43TimeLaplaceSpatialFourierRepresentative_add
@@ -3169,7 +3299,118 @@ Proof:
       `MeasureTheory.integral_add`, and `partialFourierSpatial_fun_add`.
       For scalar multiplication, use `MeasureTheory.integral_const_mul` and
       `partialFourierSpatial_fun_smul`.
-7. Conclude density by `Dense.mono` from the dense restricted span.
+      Avoid brittle rewriting by naming the exponential and Fourier factors:
+      ```lean
+      intro q hq
+      let E : (Fin n → ℝ) → ℂ := fun τ => ...
+      let FG : (Fin n → ℝ) → ℂ := fun τ =>
+        partialFourierSpatial_fun (d := d) (n := n) G.f
+          (τ, section43QSpatial (d := d) (n := n) q)
+      let FH : (Fin n → ℝ) → ℂ := fun τ =>
+        partialFourierSpatial_fun (d := d) (n := n) H.f
+          (τ, section43QSpatial (d := d) (n := n) q)
+      have hGint := integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+        (d := d) (n := n) G q hq
+      have hHint := integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+        (d := d) (n := n) H q hq
+      calc
+        (Φ + Ψ) q = Φ q + Ψ q := rfl
+        _ =
+            (∫ τ : Fin n → ℝ, E τ * FG τ) +
+            (∫ τ : Fin n → ℝ, E τ * FH τ) := by
+              rw [hΦ q hq, hΨ q hq]
+        _ = ∫ τ : Fin n → ℝ, E τ * FG τ + E τ * FH τ := by
+              exact (MeasureTheory.integral_add
+                (by simpa [E, FG] using hGint)
+                (by simpa [E, FH] using hHint)).symm
+        _ = ∫ τ : Fin n → ℝ, E τ *
+              partialFourierSpatial_fun (d := d) (n := n) (G + H).f
+                (τ, section43QSpatial (d := d) (n := n) q) := by
+              congr with τ
+              change E τ * FG τ + E τ * FH τ =
+                E τ * partialFourierSpatial_fun
+                  (d := d) (n := n) (G.f + H.f)
+                  (τ, section43QSpatial (d := d) (n := n) q)
+              rw [partialFourierSpatial_fun_add]
+              change E τ * FG τ + E τ * FH τ = E τ * (FG τ + FH τ)
+              ring
+      ```
+      Scalar multiplication is the same pattern:
+      ```lean
+      intro q hq
+      let E : (Fin n → ℝ) → ℂ := fun τ => ...
+      let FG : (Fin n → ℝ) → ℂ := fun τ =>
+        partialFourierSpatial_fun (d := d) (n := n) G.f
+          (τ, section43QSpatial (d := d) (n := n) q)
+      have hGint := integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+        (d := d) (n := n) G q hq
+      calc
+        (c • Φ) q = c * Φ q := by simp [smul_eq_mul]
+        _ = c * ∫ τ : Fin n → ℝ, E τ * FG τ := by
+              rw [hΦ q hq]
+        _ = ∫ τ : Fin n → ℝ, c * (E τ * FG τ) := by
+              exact (MeasureTheory.integral_const_mul c
+                (fun τ : Fin n → ℝ => E τ * FG τ)).symm
+        _ = ∫ τ : Fin n → ℝ, E τ *
+              partialFourierSpatial_fun (d := d) (n := n) (c • G).f
+                (τ, section43QSpatial (d := d) (n := n) q) := by
+              congr with τ
+              change c * (E τ * FG τ) =
+                E τ * partialFourierSpatial_fun
+                  (d := d) (n := n) (c • G.f)
+                  (τ, section43QSpatial (d := d) (n := n) q)
+              rw [partialFourierSpatial_fun_smul]
+              change c * (E τ * FG τ) = E τ * (c * FG τ)
+              ring
+      ```
+      The explicit `change` lines are important: they expose `(G + H).f` and
+      `(c • G).f` as `G.f + H.f` and `c • G.f` before applying the
+      partial-Fourier linearity lemmas.
+   5. Define the representative target set and prove finite-span containment:
+      ```lean
+      def section43TimeLaplaceSpatialFourierTarget
+          (d n : ℕ) [NeZero d] : Set (SchwartzNPoint d n) :=
+        {Φ |
+          ∃ (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+            (Ψ : SchwartzNPoint d n),
+            section43TimeLaplaceSpatialFourierRepresentative d n G Ψ ∧
+            section43PositiveEnergyQuotientMap (d := d) n Φ =
+              section43PositiveEnergyQuotientMap (d := d) n Ψ}
+
+      theorem section43TimeLaplaceSpatialFourierTarget_add
+          {Φ Ψ : SchwartzNPoint d n}
+          (hΦ : Φ ∈ section43TimeLaplaceSpatialFourierTarget d n)
+          (hΨ : Ψ ∈ section43TimeLaplaceSpatialFourierTarget d n) :
+          Φ + Ψ ∈ section43TimeLaplaceSpatialFourierTarget d n
+
+      theorem section43TimeLaplaceSpatialFourierTarget_smul
+          (c : ℂ) {Φ : SchwartzNPoint d n}
+          (hΦ : Φ ∈ section43TimeLaplaceSpatialFourierTarget d n) :
+          c • Φ ∈ section43TimeLaplaceSpatialFourierTarget d n
+      ```
+      In the quotient equalities, use `map_add` and `map_smul` for
+      `section43PositiveEnergyQuotientMap`, then the representative add/smul
+      theorem for the witnesses.  With these two closure lemmas, prove
+      `Submodule.span ℂ restrictedGenerators ⊆ section43TimeLaplaceSpatialFourierTarget d n`
+      by `Submodule.span_induction`, using the compiled generator containment
+      theorem as the base case.
+   Production update, 2026-04-18: the full linear-closure and dense-target
+   packet is compiled in `Section43FourierLaplaceSpatialDensity.lean`:
+   ```lean
+   section43TimeSpatialSource_tsupport_subset_positiveEnergy
+   integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+   section43TimeLaplaceSpatialFourierRepresentative_add
+   section43TimeLaplaceSpatialFourierRepresentative_smul
+   section43TimeLaplaceSpatialFourierTarget
+   section43TimeLaplaceSpatialFourierTarget_zero
+   section43TimeLaplaceSpatialFourierTarget_add
+   section43TimeLaplaceSpatialFourierTarget_smul
+   section43NPointTimeSpatialTensor_span_le_timeLaplaceSpatialFourierTarget
+   dense_section43TimeLaplaceSpatialFourier_compact_preimage
+   ```
+6. Conclude density by `Dense.mono` from the dense restricted span.  This is
+   now the compiled theorem
+   `dense_section43TimeLaplaceSpatialFourier_compact_preimage`.
 
 The `n = 0` case must be kept explicit in implementation.  Then
 `Fin n → ℝ` and `Section43SpatialSpace d n` are singleton/zero-dimensional

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -261,7 +261,7 @@ theorem section43OneSidedLaplaceRaw_contDiff
 theorem section43OneSidedLaplaceRaw_iteratedFDeriv_formula
     (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) :
     iteratedFDeriv ℝ r (section43OneSidedLaplaceRaw g) σ =
-      ContinuousMultilinearMap.mkPiAlgebraFin ℝ r ℂ
+      (ContinuousMultilinearMap.mkPiAlgebraFin ℝ r ℝ).smulRight
         (∫ t : ℝ,
           (-t : ℂ) ^ r *
             Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t)
@@ -274,6 +274,187 @@ theorem section43OneSidedLaplaceRaw_rapid_on_Ici_neg_one
           ‖iteratedFDeriv ℝ r (section43OneSidedLaplaceRaw g) σ‖ ≤ C
 ```
 
+Lean-ready raw-Laplace calculus packet:
+
+Production status, 2026-04-17: this packet is compiled through Step 8 in
+`Section43FourierLaplaceDensity.lean`.  The remaining theorem from this group
+is the rapid estimate on `Set.Ici (-1)`.
+
+1. Add the genuine derivative-candidate integral, not as a wrapper but as the
+   object that appears after differentiating under the integral:
+
+```lean
+noncomputable def section43OneSidedLaplaceRawDerivCandidate
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) : ℂ :=
+  ∫ t : ℝ,
+    (-t : ℂ) ^ r *
+      Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t
+```
+
+Then `section43OneSidedLaplaceRawDerivCandidate g 0 = section43OneSidedLaplaceRaw g`.
+
+2. Prove integrability of every derivative kernel for every real `σ`:
+
+```lean
+theorem section43OneSidedLaplaceRawDerivCandidate_integrable
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) :
+    Integrable
+      (fun t : ℝ =>
+        (-t : ℂ) ^ r *
+          Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t)
+```
+
+Proof transcript:
+
+- The integrand is continuous as a product of the polynomial factor, the
+  complex exponential factor, and `g.f.continuous`.
+- Its compact support follows from `g.compact.mul_left`, because the first two
+  factors multiply `g.f` on the left.
+- Apply `Continuous.integrable_of_hasCompactSupport`.
+
+This lemma is intentionally stronger than the existing nonnegative-real-part
+integrability theorem: compact source support makes the kernel integrable for
+all real `σ`, including the transition strip `-1 ≤ σ ≤ 0` where the cutoff has
+nonzero derivatives.
+
+3. Prove the pointwise kernel derivative:
+
+```lean
+theorem section43OneSidedLaplaceRawDerivKernel_hasDerivAt
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (t σ : ℝ) :
+    HasDerivAt
+      (fun σ : ℝ =>
+        (-t : ℂ) ^ r *
+          Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t)
+      ((-t : ℂ) ^ (r + 1) *
+        Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t)
+      σ
+```
+
+Proof transcript:
+
+- First prove
+
+```lean
+HasDerivAt
+  (fun σ : ℝ => Complex.exp (-(t : ℂ) * (σ : ℂ)))
+  (-(t : ℂ) * Complex.exp (-(t : ℂ) * (σ : ℂ))) σ
+```
+
+  by differentiating `fun σ : ℝ => -((t : ℂ) * (σ : ℂ))`: prove the linear
+  derivative for `fun σ => (t : ℂ) * (σ : ℂ)` using
+  `(Complex.ofRealCLM.hasDerivAt (x := σ))`, negate it, then apply `.cexp`.
+- Multiply by the constants `(-t : ℂ)^r` and `g.f t`.
+- Finish by `ring` to identify
+  `(-t)^r * (-(t))` with `(-t)^(r+1)`.
+
+4. Prove the local domination needed by
+   `hasDerivAt_integral_of_dominated_loc_of_deriv_le`.
+
+For fixed `σ₀`, choose support bounds
+`0 < δ`, `δ ≤ R`, and `tsupport g.f ⊆ Set.Icc δ R`.  Let
+
+```lean
+Mσ := |σ₀| + 1
+B r σ₀ :=
+  (max |δ| |R|) ^ r * Real.exp (R * Mσ)
+```
+
+and use the real bound
+
+```lean
+bound t := B (r + 1) σ₀ * ‖g.f t‖
+```
+
+Then for all `σ ∈ Metric.closedBall σ₀ 1`,
+
+```lean
+‖(-t : ℂ) ^ (r + 1) *
+    Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t‖ ≤ bound t.
+```
+
+Proof transcript:
+
+- If `g.f t = 0`, both sides reduce to `0 ≤ 0`.
+- If `g.f t ≠ 0`, then `t ∈ tsupport g.f`, hence `δ ≤ t ≤ R`.
+- Thus `0 ≤ t`, `|t| ≤ max |δ| |R|`, and
+  `‖(-t : ℂ)^(r+1)‖ ≤ (max |δ| |R|)^(r+1)`.
+- From `σ ∈ closedBall σ₀ 1`, get `|σ| ≤ |σ₀| + 1`.
+- Since `0 ≤ t ≤ R`,
+  `(-(t : ℂ) * (σ : ℂ)).re = -(t * σ) ≤ R * (|σ₀| + 1)`.
+- Therefore
+  `‖Complex.exp (-(t : ℂ) * (σ : ℂ))‖ ≤ Real.exp (R * (|σ₀| + 1))`
+  by `Complex.norm_exp` and `Real.exp_le_exp`.
+- `bound` is integrable because it is a constant multiple of
+  `g.f.integrable.norm`.
+
+5. Apply
+
+```lean
+hasDerivAt_integral_of_dominated_loc_of_deriv_le
+```
+
+with
+
+```lean
+F σ t :=
+  (-t : ℂ)^r * Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t
+F' σ t :=
+  (-t : ℂ)^(r+1) * Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t
+s := Metric.closedBall σ₀ 1
+bound := fun t => B (r + 1) σ₀ * ‖g.f t‖
+```
+
+This gives:
+
+```lean
+theorem section43OneSidedLaplaceRawDerivCandidate_hasDerivAt
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) :
+    HasDerivAt
+      (section43OneSidedLaplaceRawDerivCandidate g r)
+      (section43OneSidedLaplaceRawDerivCandidate g (r + 1) σ)
+      σ
+```
+
+6. Induct on `r` to identify ordinary iterated derivatives:
+
+```lean
+theorem section43OneSidedLaplaceRaw_iteratedDeriv_formula
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) :
+    iteratedDeriv r (section43OneSidedLaplaceRaw g) σ =
+      section43OneSidedLaplaceRawDerivCandidate g r σ
+```
+
+Use `iteratedDeriv_succ` and
+`section43OneSidedLaplaceRawDerivCandidate_hasDerivAt.deriv`.
+
+7. Smoothness follows by the same local pattern already used in
+   `section43ContDiff_partialFourierSpatial_timeSlice`:
+
+```lean
+apply contDiff_of_differentiable_iteratedDeriv
+intro r hr
+rw [section43OneSidedLaplaceRaw_iteratedDeriv_formula]
+exact fun σ =>
+  (section43OneSidedLaplaceRawDerivCandidate_hasDerivAt g r σ).differentiableAt
+```
+
+8. Convert to the Fréchet formula only after the ordinary derivative formula is
+   proved.  Use
+   `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` to prove equality by
+   extensionality against `m : Fin r → ℝ`:
+
+```lean
+theorem section43OneSidedLaplaceRaw_iteratedFDeriv_formula
+    (g : Section43CompactPositiveTimeSource1D) (r : ℕ) (σ : ℝ) :
+    iteratedFDeriv ℝ r (section43OneSidedLaplaceRaw g) σ =
+      (ContinuousMultilinearMap.mkPiAlgebraFin ℝ r ℝ).smulRight
+        (section43OneSidedLaplaceRawDerivCandidate g r σ)
+```
+
+Both sides evaluate to `(∏ i, m i) •
+section43OneSidedLaplaceRawDerivCandidate g r σ`.
+
 For the rapid theorem, use
 `exists_positive_Icc_bounds_of_compactPositiveTimeSource` to choose
 `0 < δ ≤ R` and `tsupport g.f ⊆ Set.Icc δ R`.  Split `σ ∈ Set.Ici (-1)` into
@@ -281,6 +462,90 @@ For the rapid theorem, use
 use compact support.  On `[0,∞)`, use
 `Real.exp (-(δ * σ))` and the standard fact that exponential decay dominates
 all polynomial powers.
+
+Lean-ready rapid-bound transcript:
+
+1. Normalize the Fréchet derivative norm via the compiled formula:
+
+```lean
+rw [section43OneSidedLaplaceRaw_iteratedFDeriv_formula]
+rw [ContinuousMultilinearMap.norm_smulRight,
+  ContinuousMultilinearMap.norm_mkPiAlgebraFin]
+```
+
+This reduces the target to bounding
+`‖section43OneSidedLaplaceRawDerivCandidate g r σ‖`.
+
+2. Let
+
+```lean
+A r := (R ^ r) * ∫ t : ℝ, ‖g.f t‖
+```
+
+or, if Lean prefers avoiding positivity of the integral inline, use
+
+```lean
+A r := (max |δ| |R|) ^ r * ∫ t : ℝ, ‖g.f t‖
+```
+
+The integral is finite because `g.f.integrable.norm`.
+
+3. Prove the candidate integral bound by
+`norm_integral_le_integral_norm` and support splitting:
+
+```lean
+‖section43OneSidedLaplaceRawDerivCandidate g r σ‖
+  ≤ A r * Real.exp (R)
+```
+
+for `-1 ≤ σ ≤ 0`, and
+
+```lean
+‖section43OneSidedLaplaceRawDerivCandidate g r σ‖
+  ≤ A r * Real.exp (-(δ * σ))
+```
+
+for `0 ≤ σ`.
+
+Proof details:
+
+- If `g.f t = 0`, the integrand norm is zero.
+- If `g.f t ≠ 0`, then `δ ≤ t ≤ R`.
+- For `-1 ≤ σ ≤ 0`, use
+  `(-(t : ℂ) * (σ : ℂ)).re = -(t * σ) ≤ R` because
+  `t ≤ R` and `-σ ≤ 1`.
+- For `0 ≤ σ`, use
+  `-(t * σ) ≤ -(δ * σ)` because `δ ≤ t` and `0 ≤ σ`.
+
+4. The compact strip contribution is bounded by
+
+```lean
+Cstrip r s := 2 ^ s * A r * Real.exp R
+```
+
+because `σ ∈ [-1,0]` implies `‖σ‖ ≤ 1`, hence
+`(1 + ‖σ‖)^s ≤ 2^s`.
+
+5. The positive half-line contribution is bounded by applying
+`SCV.pow_mul_exp_neg_le_const hδ_pos s` to `ξ := 1 + σ`:
+
+```lean
+(1 + ‖σ‖)^s * Real.exp (-(δ * σ))
+  = Real.exp δ * ((1 + σ)^s * Real.exp (-(δ * (1 + σ))))
+  ≤ Real.exp δ * Cexp
+```
+
+for `0 ≤ σ`.  This avoids a separate binomial estimate for `(1 + σ)^s`.
+
+6. Take
+
+```lean
+C := max 0 (Cstrip r s + A r * Real.exp δ * Cexp)
+```
+
+or the sum of nonnegative factors if Lean already has the individual
+nonnegativity facts available.  Then dispatch the two cases `σ ≤ 0` and
+`0 ≤ σ`.
 
 Dense range theorem:
 

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -2704,6 +2704,25 @@ terms of `section43QTime` and `section43QSpatial`.  Only after that transport
 should the compact spacetime product source and the
 `partialFourierSpatial_fun` factorization be implemented.
 
+Production update, 2026-04-18: the `SchwartzNPoint d n` transport is now also
+compiled in the same companion file:
+
+```lean
+section43NPointTimeSpatialTensor
+section43NPointTimeSpatialTensor_apply
+dense_section43NPointTimeSpatialTensor_span_of_factor_dense
+dense_section43NPointTimeSpatialTensor_span_compactLaplace_spatialFourier
+```
+
+The remaining Layer-3 implementation seam is therefore no longer density
+transport.  It is the source-side construction and Fourier-slice
+identification:
+
+```lean
+section43TimeSpatialProductSource
+partialFourierSpatial_fun_section43TimeSpatialProductSource
+```
+
 The source attached to a restricted tensor is:
 
 ```lean

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -3111,6 +3111,64 @@ Proof:
    section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
    section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget
    ```
+   Linear-closure packet needed next:
+   1. Give `Section43CompactStrictPositiveTimeSpatialSource d n` the same
+      `Zero`, `Add`, `SMul ℂ`, `AddCommMonoid`, and `Module ℂ` structure as
+      `Section43CompactStrictPositiveTimeSource n`, using `f` as the injective
+      carrier map.  The support proofs are exactly:
+      `tsupport_add`, `tsupport_smul_subset_right`, `HasCompactSupport.add`,
+      and `HasCompactSupport.smul_left`.
+   2. Prove strict support implies closed positive-energy support:
+      ```lean
+      theorem section43TimeSpatialSource_tsupport_subset_positiveEnergy
+          (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+          tsupport (G.f : NPointDomain d n → ℂ) ⊆
+            section43PositiveEnergyRegion d n
+      ```
+      by `exact le_of_lt (G.positive hq i)`.
+   3. Prove integrability of the representative time integrand:
+      ```lean
+      theorem integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+          (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+          (q : NPointDomain d n)
+          (hq : q ∈ section43PositiveEnergyRegion d n) :
+          Integrable
+            (fun τ : Fin n → ℝ =>
+              Complex.exp
+                (-(∑ i : Fin n,
+                  (τ i : ℂ) *
+                    (section43QTime (d := d) (n := n) q i : ℂ))) *
+              partialFourierSpatial_fun
+                (d := d) (n := n) G.f
+                (τ, section43QSpatial (d := d) (n := n) q))
+      ```
+      Proof route: copy the proof of
+      `integrable_section43FourierLaplace_timeIntegrand`, replacing
+      `section43DiffPullbackCLM` by `G.f` and using
+      `section43PartialFourierSpatial_fun_eq_zero_of_neg_time_of_support_positiveEnergy`
+      with `section43TimeSpatialSource_tsupport_subset_positiveEnergy G`.
+      The base integrability is `integrable_partialFourierSpatial_timeSlice`;
+      on nonnegative `τ`, use `norm_exp_neg_section43_timePair_le_one`.
+   4. Prove representative linearity:
+      ```lean
+      theorem section43TimeLaplaceSpatialFourierRepresentative_add
+          {G H : Section43CompactStrictPositiveTimeSpatialSource d n}
+          {Φ Ψ : SchwartzNPoint d n}
+          (hΦ : section43TimeLaplaceSpatialFourierRepresentative d n G Φ)
+          (hΨ : section43TimeLaplaceSpatialFourierRepresentative d n H Ψ) :
+          section43TimeLaplaceSpatialFourierRepresentative d n (G + H) (Φ + Ψ)
+
+      theorem section43TimeLaplaceSpatialFourierRepresentative_smul
+          (c : ℂ)
+          {G : Section43CompactStrictPositiveTimeSpatialSource d n}
+          {Φ : SchwartzNPoint d n}
+          (hΦ : section43TimeLaplaceSpatialFourierRepresentative d n G Φ) :
+          section43TimeLaplaceSpatialFourierRepresentative d n (c • G) (c • Φ)
+      ```
+      For add, use the integrability theorem for `G` and `H`,
+      `MeasureTheory.integral_add`, and `partialFourierSpatial_fun_add`.
+      For scalar multiplication, use `MeasureTheory.integral_const_mul` and
+      `partialFourierSpatial_fun_smul`.
 7. Conclude density by `Dense.mono` from the dense restricted span.
 
 The `n = 0` case must be kept explicit in implementation.  Then

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -2938,6 +2938,98 @@ Proof:
    `partialFourierSpatial_fun_section43TimeSpatialProductSource` and the
    defining theorem
    `section43IteratedLaplaceSchwartzRepresentative_apply_of_mem`.
+   The first production theorem should be the single-generator statement:
+   ```lean
+   theorem section43TimeLaplaceSpatialFourierRepresentative_productSource
+       (d n : ℕ) [NeZero d]
+       (g : Section43CompactStrictPositiveTimeSource n)
+       (κ : Section43SpatialCompactSource d n) :
+       section43TimeLaplaceSpatialFourierRepresentative d n
+         (section43TimeSpatialProductSource d n g κ)
+         (section43NPointTimeSpatialTensor d n
+           (section43IteratedLaplaceSchwartzRepresentative n g)
+           (SchwartzMap.fourierTransformCLM ℂ κ.1))
+   ```
+   Proof skeleton:
+   ```lean
+   intro q hq
+   have hσ :
+       section43QTime (d := d) (n := n) q ∈
+         section43TimePositiveRegion n := by
+     intro i
+     simpa [section43PositiveEnergyRegion, section43QTime,
+       nPointTimeSpatialCLE] using hq i
+   rw [section43NPointTimeSpatialTensor_apply]
+   rw [section43IteratedLaplaceSchwartzRepresentative_apply_of_mem g hσ]
+   unfold section43IteratedLaplaceRaw
+   rw [show
+       (∫ τ : Fin n → ℝ,
+          Complex.exp
+            (-(∑ i : Fin n,
+              (τ i : ℂ) *
+                (section43QTime (d := d) (n := n) q i : ℂ))) *
+            partialFourierSpatial_fun
+              (d := d) (n := n)
+              (section43TimeSpatialProductSource d n g κ).f
+              (τ, section43QSpatial (d := d) (n := n) q)) =
+       (∫ τ : Fin n → ℝ,
+          Complex.exp
+            (-(∑ i : Fin n,
+              (τ i : ℂ) *
+                (section43QTime (d := d) (n := n) q i : ℂ))) *
+            g.f τ) *
+         (SchwartzMap.fourierTransformCLM ℂ κ.1)
+           (section43QSpatial (d := d) (n := n) q) by
+     calc
+       (∫ τ : Fin n → ℝ,
+          Complex.exp
+            (-(∑ i : Fin n,
+              (τ i : ℂ) *
+                (section43QTime (d := d) (n := n) q i : ℂ))) *
+            partialFourierSpatial_fun
+              (d := d) (n := n)
+              (section43TimeSpatialProductSource d n g κ).f
+              (τ, section43QSpatial (d := d) (n := n) q))
+           =
+         ∫ τ : Fin n → ℝ,
+           (Complex.exp
+             (-(∑ i : Fin n,
+               (τ i : ℂ) *
+                 (section43QTime (d := d) (n := n) q i : ℂ))) *
+             g.f τ) *
+           (SchwartzMap.fourierTransformCLM ℂ κ.1)
+             (section43QSpatial (d := d) (n := n) q) := by
+             congr with τ
+             rw [partialFourierSpatial_fun_section43TimeSpatialProductSource]
+             ring
+       _ =
+         (∫ τ : Fin n → ℝ,
+           Complex.exp
+             (-(∑ i : Fin n,
+               (τ i : ℂ) *
+                 (section43QTime (d := d) (n := n) q i : ℂ))) *
+             g.f τ) *
+           (SchwartzMap.fourierTransformCLM ℂ κ.1)
+             (section43QSpatial (d := d) (n := n) q) :=
+             MeasureTheory.integral_mul_const
+               ((SchwartzMap.fourierTransformCLM ℂ κ.1)
+                 (section43QSpatial (d := d) (n := n) q))
+               (fun τ : Fin n → ℝ =>
+                 Complex.exp
+                   (-(∑ i : Fin n,
+                     (τ i : ℂ) *
+                       (section43QTime (d := d) (n := n) q i : ℂ))) *
+                   g.f τ)]
+   ```
+   The theorem deliberately proves only the product-source representative
+   identity; it does not yet claim density or linear closure.
+   Production update, 2026-04-18: this theorem and the representative predicate
+   are now compiled in
+   `Section43FourierLaplaceSpatialDensity.lean`:
+   ```lean
+   section43TimeLaplaceSpatialFourierRepresentative
+   section43TimeLaplaceSpatialFourierRepresentative_productSource
+   ```
 6. Therefore every restricted tensor is in the target.  Since the target is the
    preimage of a linear range under the quotient map once the time-spatial
    transform is packaged linearly, it is a submodule; otherwise prove directly

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -57,8 +57,9 @@ denseRange_section43FourierLaplaceTransformComponentMap_of_dense_preimage
 bvt_W_positive_of_component_dense_preimage
 ```
 
-Production status, 2026-04-17: this density file now exists and the foundation
-plus one-variable Paley-Wiener uniqueness packets are compiled:
+Production status, 2026-04-17: this density file now exists and the foundation,
+raw one-sided Laplace calculus, cutoff-Schwartz representative, and
+one-variable Paley-Wiener uniqueness packets are compiled:
 
 ```lean
 Section43CompactPositiveTimeSource1D
@@ -74,6 +75,23 @@ exists_positive_Icc_bounds_of_compactPositiveTimeSource
 section43SmoothCutoff_complex_iteratedFDeriv_support_subset_Ici_neg_one
 section43OneSidedLaplaceCutoffFun
 section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg
+section43OneSidedLaplaceRawDerivCandidate
+section43OneSidedLaplaceRawDerivCandidate_integrable
+section43OneSidedLaplaceRawDerivKernel_hasDerivAt
+section43OneSidedLaplaceRawDerivCandidate_hasDerivAt
+section43OneSidedLaplaceRaw_iteratedDeriv_formula
+section43OneSidedLaplaceRaw_contDiff
+section43OneSidedLaplaceRaw_iteratedFDeriv_formula
+section43OneSidedLaplaceRawDerivCandidate_norm_le_of_re_bound
+section43OneSidedLaplaceRawDerivCandidate_norm_le_strip
+section43OneSidedLaplaceRawDerivCandidate_norm_le_nonneg
+section43OneSidedLaplaceRaw_rapid_on_Ici_neg_one
+section43OneSidedLaplaceSchwartzRepresentative1D
+section43OneSidedLaplaceSchwartzRepresentative1D_apply
+exists_section43OneSidedLaplaceRepresentative1D
+section43OneSidedLaplaceCompactTransform1D
+section43OneSidedLaplaceCompactTransform1D_choose_spec
+section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient
 section43FourierInvCLM1D
 section43FourierInvCLM1D_apply
 section43PositiveEnergy1D_to_oneSidedFourierFunctional
@@ -82,8 +100,11 @@ fourierPairingDescendsToSection43PositiveEnergy1D_to_oneSided
 section43OneSidedAnnihilatorFL
 section43OneSidedAnnihilatorFL_eq_fourierLaplaceExt_to_oneSided
 section43OneSidedAnnihilatorFLOnImag
+section43ImagAxisPsiKernel
 section43OneSidedAnnihilatorFLOnImag_of_pos
 section43OneSidedAnnihilatorFLOnImag_of_not_pos
+section43OneSidedAnnihilatorFLOnImag_eq_apply_kernel
+continuousOn_section43OneSidedAnnihilatorFLOnImag_Ioi
 section43PositiveEnergy1D_ext_of_FL_zero
 ```
 
@@ -91,8 +112,6 @@ The remaining one-variable blocker is no longer Paley-Wiener uniqueness.  It is
 the compact-source annihilator bridge:
 
 ```lean
-exists_section43OneSidedLaplaceRepresentative1D
-section43OneSidedLaplaceCompactTransform1D
 section43OneSidedAnnihilatorFL_integral_zero_of_annihilates_laplace
 section43OneSidedAnnihilatorFLOnImag_eq_zero_of_annihilates_laplace
 section43OneSidedAnnihilatorFL_eq_zero_of_annihilates_laplace
@@ -125,17 +144,16 @@ The small density file is:
 OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceDensity.lean
 ```
 
-Suggested imports:
+Current imports:
 
 ```lean
-import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceClosure
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43OneVariableSlice
+import OSReconstruction.Wightman.Reconstruction.WickRotation.Section43FourierLaplaceCompactDifferentiation
 ```
 
-If this creates an import cycle, import only the lower files needed for the
-analytic packet, then move `Section43CompactOrderedSource` and
-`section43FourierLaplaceTransformComponentMap` from
-`Section43FourierLaplaceClosure.lean` into the density file or a tiny shared
-source file.  Do not import `OSToWightmanPositivity.lean`.
+This keeps the density file below `OSToWightmanPositivity.lean` while reusing
+the already-compiled general cutoff-times-rapid-to-Schwartz theorem from
+`Section43FourierLaplaceCompactDifferentiation.lean`.
 
 ## Layer 1: One-Variable OS I Lemma 8.2
 
@@ -276,9 +294,11 @@ theorem section43OneSidedLaplaceRaw_rapid_on_Ici_neg_one
 
 Lean-ready raw-Laplace calculus packet:
 
-Production status, 2026-04-17: this packet is compiled through Step 8 in
-`Section43FourierLaplaceDensity.lean`.  The remaining theorem from this group
-is the rapid estimate on `Set.Ici (-1)`.
+Production status, 2026-04-17: this packet is compiled through the rapid
+estimate and cutoff-Schwartz representative construction in
+`Section43FourierLaplaceDensity.lean`.  The next theorem group is the
+annihilator bridge from compact one-sided Laplace sources to vanishing of
+`section43OneSidedAnnihilatorFL`.
 
 1. Add the genuine derivative-candidate integral, not as a wrapper but as the
    object that appears after differentiating under the integral:
@@ -657,12 +677,128 @@ density theorem: the production Laplace kernel is
 agrees on `σ ≥ 0` with `Complex.exp (Complex.I * ((t : ℂ) * I) * σ)`,
 hence with the same `Complex.exp (-(t : ℂ) * σ)` kernel.
 
-Then convert integral vanishing against every compact strict-positive source to
-pointwise vanishing on the strict half-line using the existing local
-distribution lemma:
+Do not try to prove this theorem as one monolithic Fubini block.  The
+implementation-ready bridge should be split into the following exact subpacket.
+
+First define the imaginary-axis kernel with the same off-half-line branch as
+`section43OneSidedAnnihilatorFLOnImag`:
 
 ```lean
-OSReconstruction.SCV.eq_zero_on_open_of_compactSupport_schwartz_integral_zero
+noncomputable def section43ImagAxisPsiKernel (t : ℝ) : SchwartzMap ℝ ℂ :=
+  if ht : 0 < t then
+    SCV.schwartzPsiZ ((t : ℂ) * Complex.I) (by simpa [Complex.mul_im] using ht)
+  else
+    0
+```
+
+Compile its quotient-pairing identity:
+
+```lean
+theorem section43OneSidedAnnihilatorFLOnImag_eq_apply_kernel
+    (A : Section43PositiveEnergy1D →L[ℂ] ℂ) (t : ℝ) :
+    section43OneSidedAnnihilatorFLOnImag A t =
+      A (section43PositiveEnergyQuotientMap1D
+        (section43ImagAxisPsiKernel t))
+```
+
+Proof split:
+
+- If `0 < t`, unfold both definitions and use proof irrelevance for the
+  positivity proofs.
+- If `¬ 0 < t`, both sides are zero.
+
+Important formalization correction: do **not** define a Bochner integral valued
+in `SchwartzMap ℝ ℂ`.  In this repository `SchwartzMap` carries the locally
+convex Schwartz topology, but it is not a `NormedAddCommGroup`, so
+`∫ t, g.f t • section43ImagAxisPsiKernel t` is not a legal Bochner integral in
+Lean.  The correct bridge is a scalar, weak Fubini theorem after applying an
+arbitrary continuous linear functional.
+
+The next implementation target should therefore be:
+
+```lean
+theorem section43OneSidedLaplace_scalar_fubini_apply
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ)
+    (g : Section43CompactPositiveTimeSource1D) :
+    T (section43OneSidedLaplaceSchwartzRepresentative1D g) =
+      ∫ t : ℝ, T (section43ImagAxisPsiKernel t) * g.f t
+```
+
+After this theorem, the annihilator Fubini theorem is short:
+
+```lean
+have hT :
+    A (section43PositiveEnergyQuotientMap1D
+        (section43OneSidedLaplaceSchwartzRepresentative1D g)) =
+      ∫ t : ℝ,
+        section43OneSidedAnnihilatorFLOnImag A t * g.f t := by
+  simpa [ContinuousLinearMap.comp_apply,
+    section43OneSidedAnnihilatorFLOnImag_eq_apply_kernel,
+    mul_comm, mul_left_comm, mul_assoc]
+    using section43OneSidedLaplace_scalar_fubini_apply
+      ((A.comp section43PositiveEnergyQuotientMap1D)) g
+```
+
+Then combine with
+`section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient` and `hA g`.
+
+Lean proof plan for `section43OneSidedLaplace_scalar_fubini_apply`:
+
+1. Use `SCV.schwartz_functional_bound T` to choose a finite set of Schwartz
+   seminorms and a constant controlling `‖T φ‖`.
+2. Use `exists_positive_Icc_bounds_of_compactPositiveTimeSource g` to reduce
+   all source-time integrals to a compact interval `[δ,R]` with `0 < δ`.
+3. Prove a compact-vertical-segment seminorm bound for the imaginary-axis
+   kernels:
+
+```lean
+theorem section43ImagAxisPsiKernel_seminorm_le_on_Icc
+    {δ R : ℝ} (hδ_pos : 0 < δ) (hδR : δ ≤ R)
+    (k n : ℕ) :
+    ∃ C : ℝ, 0 ≤ C ∧
+      ∀ t ∈ Set.Icc δ R,
+        SchwartzMap.seminorm ℂ k n (section43ImagAxisPsiKernel t) ≤ C
+```
+
+   This is best proved directly from the explicit `SCV.psiZ` formula.  For
+   `t ∈ [δ,R]` and derivative order `n`, the derivative contributes a power of
+   `t`, bounded by `max |δ| |R| ^ n`, and the exponential factor decays like
+   `exp (-t * σ)` on `σ ≥ 0` while the cutoff side of `SCV.psiZ` handles
+   `σ < 0` by the already-proved Schwartz estimates in `SCV.schwartzPsiZ`.
+   If direct proof is too large, first prove the bound by continuity of
+   `t ↦ weightedDerivToBCFCLM k n (section43ImagAxisPsiKernel t)` on compact
+   `[δ,R]`, following the horizontal-continuity pattern in `SCV.PaleyWiener`.
+4. Prove scalar integrability:
+
+```lean
+theorem integrable_section43_scalar_kernel_after_functional
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ)
+    (g : Section43CompactPositiveTimeSource1D) :
+    Integrable (fun t : ℝ => T (section43ImagAxisPsiKernel t) * g.f t)
+```
+
+   Use the seminorm bound from Step 3, the functional bound from Step 1, and
+   compact support/integrability of `g.f`.
+5. Prove the weak integral identity by approximating the compactly supported
+   parameter integral in the Schwartz topology using Riemann sums or a standard
+   parameter-integral theorem formulated in terms of the finite seminorm family
+   from Step 1.  The statement should avoid constructing a
+   `SchwartzMap`-valued Bochner integral; it only needs convergence after
+   applying `T`.
+6. On the nonnegative axis, rewrite the explicit representative with
+   `section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg`,
+   `SCV.schwartzPsiZ_apply`, and `SCV.psiZ_eq_exp_of_nonneg`.  On
+   `¬ 0 < t`, use `g.f t = 0`, which follows from `g.positive` and
+   `Function.support_subset_tsupport`.
+
+Then convert integral vanishing against every compact strict-positive source to
+pointwise vanishing on the strict half-line using the existing local
+distribution lemma.  Since `section43OneSidedAnnihilatorFLOnImag` has an
+off-half-line zero branch and need not be globally continuous at the origin, use
+the continuous-on-open version, not the global-continuity version:
+
+```lean
+OSReconstruction.SCV.eqOn_open_of_compactSupport_schwartz_integral_eq_of_continuousOn
 ```
 
 The Lean target is:
@@ -677,14 +813,27 @@ theorem section43OneSidedAnnihilatorFLOnImag_eq_zero_of_annihilates_laplace
       section43OneSidedAnnihilatorFLOnImag A t = 0
 ```
 
+Compiled continuity input:
+
+```lean
+theorem continuousOn_section43OneSidedAnnihilatorFLOnImag_Ioi
+    (A : Section43PositiveEnergy1D →L[ℂ] ℂ) :
+    ContinuousOn (section43OneSidedAnnihilatorFLOnImag A) (Set.Ioi (0 : ℝ))
+```
+
+It rewrites `section43OneSidedAnnihilatorFL` as
+`SCV.fourierLaplaceExt (section43PositiveEnergy1D_to_oneSidedFourierFunctional A)`,
+uses `SCV.fourierLaplaceExt_differentiableOn.continuousOn`, and composes with
+the vertical path `t ↦ (t : ℂ) * Complex.I`.
+
 Proof transcript:
 
-1. Apply `eq_zero_on_open_of_compactSupport_schwartz_integral_zero` with
-   `U := Set.Ioi (0 : ℝ)` and
-   `g := section43OneSidedAnnihilatorFLOnImag A`.
-2. Continuity of `g` on `Set.Ioi 0` follows from holomorphicity or directly
-   from continuity of `SCV.schwartzPsiZ` in the imaginary-axis parameter and
-   continuity of `A`.
+1. Apply `eqOn_open_of_compactSupport_schwartz_integral_eq_of_continuousOn`
+   with `U := Set.Ioi (0 : ℝ)`, `g := section43OneSidedAnnihilatorFLOnImag A`,
+   and `h := 0`.
+2. Continuity of `g` on `Set.Ioi 0` is exactly
+   `continuousOn_section43OneSidedAnnihilatorFLOnImag_Ioi A`; continuity of
+   `h := 0` is immediate.
 3. Its test-function hypothesis is exactly
    `section43OneSidedAnnihilatorFL_integral_zero_of_annihilates_laplace`, after
    packaging an arbitrary compactly supported Schwartz test with support in

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -2492,6 +2492,34 @@ product-integral lemmas handle the empty finite product.  Do not split the main
 density theorem unless Lean's finite-product integral API forces a local
 `n = 0` helper.
 
+Production status, 2026-04-18: the finite-product dense-preimage package is
+compiled in
+`OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceTimeProductDensity.lean`.
+It proves the missing linearity rather than assuming that the plain function
+range is a submodule:
+
+```lean
+eqOn_nonneg_of_section43PositiveEnergyQuotientMap1D_eq
+section43IteratedLaplaceRaw_add
+section43IteratedLaplaceRaw_smul
+section43IteratedLaplaceRepresentative_add
+section43IteratedLaplaceRepresentative_smul
+section43IteratedLaplaceCompactTransform_map_add
+section43IteratedLaplaceCompactTransform_map_smul
+section43IteratedLaplaceCompactTransformLinearMap
+section43TimeProductTensor_mem_iteratedLaplaceCompactTransform_preimage
+dense_section43IteratedLaplaceCompactTransform_preimage
+denseRange_section43IteratedLaplaceCompactTransformLinearMap
+```
+
+The proof uses the one-variable dense preimage theorem, the compiled
+factor-dense product-tensor theorem, quotient extensionality on each
+coordinate, and the product-source transform identity.  No new axioms,
+wrappers, or placeholders are used.  The next proof-doc frontier is Layer 3:
+make the spatial-Fourier transport from
+`SchwartzMap (Fin n → ℝ) ℂ` to `SchwartzNPoint d n` implementation-ready
+before attempting production Lean.
+
 ## Layer 3: Add Spatial Fourier Transform
 
 Definitions:

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -1938,6 +1938,125 @@ use `hasFDerivAt_integral_of_dominated_of_fderiv_le`, the local ball
 `HasFDerivAt` is obtained from smoothness of
 `fun σ' => Complex.exp (-(∑ i, (τ i : ℂ) * (σ' i : ℂ))) * g.f τ`.
 
+Lean-ready local-bound packet, 2026-04-18:
+
+The time-only local domination theorem should not copy the spatial
+derivative-word sum from the ordered-support Fourier-Laplace proof.  In the
+present setting the σ-dependence is just the exponential of a continuous
+linear functional, multiplied by the fixed scalar `g.f τ`.  The implementation
+should first compile these helper lemmas:
+
+```lean
+noncomputable def section43TimeLaplaceLinearCLM
+    (n : ℕ) (τ : Fin n → ℝ) : (Fin n → ℝ) →L[ℝ] ℂ
+
+theorem section43TimeLaplaceLinearCLM_apply
+    (n : ℕ) (τ σ : Fin n → ℝ) :
+    section43TimeLaplaceLinearCLM n τ σ =
+      -(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))
+
+theorem norm_time_le_norm_add_one_of_mem_closedBall
+    (n : ℕ) (σ σ' : Fin n → ℝ)
+    (hσ' : σ' ∈ Metric.closedBall σ (1 : ℝ)) :
+    ‖σ'‖ ≤ ‖σ‖ + 1
+
+theorem norm_section43TimeLaplaceLinearCLM_le
+    (n : ℕ) (τ : Fin n → ℝ) {R : ℝ}
+    (hR_nonneg : 0 ≤ R)
+    (hτ : τ ∈ Metric.closedBall (0 : Fin n → ℝ) R) :
+    ‖section43TimeLaplaceLinearCLM n τ‖ ≤ ∑ _ : Fin n, R
+
+theorem norm_exp_neg_timePair_le_local_time_closedBall
+    (n : ℕ) (σ σ' τ : Fin n → ℝ)
+    {R : ℝ} (hR_nonneg : 0 ≤ R)
+    (hτ : τ ∈ Metric.closedBall (0 : Fin n → ℝ) R)
+    (hσ' : σ' ∈ Metric.closedBall σ (1 : ℝ)) :
+    ‖Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ)))‖ ≤
+      Real.exp (∑ _ : Fin n, R * (‖σ‖ + 1))
+
+theorem exists_norm_bound_section43CompactStrictPositiveTimeSource_on_time_closedBall
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) (R : ℝ) :
+    ∃ Cg : ℝ, 0 ≤ Cg ∧
+      ∀ τ ∈ Metric.closedBall (0 : Fin n → ℝ) R, ‖g.f τ‖ ≤ Cg
+
+theorem section43IteratedLaplaceRaw_integrand_iteratedFDeriv_eq_zero_of_not_mem_tsupport
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    {τ : Fin n → ℝ}
+    (hτ : τ ∉ tsupport (g.f : (Fin n → ℝ) → ℂ)) :
+    iteratedFDeriv ℝ r
+      (fun σ : Fin n → ℝ =>
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+          g.f τ) =
+      0
+```
+
+For the zero theorem, first use
+`notMem_tsupport_iff_eventuallyEq` or `subset_tsupport` to prove `g.f τ = 0`,
+then the σ-function is definitionally the zero function after `funext`, so
+`iteratedFDeriv` reduces to `0`.
+
+Then prove the actual local dominated derivative bound:
+
+```lean
+theorem section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    ∃ bound : (Fin n → ℝ) → ℝ,
+      Integrable bound ∧
+      ∀ᵐ τ, ∀ σ' ∈ Metric.closedBall σ (1 : ℝ),
+        ‖(iteratedFDeriv ℝ (r + 1)
+          (fun σ'' : Fin n → ℝ =>
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ'' i : ℂ))) *
+              g.f τ)
+          σ').curryLeft‖ ≤ bound τ
+```
+
+Proof transcript:
+
+1. Choose `R ≥ 0` and
+   `hR_supp : tsupport g.f ⊆ Metric.closedBall 0 R` from
+   `exists_time_closedBall_of_compact_tsupport`.
+2. Set `Kτ = Metric.closedBall (0 : Fin n → ℝ) R`.
+3. Choose `Cg ≥ 0` bounding `‖g.f τ‖` on `Kτ`.
+4. Let
+   `Cexp = Real.exp (∑ _ : Fin n, R * (‖σ‖ + 1))` and
+   `CL = ∑ _ : Fin n, R`.
+5. Let
+   `C = (r + 1).factorial * Cexp * CL ^ (r + 1) * Cg`.
+6. Take `bound = Set.indicator Kτ (fun _ => C)`.  Integrability is
+   `integrable_indicator_time_closedBall_const n R C`.
+7. On `Kτ`, rewrite the scalar integrand as
+   `(fun σ'' => Complex.exp (section43TimeLaplaceLinearCLM n τ σ''))`
+   multiplied by the constant `g.f τ`.  Apply
+   `iteratedFDeriv_smul_const_apply`,
+   `norm_iteratedFDeriv_cexp_comp_clm_le`,
+   `norm_section43TimeLaplaceLinearCLM_le`, the local exponential bound, and
+   the source bound.
+8. Off `Kτ`, `τ ∉ tsupport g.f` by `hR_supp`, so the whole pointwise
+   derivative is zero by the zero theorem.
+
+Production status, 2026-04-18: this local-bound packet is compiled in
+`Section43FourierLaplaceTimeProduct.lean`.  The compiled theorem
+
+```lean
+section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+```
+
+is now the exact time-only analogue needed by
+`hasFDerivAt_integral_of_dominated_of_fderiv_le`.  The next missing proof-doc
+item is not another bound; it is the measurability/integrability transcript for
+
+```lean
+integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+```
+
+The base scalar integrability theorem is already compiled as
+`integrable_section43IteratedLaplaceRaw_integrand_of_compact`.  For the
+successor case, reuse the local-bound theorem and prove the required
+AEStronglyMeasurable fact by an explicit time-only continuity lemma for
+`τ ↦ iteratedFDeriv ... σ`.  Do not introduce a wrapper theorem that assumes
+measurability as a hypothesis; the measurability is part of this seam.
+
 For rapid decay on the cutoff-derivative support, reuse the already compiled
 time-only estimates:
 
@@ -1964,6 +2083,50 @@ candidate by a compact-support integrable majorant, applies
 `norm_exp_neg_timePair_le_exp_thickened_margin_sum`, and then absorbs the
 remaining polynomial in `σ` using
 `exp_margin_sum_controls_thickened_time_polynomial`.
+
+Lean-ready rapid-decay transcript, 2026-04-18:
+
+The time-only rapid proof is simpler than the ordered-support spatial proof.
+Do not introduce derivative words.  For fixed `r,s`:
+
+1. Rewrite
+   `iteratedFDeriv ℝ r (section43IteratedLaplaceRaw n g) σ` by
+   `section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate`.
+2. Choose `δ > 0` from
+   `exists_positive_margin_of_compact_time_tsupport_subset_strictPositive g`.
+3. Choose `R ≥ 0` from `exists_time_closedBall_of_compact_tsupport g`.
+4. Choose `Cg ≥ 0` bounding `‖g.f τ‖` on `Metric.closedBall 0 R`.
+5. Let
+   `CL = ∑ _ : Fin n, R`,
+   `Cderiv = r.factorial * CL ^ r * Cg`, and
+   `Kτ = Metric.closedBall (0 : Fin n → ℝ) R`.
+6. Let
+   `M = ∫ τ, Set.indicator Kτ (fun _ => Cderiv) τ`.
+   This is finite by `integrable_indicator_time_closedBall_const` and
+   nonnegative by `integral_nonneg`.
+7. For `σ ∈ section43TimePositiveThickening n 1`, define
+   `Eσ =
+      Real.exp (∑ _ : Fin n, R * 1) *
+        Real.exp (-(δ * ∑ i : Fin n, (σ i + 1)))`.
+8. Pointwise in `τ`, prove
+   `‖G σ τ‖ ≤ Eσ * Set.indicator Kτ (fun _ => Cderiv) τ`, where `G` is the
+   integrand defining
+   `section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ`.
+9. Inside `Kτ`, if `τ ∉ tsupport g.f`, the derivative is zero by
+   `section43IteratedLaplaceRaw_integrand_iteratedFDeriv_eq_zero_of_not_mem_tsupport`.
+   If `τ ∈ tsupport g.f`, use the support margin for `δ ≤ τ i`, the closed-ball
+   bound `‖τ‖ ≤ R`, the collar hypothesis `-1 ≤ σ i`, and
+   `norm_exp_neg_timePair_le_exp_thickened_margin_sum`.
+10. The derivative factor is bounded by
+    `norm_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_le`,
+    `norm_section43TimeLaplaceLinearCLM_le`, and the source bound `Cg`.
+11. Integrating gives
+    `‖candidate σ‖ ≤ Eσ * M`.
+12. Apply
+    `exp_margin_sum_controls_thickened_time_polynomial
+       (n := n) (δ := δ) (ε := 1) (R := R) ... s`
+    to get `Ct` with `(1 + ‖σ‖)^s * Eσ ≤ Ct`.
+13. The final rapid constant is `C = Ct * M`.
 
 The final representative is then:
 
@@ -2003,6 +2166,43 @@ The last theorem is just
 `section43IteratedLaplaceRepresentative`, rewriting by
 `section43IteratedLaplaceSchwartzRepresentative_apply_of_mem`, and unfolding
 `section43IteratedLaplaceRaw`.
+
+Production status, 2026-04-18: the arbitrary-source representative package is
+compiled in `Section43FourierLaplaceTimeProduct.lean`, including
+
+```lean
+integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt
+section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate
+section43IteratedLaplaceRaw_contDiff
+section43IteratedLaplaceRaw_iteratedFDeriv_rapid_on_timeThickening
+section43IteratedLaplaceSchwartzRepresentative
+exists_section43IteratedLaplaceRepresentative
+section43IteratedLaplaceCompactTransform
+section43IteratedLaplaceCompactTransform_productSource
+```
+
+The next implementation step should not continue growing
+`Section43FourierLaplaceTimeProduct.lean`; it is now close to the 2000-line
+support-file limit.  Start a small companion file for the finite-product dense
+preimage theorem:
+
+```lean
+theorem dense_section43IteratedLaplaceCompactTransform_preimage
+    (n : ℕ) :
+    Dense
+      ((section43TimePositiveQuotientMap n) ⁻¹'
+        Set.range (section43IteratedLaplaceCompactTransform n))
+```
+
+This theorem should use:
+
+```lean
+dense_section43OneSidedLaplaceCompactTransform1D_preimage
+section43_timeProductTensor_span_dense_of_factor_dense
+section43IteratedLaplaceCompactTransform_productSource
+section43TimePositiveQuotientMap_eq_of_eqOn_region
+```
 
 Production status, 2026-04-18: the low-risk first half of this package is
 compiled in `Section43FourierLaplaceTimeProduct.lean`:

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -3036,6 +3036,81 @@ Proof:
    that it is closed under finite linear combinations using additivity of the
    representative predicate and quotient map.  Prefer the linear-map packaging,
    mirroring `section43IteratedLaplaceCompactTransformLinearMap`.
+   The immediate Lean subpacket before the full span/submodule closure is:
+   ```lean
+   theorem section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
+       (d n : ℕ) [NeZero d]
+       {φ ψ : SchwartzMap (Fin n → ℝ) ℂ}
+       (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+       (hφψ :
+         section43TimePositiveQuotientMap n φ =
+           section43TimePositiveQuotientMap n ψ) :
+       section43PositiveEnergyQuotientMap (d := d) n
+         (section43NPointTimeSpatialTensor d n φ χ) =
+       section43PositiveEnergyQuotientMap (d := d) n
+         (section43NPointTimeSpatialTensor d n ψ χ)
+   ```
+   Proof skeleton:
+   ```lean
+   apply section43PositiveEnergyQuotientMap_eq_of_eqOn_region (d := d)
+   intro q hq
+   have hσ :
+       section43QTime (d := d) (n := n) q ∈
+         section43TimePositiveRegion n := by
+     intro i
+     simpa [section43PositiveEnergyRegion, section43QTime,
+       nPointTimeSpatialCLE] using hq i
+   have hφψ_point :
+       φ (section43QTime (d := d) (n := n) q) =
+         ψ (section43QTime (d := d) (n := n) q) :=
+     eqOn_region_of_section43TimePositiveQuotientMap_eq hφψ hσ
+   simp [section43NPointTimeSpatialTensor_apply, hφψ_point]
+   ```
+   Then prove the restricted-generator witness theorem:
+   ```lean
+   theorem section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget
+       (d n : ℕ) [NeZero d]
+       (φ : SchwartzMap (Fin n → ℝ) ℂ)
+       (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+       (hφ :
+         φ ∈ ((section43TimePositiveQuotientMap n) ⁻¹'
+           Set.range (section43IteratedLaplaceCompactTransform n)))
+       (hχ : χ ∈ section43SpatialFourierCompactRange d n) :
+       ∃ (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+         (Ψ : SchwartzNPoint d n),
+         section43TimeLaplaceSpatialFourierRepresentative d n G Ψ ∧
+         section43PositiveEnergyQuotientMap (d := d) n
+           (section43NPointTimeSpatialTensor d n φ χ) =
+         section43PositiveEnergyQuotientMap (d := d) n Ψ
+   ```
+   Proof route:
+   ```lean
+   rcases hφ with ⟨g, hg⟩
+   rcases hχ with ⟨κ, rfl⟩
+   let Ψt := section43IteratedLaplaceSchwartzRepresentative n g
+   let Ψ :=
+     section43NPointTimeSpatialTensor d n Ψt
+       (SchwartzMap.fourierTransformCLM ℂ κ.1)
+   refine ⟨section43TimeSpatialProductSource d n g κ, Ψ, ?_, ?_⟩
+   · exact section43TimeLaplaceSpatialFourierRepresentative_productSource d n g κ
+   · have hΨt_rep : section43IteratedLaplaceRepresentative n g Ψt := by
+       intro σ hσ
+       exact section43IteratedLaplaceSchwartzRepresentative_apply_of_mem g hσ
+     have hcompact :
+         section43IteratedLaplaceCompactTransform n g =
+           section43TimePositiveQuotientMap n Ψt :=
+       section43IteratedLaplaceCompactTransform_eq_quotient n g Ψt hΨt_rep
+     exact
+       section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
+         d n (SchwartzMap.fourierTransformCLM ℂ κ.1)
+         (hg.symm.trans hcompact)
+   ```
+   Production update, 2026-04-18: both generator-level theorems above are now
+   compiled in `Section43FourierLaplaceSpatialDensity.lean`:
+   ```lean
+   section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
+   section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget
+   ```
 7. Conclude density by `Dense.mono` from the dense restricted span.
 
 The `n = 0` case must be kept explicit in implementation.  Then

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -2522,9 +2522,35 @@ before attempting production Lean.
 
 ## Layer 3: Add Spatial Fourier Transform
 
+Layer-3 correction, 2026-04-18:
+
+The phrase "compose with the spatial Fourier transform" is not by itself an
+implementation-ready proof.  The final source type requires compact support in
+spacetime.  Therefore the dense spatial factors cannot be arbitrary inverse
+Fourier transforms: `FourierTransform.fourierInv χ` is generally not compactly
+supported.  The correct dense set on the spatial-frequency side is the Fourier
+image of compactly supported spatial Schwartz sources.
+
 Definitions:
 
 ```lean
+abbrev Section43SpatialSpace (d n : ℕ) [NeZero d] :=
+  EuclideanSpace ℝ (Fin n × Fin d)
+
+def Section43SpatialCompactSource (d n : ℕ) [NeZero d] :=
+  {κ : SchwartzMap (Section43SpatialSpace d n) ℂ //
+    HasCompactSupport (κ : Section43SpatialSpace d n → ℂ)}
+
+def section43SpatialFourierCompactRange
+    (d n : ℕ) [NeZero d] :
+    Set (SchwartzMap (Section43SpatialSpace d n) ℂ) :=
+  Set.range fun κ : Section43SpatialCompactSource d n =>
+    SchwartzMap.fourierTransformCLM ℂ κ.1
+
+theorem dense_section43SpatialFourierCompactRange
+    (d n : ℕ) [NeZero d] :
+    Dense (section43SpatialFourierCompactRange d n)
+
 structure Section43CompactStrictPositiveTimeSpatialSource
     (d n : ℕ) [NeZero d] where
   f : SchwartzNPoint d n
@@ -2548,6 +2574,173 @@ def section43TimeLaplaceSpatialFourierRepresentative
             (τ, section43QSpatial (d := d) (n := n) q)
 ```
 
+The proof of `dense_section43SpatialFourierCompactRange` is a required
+subpacket, not a handwave:
+
+1. Prove compactly supported Schwartz functions are dense on
+   `Section43SpatialSpace d n`.  Transport the compiled theorem
+   `SchwartzMap.dense_hasCompactSupport` from
+   `SchwartzMap (Fin (n * d) → ℝ) ℂ` through the continuous linear equivalence
+   ```lean
+   section43SpatialFlatCLE (d n) :
+     Section43SpatialSpace d n ≃L[ℝ] (Fin (n * d) → ℝ)
+   ```
+   built from `EuclideanSpace.equiv (Fin n × Fin d) ℝ` and
+   `finProdFinEquiv`.
+2. Compact support is preserved by this transport because a continuous linear
+   equivalence maps compact sets to compact sets and pulls support back along
+   the inverse map.
+3. For any target spatial-frequency Schwartz function `χ`, set
+   `κ₀ := FourierTransform.fourierInv χ`.  Approximate `κ₀` by compactly
+   supported spatial Schwartz functions `κ_j`.
+4. Continuity of `SchwartzMap.fourierTransformCLM ℂ` gives
+   `𝓕 κ_j → 𝓕 κ₀`, and
+   `FourierTransform.fourier_fourierInv_eq` identifies the limit with `χ`.
+
+The time-spatial product tensors used in the density proof are:
+
+```lean
+noncomputable def section43TimeSpatialTensor
+    (d n : ℕ) [NeZero d]
+    (Φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ) :
+    SchwartzNPoint d n
+```
+
+Lean construction transcript for `section43TimeSpatialTensor`:
+
+1. Transport the spatial factor through
+   `section43SpatialFlatCLE d n` to
+   `SchwartzMap (Fin (n * d) → ℝ) ℂ`.
+2. Use `SchwartzMap.tensorProduct Φ χflat` to obtain a Schwartz function on
+   `Fin (n + n * d) → ℝ`.
+3. Transport that function back through the continuous linear equivalence
+   between `Fin (n + n*d) → ℝ` and
+   `(Fin n → ℝ) × Section43SpatialSpace d n`, then through
+   `nPointTimeSpatialSchwartzCLE d n`.
+4. Its pointwise formula must be recorded as a simp theorem:
+   ```lean
+   theorem section43TimeSpatialTensor_apply
+       (Φ : SchwartzMap (Fin n → ℝ) ℂ)
+       (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+       (q : NPointDomain d n) :
+       section43TimeSpatialTensor d n Φ χ q =
+         Φ (section43QTime (d := d) (n := n) q) *
+         χ (section43QSpatial (d := d) (n := n) q)
+   ```
+
+The restricted product-tensor density theorem needed here is:
+
+```lean
+theorem dense_section43TimeSpatialTensor_span_of_factor_dense
+    (d n : ℕ) [NeZero d]
+    {St : Set (SchwartzMap (Fin n → ℝ) ℂ)}
+    {Sx : Set (SchwartzMap (Section43SpatialSpace d n) ℂ)}
+    (hSt : Dense St) (hSx : Dense Sx) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzNPoint d n |
+          ∃ Φ ∈ St, ∃ χ ∈ Sx,
+            F = section43TimeSpatialTensor d n Φ χ}) :
+        Submodule ℂ (SchwartzNPoint d n)) :
+        Set (SchwartzNPoint d n))
+```
+
+Proof transcript:
+
+1. First prove the unrestricted simple-tensor span is dense by transporting
+   `productTensor_span_dense 0 (n + n*d)` through the same finite-dimensional
+   flattening equivalences.  This is the two-factor analogue of
+   `section43_timeProductTensor_span_dense`.
+2. Let `D := St ×ˢ Sx`.  `Dense D` follows from `Dense.prod hSt hSx` or the
+   corresponding product-filter theorem.
+3. The map `(Φ, χ) ↦ section43TimeSpatialTensor d n Φ χ` is continuous.  Prove
+   this by transporting `SchwartzMap.tensorProduct_continuous` through the
+   finite-dimensional equivalences.
+4. As in `section43_timeProductTensor_span_dense_of_factor_dense`, the closure
+   of the restricted span contains every unrestricted simple tensor; since the
+   unrestricted span is dense, the restricted span is dense.
+
+Production status, 2026-04-18: the product-space half of Layer 3 is now
+compiled in
+`OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean`.
+The compiled declarations deliberately stop before the final
+`SchwartzNPoint d n` transport:
+
+```lean
+Section43SpatialSpace
+section43SpatialFlatCLE
+section43SpatialFlatSchwartzCLE
+Section43SpatialCompactSource
+dense_section43Spatial_hasCompactSupport
+section43SpatialFourierCompactRange
+dense_section43SpatialFourierCompactRange
+Section43TimeSpatialSpace
+section43TimeSpatialFlatCLE
+section43TimeSpatialFlatCLE_splitFirst
+section43TimeSpatialFlatCLE_splitLast
+section43TimeSpatialTensor
+section43TimeSpatialTensor_apply
+dense_section43_flatBlockTensor_span
+dense_section43TimeSpatialTensor_span
+dense_section43TimeSpatialTensor_span_of_factor_dense
+dense_section43TimeSpatialTensor_span_compactLaplace_spatialFourier
+```
+
+The final theorem above uses
+`dense_section43IteratedLaplaceCompactTransform_preimage n` for the finite-time
+factor and `dense_section43SpatialFourierCompactRange d n` for the spatial
+factor.  It proves density of finite sums of tensors whose time factor is in
+the compact-Laplace positive-time preimage and whose spatial factor is the
+Fourier transform of a compact spatial source.  No new axioms, wrappers,
+`sorry`s, or heartbeat overrides are used.
+
+Important boundary: the compiled `section43TimeSpatialTensor` currently has
+codomain
+`SchwartzMap ((Fin n → ℝ) × Section43SpatialSpace d n) ℂ`, not
+`SchwartzNPoint d n`.  The next Lean step is to transport this packet through
+`nPointTimeSpatialSchwartzCLE` and prove the transported pointwise formula in
+terms of `section43QTime` and `section43QSpatial`.  Only after that transport
+should the compact spacetime product source and the
+`partialFourierSpatial_fun` factorization be implemented.
+
+The source attached to a restricted tensor is:
+
+```lean
+noncomputable def section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n) :
+    Section43CompactStrictPositiveTimeSpatialSource d n
+```
+
+Construction and obligations:
+
+1. In `(τ, η)` variables the underlying Schwartz function is
+   `g.f τ * κ.1 η`, transported through `nPointTimeSpatialSchwartzCLE`.
+2. Strict positive-time support follows because if the product is nonzero then
+   `τ ∈ tsupport g.f`, hence `g.positive` gives
+   `∀ i, 0 < τ i`.
+3. Compact support follows from
+   `tsupport (g.f τ * κ η) ⊆ tsupport g.f ×ˢ tsupport κ` and compactness of
+   both factors, transported through the time/spatial continuous linear
+   equivalence.
+4. The spatial Fourier slice factorizes:
+   ```lean
+   theorem partialFourierSpatial_fun_section43TimeSpatialProductSource
+       (g : Section43CompactStrictPositiveTimeSource n)
+       (κ : Section43SpatialCompactSource d n)
+       (τ : Fin n → ℝ) (ξ : Section43SpatialSpace d n) :
+       partialFourierSpatial_fun
+         (d := d) (n := n)
+         (section43TimeSpatialProductSource d n g κ).f
+         (τ, ξ) =
+       g.f τ * (SchwartzMap.fourierTransformCLM ℂ κ.1) ξ
+   ```
+   Implementation route: unfold `partialFourierSpatial_fun`; the fixed-time
+   slice is `g.f τ • κ.1`; apply `(SchwartzMap.fourierTransformCLM ℂ).map_smul`.
+   This avoids manual Fourier-integral normalization.
+
 Main theorem:
 
 ```lean
@@ -2564,14 +2757,49 @@ theorem dense_section43TimeLaplaceSpatialFourier_compact_preimage
 
 Proof:
 
-1. Use `nPointTimeSpatialCLE` to identify `NPointDomain d n` with
-   `(Fin n → ℝ) × EuclideanSpace ℝ (Fin n × Fin d)`.
-2. Apply Layer 2 in the time variables.
-3. Use the spatial Fourier transform as a continuous linear equivalence in the
-   spatial variables.  Density is preserved by continuous linear equivalences
-   and by the open quotient map.
-4. Use `partialFourierSpatial_fun_eq_integral` to identify the representative
-   formula with the production spatial Fourier convention.
+1. Let
+   ```lean
+   St :=
+     (section43TimePositiveQuotientMap n) ⁻¹'
+       Set.range (section43IteratedLaplaceCompactTransform n)
+   Sx := section43SpatialFourierCompactRange d n
+   ```
+   The compiled theorem
+   `dense_section43IteratedLaplaceCompactTransform_preimage n` gives
+   `Dense St`; the new spatial packet gives `Dense Sx`.
+2. Apply
+   `dense_section43TimeSpatialTensor_span_of_factor_dense d n hSt hSx`.
+3. Show every restricted tensor lies in the target preimage.  If
+   `Φ ∈ St`, choose
+   `g : Section43CompactStrictPositiveTimeSource n` with
+   `section43IteratedLaplaceCompactTransform n g =
+    section43TimePositiveQuotientMap n Φ`.
+   If `χ ∈ Sx`, choose
+   `κ : Section43SpatialCompactSource d n` with
+   `χ = SchwartzMap.fourierTransformCLM ℂ κ.1`.
+4. Let `Ψt := section43IteratedLaplaceSchwartzRepresentative n g` and
+   `Ψ := section43TimeSpatialTensor d n Ψt χ`.  On the positive-energy region,
+   quotient equality for `Φ` gives
+   `Φ σ = Ψt σ` for `σ = section43QTime q`, and hence
+   `section43TimeSpatialTensor d n Φ χ` and `Ψ` agree pointwise.
+5. Let `G := section43TimeSpatialProductSource d n g κ`.  The representative
+   predicate for `Ψ` follows from
+   `partialFourierSpatial_fun_section43TimeSpatialProductSource` and the
+   defining theorem
+   `section43IteratedLaplaceSchwartzRepresentative_apply_of_mem`.
+6. Therefore every restricted tensor is in the target.  Since the target is the
+   preimage of a linear range under the quotient map once the time-spatial
+   transform is packaged linearly, it is a submodule; otherwise prove directly
+   that it is closed under finite linear combinations using additivity of the
+   representative predicate and quotient map.  Prefer the linear-map packaging,
+   mirroring `section43IteratedLaplaceCompactTransformLinearMap`.
+7. Conclude density by `Dense.mono` from the dense restricted span.
+
+The `n = 0` case must be kept explicit in implementation.  Then
+`Fin n → ℝ` and `Section43SpatialSpace d n` are singleton/zero-dimensional
+spaces, the time integral is over a point, and the theorem reduces to the
+spatial Fourier compact-range density plus scalar multiplication.  Do not
+force this case through one-variable Laplace statements.
 
 ## Layer 4: Difference-Coordinate Transport
 

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -3665,3 +3665,10 @@ fun OS lgc F =>
     (fun n => dense_section43FourierLaplaceTransformComponentMap_preimage d n)
     F
 ```
+
+Production update, 2026-04-18: theorem-3 positivity is now closed in
+`OSToWightmanBoundaryValues.lean`.  The proof imports the compiled ordered
+density bridge and applies
+`OSReconstruction.bvt_W_positive_of_component_dense_preimage` with
+`OSReconstruction.dense_section43FourierLaplace_compact_ordered_preimage_raw`.
+No additional analytic theorem is inserted at the public frontier.

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -606,28 +606,139 @@ theorem dense_section43OneSidedLaplaceCompactTransform1D_preimage :
 
 Preferred proof is the OS I Lemma-8.2 dual-annihilator proof.
 
-Use the following locally convex separation helper.  If Mathlib already exposes
-this theorem under a different name, add a local wrapper with this statement so
-the density proof has a stable target:
+Important theorem-shape correction: the dual-annihilator proof cannot be
+applied to an arbitrary non-linear `Set.range`.  It proves density of a linear
+subspace.  Therefore the Lean route must first expose the compact strict-positive
+sources as a complex vector space and prove that the compact one-sided Laplace
+transform is linear.
+
+Add the source operations:
 
 ```lean
-theorem denseRange_of_dual_annihilator_zero
-    {E F : Type*}
-    [AddCommGroup E] [Module ℂ E] [TopologicalSpace E]
-    [AddCommGroup F] [Module ℂ F] [TopologicalSpace F]
-    [LocallyConvexSpace ℂ F]
-    (L : E → F)
-    (hlin : IsLinearMap ℂ L)
-    (hann :
-      ∀ A : F →L[ℂ] ℂ,
-        (∀ x : E, A (L x) = 0) → A = 0) :
-    DenseRange L
+namespace Section43CompactPositiveTimeSource1D
+
+instance : Zero Section43CompactPositiveTimeSource1D
+instance : Add Section43CompactPositiveTimeSource1D
+instance : SMul ℕ Section43CompactPositiveTimeSource1D
+instance : AddCommMonoid Section43CompactPositiveTimeSource1D
+instance : SMul ℂ Section43CompactPositiveTimeSource1D
+instance : Module ℂ Section43CompactPositiveTimeSource1D
+
+end Section43CompactPositiveTimeSource1D
 ```
 
-If the target is a quotient and it is easier to work in the ambient space, use
-the equivalent preimage form supplied by `IsOpenQuotientMap.dense_preimage_iff`.
+The proof obligations are only support stability:
 
-Then prove the analytic annihilator lemma:
+- zero source: `HasCompactSupport.zero` and empty support;
+- addition: `tsupport_add` plus union into `Set.Ioi 0`, and
+  `HasCompactSupport.add`;
+- natural scalar multiplication: use `(n : ℂ) • g.f`, with
+  `Nat.cast_smul_eq_nsmul` for the additive monoid law;
+- scalar multiplication: `tsupport_smul_subset_right` and
+  `HasCompactSupport.smul_left`.
+
+Then prove linearity of the quotient-valued compact transform:
+
+```lean
+theorem section43OneSidedLaplaceCompactTransform1D_map_add
+    (g h : Section43CompactPositiveTimeSource1D) :
+    section43OneSidedLaplaceCompactTransform1D (g + h) =
+      section43OneSidedLaplaceCompactTransform1D g +
+        section43OneSidedLaplaceCompactTransform1D h
+
+theorem section43OneSidedLaplaceCompactTransform1D_map_smul
+    (c : ℂ) (g : Section43CompactPositiveTimeSource1D) :
+    section43OneSidedLaplaceCompactTransform1D (c • g) =
+      c • section43OneSidedLaplaceCompactTransform1D g
+
+noncomputable def section43OneSidedLaplaceCompactTransform1DLinearMap :
+    Section43CompactPositiveTimeSource1D →ₗ[ℂ] Section43PositiveEnergy1D
+```
+
+Proof transcript for `map_add` and `map_smul`:
+
+- Rewrite each transform with
+  `section43OneSidedLaplaceCompactTransform1D_eq_cutoff_quotient`.
+- Reduce quotient equality with
+  `section43PositiveEnergyQuotientMap1D_eq_of_eqOn_nonneg`.
+- On `σ ≥ 0`, rewrite the explicit Schwartz representative with
+  `section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg`.
+- Use the raw Laplace integral definition, `integral_add` with
+  `section43OneSidedLaplaceRaw_integrable_of_nonneg`, and `integral_const_mul`
+  for scalar multiplication.
+
+Production status, 2026-04-17: the source module structure, transform
+linearity, and linear-map packaging are compiled in
+`Section43FourierLaplaceFiniteProbe.lean`.
+
+The density theorem is best proved directly in the ambient Schwartz preimage,
+not first inside the quotient.  The quotient does not currently expose a handy
+`LocallyConvexSpace ℝ Section43PositiveEnergy1D` instance, and no such
+infrastructure is needed for the target theorem.
+
+Use:
+
+```lean
+let L := section43OneSidedLaplaceCompactTransform1DLinearMap
+let Mq : Submodule ℂ Section43PositiveEnergy1D := LinearMap.range L
+let q := section43PositiveEnergyQuotientMap1D
+let S : Submodule ℂ (SchwartzMap ℝ ℂ) := Mq.comap q.toLinearMap
+```
+
+Proof transcript:
+
+1. Rewrite the target set as `(S : Set (SchwartzMap ℝ ℂ))`.
+2. It suffices to show `S.topologicalClosure = ⊤`, via
+   `Submodule.dense_iff_topologicalClosure_eq_top`.
+3. If `S.topologicalClosure ≠ ⊤`, choose
+   `x : SchwartzMap ℝ ℂ` outside the closure.
+4. Apply the real locally-convex Hahn-Banach theorem
+   `geometric_hahn_banach_closed_point` in the ambient Schwartz space to
+   `S.topologicalClosure`.  The convexity proof uses the complex submodule
+   operations with real coefficients cast into `ℂ`.
+5. The separation functional is real-linear:
+
+```lean
+f : SchwartzMap ℝ ℂ →L[ℝ] ℝ
+```
+
+   The usual scaling argument shows `f` vanishes on `S.topologicalClosure`.
+6. Extend `f` to a complex-linear functional on ambient Schwartz space:
+
+```lean
+let F : SchwartzMap ℝ ℂ →L[ℂ] ℂ :=
+  StrongDual.extendRCLike (𝕜 := ℂ) f
+```
+
+   Since `S.topologicalClosure` is a complex submodule, both `f y` and
+   `f (I • y)` vanish on the closure, hence `F` vanishes there.
+7. Because the quotient kernel is contained in `S`, `F` descends through
+   `section43PositiveEnergyQuotientMap1D` to a complex continuous functional
+
+```lean
+A : Section43PositiveEnergy1D →L[ℂ] ℂ
+```
+
+8. `F` vanishes on representatives of every compact transform, so
+   `A (section43OneSidedLaplaceCompactTransform1D g) = 0` for every compact
+   strict-positive source `g`.
+9. Apply the compiled annihilator theorem
+   `section43OneSidedLaplaceCompactTransform1D_dual_annihilator` to get
+   `A = 0`; therefore `F = 0` on ambient Schwartz, and the real-part identity
+   for `StrongDual.extendRCLike` gives `f x = 0`, contradicting the separating
+   inequality.
+10. The quotient dense-range theorem is then a corollary of the preimage theorem
+    by `IsOpenQuotientMap.dense_preimage_iff.mp`.
+
+Production status, 2026-04-17: this ambient preimage proof and the dense-range
+corollary are compiled as:
+
+```lean
+dense_section43OneSidedLaplaceCompactTransform1D_preimage
+denseRange_section43OneSidedLaplaceCompactTransform1DLinearMap
+```
+
+The analytic annihilator lemma used in Step 9 is:
 
 ```lean
 theorem section43OneSidedLaplaceCompactTransform1D_dual_annihilator
@@ -966,7 +1077,124 @@ section43ProbeCLM s (section43OneSidedLaplaceSchwartzRepresentative1D g) =
 This should now be placed in a small companion file, because
 `Section43FourierLaplaceDensity.lean` is already around 1600 lines.
 
-5. Prove integrability of the finite-probe family:
+5. Prove the finite-probe integrability through compact-support continuity,
+   not by trying to build a global Schwartz-valued majorant.
+
+The companion file should start with the following public support lemma copied
+from the private Paley-Wiener proof, with the `section43*` names:
+
+```lean
+theorem section43WeightedDerivToBCFCLM_norm_le
+    (k n : ℕ) (f : SchwartzMap ℝ ℂ) :
+    ‖section43WeightedDerivToBCFCLM k n f‖ ≤
+      (2 : ℝ) ^ k *
+        (SchwartzMap.seminorm ℝ 0 n f +
+          SchwartzMap.seminorm ℝ (2 * k) n f)
+```
+
+Proof transcript:
+
+- Use `BoundedContinuousFunction.dist_le` after rewriting the norm as distance
+  from zero.
+- For `|σ| ≤ 1`, use
+  `‖section43PolyWeight k σ‖ ≤ 2^k` and
+  `SchwartzMap.le_seminorm' (k := 0)`.
+- For `1 < |σ|`, use
+  `‖section43PolyWeight k σ‖ ≤ 2^k * |σ|^(2*k)` and
+  `SchwartzMap.le_seminorm' (k := 2*k)`.
+- This is exactly the estimate needed to turn Schwartz-topology convergence of
+  `ψ_z` into BCF-norm convergence of the weighted probes.
+
+Then prove positive-axis continuity of the weighted probe family:
+
+```lean
+theorem continuousOn_section43WeightedDerivToBCFCLM_imagAxisPsiKernel_Ioi
+    (k n : ℕ) :
+    ContinuousOn
+      (fun t : ℝ =>
+        section43WeightedDerivToBCFCLM k n
+          (section43ImagAxisPsiKernel t))
+      (Set.Ioi (0 : ℝ))
+```
+
+Proof transcript:
+
+- Fix `t₀ > 0`.  On a small neighborhood with
+  `‖h‖ ≤ t₀ / 2`, both `t₀ + h` and `t₀` remain in the positive branch, so
+  `section43ImagAxisPsiKernel (t₀ + h)` and
+  `section43ImagAxisPsiKernel t₀` unfold to
+  `SCV.schwartzPsiZ (((t₀ + h : ℝ) : ℂ) * Complex.I) _` and
+  `SCV.schwartzPsiZ ((t₀ : ℂ) * Complex.I) _`.
+- Apply the already public remainder theorem
+  `SCV.schwartzPsiZExpTaylorLinearRemainderQuot_seminorm_le` at
+  `z := (t₀ : ℂ) * Complex.I` and complex increment
+  `hC := (h : ℂ) * Complex.I`.  Its hypotheses are:
+  `0 < z.im`, `‖hC‖ ≤ z.im / 2`, and `‖hC‖ ≤ 1`.
+- Use the identity behind
+  `SCV.psiZ_sub_sub_deriv_eq_smul_remainder` to write
+
+```lean
+SCV.schwartzPsiZ (z + hC) _ - SCV.schwartzPsiZ z _ =
+  hC • ((SchwartzMap.smulLeftCLM ℂ (fun σ : ℝ => Complex.I * (σ : ℂ)))
+      (SCV.schwartzPsiZ z _)) +
+  hC • SCV.schwartzPsiZExpTaylorLinearRemainderQuot z _ hC _ _
+```
+
+  after extensionality in `σ`.
+- Apply `section43WeightedDerivToBCFCLM k n` to that equality.  Bound the norm
+  by the sum of the two `hC`-scaled terms.  The derivative term has fixed norm;
+  the remainder term is bounded by
+  `section43WeightedDerivToBCFCLM_norm_le` and
+  `SCV.schwartzPsiZExpTaylorLinearRemainderQuot_seminorm_le` for seminorms
+  `(0,n)` and `(2*k,n)`.
+- The resulting bound is `const * ‖h‖`, which tends to zero.  This proves
+  continuity at `t₀`; assemble with `continuousOn_iff_continuousAt`.
+
+This is the exact vertical analogue of the private horizontal-continuity block
+in `SCV.PaleyWiener` around
+`tendsto_weightedDerivToBCFCLM_schwartzPsiZ_horizontal_diff_zero` and
+`continuous_weightedDerivToBCFCLM_schwartzPsiZ_horizontal`, except the complex
+increment is `h * I` instead of `h`.
+
+Now prove component integrability, using the compact strict-positive support of
+`g`:
+
+```lean
+theorem integrable_section43WeightedProbe_imagAxisPsiKernel_source
+    (g : Section43CompactPositiveTimeSource1D)
+    (k n : ℕ) :
+    Integrable
+      (fun t : ℝ =>
+        g.f t •
+          section43WeightedDerivToBCFCLM k n
+            (section43ImagAxisPsiKernel t))
+```
+
+Proof transcript:
+
+- Choose `δ R` from
+  `exists_positive_Icc_bounds_of_compactPositiveTimeSource g`.
+- Prove the support inclusion
+
+```lean
+Function.support
+  (fun t : ℝ =>
+    g.f t • section43WeightedDerivToBCFCLM k n
+      (section43ImagAxisPsiKernel t))
+  ⊆ Set.Icc δ R
+```
+
+  because if the smul is nonzero then `g.f t ≠ 0`, hence
+  `t ∈ tsupport (g.f : ℝ → ℂ)`, and the chosen support bound applies.
+- Prove `ContinuousOn` of the same function on `Set.Icc δ R` by combining:
+  `g.f.continuous.continuousOn`,
+  `continuousOn_section43WeightedDerivToBCFCLM_imagAxisPsiKernel_Ioi k n`,
+  and `Set.Icc δ R ⊆ Set.Ioi 0`, which follows from `0 < δ` and `δ ≤ t`.
+- Apply `ContinuousOn.integrableOn_compact` on `Set.Icc δ R`, then convert to
+  global integrability using
+  `integrableOn_iff_integrable_of_support_subset`.
+
+The finite-product integrability theorem is then mechanical:
 
 ```lean
 theorem integrable_section43Probe_imagAxisPsiKernel_source
@@ -977,10 +1205,40 @@ theorem integrable_section43Probe_imagAxisPsiKernel_source
         g.f t • section43ProbeCLM s (section43ImagAxisPsiKernel t))
 ```
 
-   Use `exists_positive_Icc_bounds_of_compactPositiveTimeSource g` to reduce to
-   `[δ,R]`; outside this compact support the factor `g.f t` is zero.  On
-   `[δ,R]`, the explicit derivative formula in Step 3 gives a uniform bound for
-   each selected weighted derivative probe.
+Proof transcript:
+
+- Use `Integrable.of_eval`.
+- For each `p : ↑s.attach`, unfold `section43ProbeCLM` and use
+  `integrable_section43WeightedProbe_imagAxisPsiKernel_source g
+    p.1.1.1 p.1.1.2`.
+
+With this integrability in hand, the Banach-valued probe identity is a pure
+extensionality argument:
+
+```lean
+theorem section43Probe_integral_imagAxisPsiKernel
+    (s : Finset (ℕ × ℕ))
+    (g : Section43CompactPositiveTimeSource1D) :
+    section43ProbeCLM s (section43OneSidedLaplaceSchwartzRepresentative1D g) =
+      ∫ t : ℝ,
+        g.f t • section43ProbeCLM s (section43ImagAxisPsiKernel t)
+```
+
+Proof transcript:
+
+- `ext p σ`.
+- Move the finite-product projection through the Bochner integral using
+  `(ContinuousLinearMap.proj ... p).integral_comp_comm
+    (integrable_section43Probe_imagAxisPsiKernel_source s g)`.
+- Move BCF evaluation through the component integral using
+  `(BoundedContinuousFunction.evalCLM ℂ σ).integral_comp_comm
+    (integrable_section43WeightedProbe_imagAxisPsiKernel_source g
+      p.1.1.1 p.1.1.2)`.
+- Simplify the projected/evaluated integrand to
+  `g.f t * section43WeightedDerivToBCFCLM p.1.1.1 p.1.1.2
+    (section43ImagAxisPsiKernel t) σ`.
+- Finish with the already compiled scalar component identity
+  `section43WeightedDerivToBCFCLM_representative_eq_integral_kernel_apply`.
 
 6. Combine finite-probe Fubini with the factorization:
 
@@ -1218,7 +1476,22 @@ part of the packet.  It should stay isolated as pure analysis.
 
 ## Layer 2: Finite Time Product
 
-Definitions:
+Layer 2 should not be implemented as a vague "coordinate induction".  The
+Lean-ready route is a tensor-product density argument:
+
+- use the already-compiled one-variable dense preimage theorem for each factor;
+- use the nuclear/product-tensor density theorem to reduce the finite time
+  Schwartz space to finite sums of pure tensors;
+- prove that a pure tensor whose factors are one-variable compact-Laplace
+  preimage representatives lies in the multitime compact-Laplace preimage;
+- close density because the multitime preimage is a submodule.
+
+This is still OS I Lemma 4.1: Lemma 8.2 supplies the one-coordinate positive
+support Fourier-Laplace density, and the Schwartz nuclear theorem supplies the
+finite product passage.
+
+Definitions to add in a new small companion file, not in the already-large
+one-variable density file:
 
 ```lean
 def section43TimePositiveRegion (n : ℕ) : Set (Fin n → ℝ) :=
@@ -1255,6 +1528,724 @@ def section43IteratedLaplaceRepresentative
           g.f τ
 ```
 
+The source type must be made into a complex module exactly as in the
+one-variable source packet:
+
+```lean
+namespace Section43CompactStrictPositiveTimeSource
+
+instance : Zero (Section43CompactStrictPositiveTimeSource n)
+instance : Add (Section43CompactStrictPositiveTimeSource n)
+instance : SMul ℕ (Section43CompactStrictPositiveTimeSource n)
+instance : AddCommMonoid (Section43CompactStrictPositiveTimeSource n)
+instance : SMul ℂ (Section43CompactStrictPositiveTimeSource n)
+instance : Module ℂ (Section43CompactStrictPositiveTimeSource n)
+
+end Section43CompactStrictPositiveTimeSource
+```
+
+The proof obligations are the same support-stability obligations as in the
+one-variable file.  Addition uses `tsupport_add` and
+`HasCompactSupport.add`; scalar multiplication uses
+`tsupport_smul_subset_right` and `HasCompactSupport.smul_left`.
+
+Package the multitime transform as a linear map:
+
+```lean
+noncomputable def section43IteratedLaplaceCompactTransform
+    (n : ℕ) :
+    Section43CompactStrictPositiveTimeSource n →
+      Section43TimePositiveComponent n
+
+theorem section43IteratedLaplaceCompactTransform_eq_quotient
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (Φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (hΦ : section43IteratedLaplaceRepresentative n g Φ) :
+    section43IteratedLaplaceCompactTransform n g =
+      section43TimePositiveQuotientMap n Φ
+
+theorem section43IteratedLaplaceCompactTransform_map_add
+    (g h : Section43CompactStrictPositiveTimeSource n) :
+    section43IteratedLaplaceCompactTransform n (g + h) =
+      section43IteratedLaplaceCompactTransform n g +
+        section43IteratedLaplaceCompactTransform n h
+
+theorem section43IteratedLaplaceCompactTransform_map_smul
+    (c : ℂ) (g : Section43CompactStrictPositiveTimeSource n) :
+    section43IteratedLaplaceCompactTransform n (c • g) =
+      c • section43IteratedLaplaceCompactTransform n g
+
+noncomputable def section43IteratedLaplaceCompactTransformLinearMap
+    (n : ℕ) :
+    Section43CompactStrictPositiveTimeSource n →ₗ[ℂ]
+      Section43TimePositiveComponent n
+```
+
+For `map_add` and `map_smul`, use quotient equality on
+`section43TimePositiveRegion n`; rewrite the representative integral by
+linearity of the scalar integral.  Integrability follows from compact support of
+the source and boundedness of the exponential on compact support when
+`σ` is fixed in the closed positive orthant.
+
+### Layer 2A: Time Product Tensors
+
+Name the pure tensor map explicitly:
+
+```lean
+noncomputable def section43TimeProductTensor
+    {n : ℕ} (fs : Fin n → SchwartzMap ℝ ℂ) :
+    SchwartzMap (Fin n → ℝ) ℂ :=
+  SchwartzMap.productTensor fs
+```
+
+The first density input is product-tensor density for `SchwartzMap (Fin n → ℝ)
+ℂ`.  The existing theorem
+
+```lean
+productTensor_span_dense 0 n
+```
+
+lives on
+
+```lean
+SchwartzMap (Fin n → Fin 1 → ℝ) ℂ
+```
+
+so add an explicit transport:
+
+```lean
+noncomputable def section43TimeAsOnePointCLE (n : ℕ) :
+    (Fin n → ℝ) ≃L[ℝ] (Fin n → Fin 1 → ℝ)
+
+theorem section43_timeProductTensor_span_dense (n : ℕ) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzMap (Fin n → ℝ) ℂ |
+          ∃ fs : Fin n → SchwartzMap ℝ ℂ,
+            F = section43TimeProductTensor fs}) :
+        Submodule ℂ (SchwartzMap (Fin n → ℝ) ℂ)) :
+        Set (SchwartzMap (Fin n → ℝ) ℂ))
+```
+
+Proof transcript:
+
+1. Define `section43TimeAsOnePointCLE n` by
+   `x i () = x i`, with inverse `y i = y i 0`.
+2. Transfer `productTensor_span_dense 0 n` through
+   `SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+     (section43TimeAsOnePointCLE n)` and its inverse.
+3. The pointwise compatibility theorem is:
+
+```lean
+theorem section43TimeAsOnePoint_productTensor
+    (fs : Fin n → SchwartzMap ℝ ℂ) :
+    SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+        (section43TimeAsOnePointCLE n).symm
+        (section43TimeProductTensor fs)
+      =
+    SchwartzMap.productTensor
+      (fun i : Fin n =>
+        SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+          (ContinuousLinearEquiv.funUnique (Fin 1) ℝ ℝ)
+          (fs i))
+```
+
+   Prove by extensionality and `SchwartzMap.productTensor_apply`.
+
+The second density input is the factorwise dense-subset version:
+
+```lean
+theorem section43_timeProductTensor_span_dense_of_factor_dense
+    {S : Set (SchwartzMap ℝ ℂ)}
+    (hS : Dense S) (n : ℕ) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzMap (Fin n → ℝ) ℂ |
+          ∃ fs : Fin n → SchwartzMap ℝ ℂ,
+            (∀ i : Fin n, fs i ∈ S) ∧
+            F = section43TimeProductTensor fs}) :
+        Submodule ℂ (SchwartzMap (Fin n → ℝ) ℂ)) :
+        Set (SchwartzMap (Fin n → ℝ) ℂ))
+```
+
+Proof transcript:
+
+1. Let `Pall` be all time product tensors and `PS` product tensors whose
+   factors lie in `S`.
+2. Show `Pall ⊆ closure (Submodule.span ℂ PS)`.
+3. For a fixed `fs`, use density of the finite product set
+   `{gs : Fin n → SchwartzMap ℝ ℂ | ∀ i, gs i ∈ S}` in
+   `Fin n → SchwartzMap ℝ ℂ`.  This is the finite-pi density theorem from
+   Mathlib, applied to `hS`.
+4. Apply continuity of `fun gs => section43TimeProductTensor gs`
+   (`SchwartzMap.productTensor_continuous`) to put
+   `section43TimeProductTensor fs` in the closure of the image of this dense
+   pi-set.
+5. The image is contained in `PS`, hence in `Submodule.span ℂ PS`.
+6. Since `Submodule.topologicalClosure` is a submodule, it contains
+   `Submodule.span ℂ Pall`.
+7. Finish with `section43_timeProductTensor_span_dense n`.
+
+This theorem is purely topological.  It should not mention Laplace transforms,
+OS positivity, or Wightman objects.
+
+Production status, 2026-04-18: the finite-time quotient/source surface and the
+pure product-tensor density packet are compiled in
+`Section43FourierLaplaceTimeProduct.lean`:
+
+```lean
+section43TimePositiveRegion
+section43TimeStrictPositiveRegion
+section43TimePositiveThickening
+section43TimePositiveCutoff
+section43TimePositiveCutoff_eq_one_of_mem
+section43TimePositiveCutoff_eq_zero_of_time_le_neg_one
+section43TimePositiveCutoff_eq_zero_of_not_mem_thickening_one
+section43TimePositiveCutoff_contDiff
+section43TimePositiveCutoff_hasTemperateGrowth
+section43TimePositiveCutoff_iteratedFDeriv_eq_zero_of_not_mem_thickening_one
+section43TimePositiveCutoff_iteratedFDeriv_support_subset_thickening_one
+section43TimeVanishingSubmodule
+Section43TimePositiveComponent
+section43TimePositiveQuotientMap
+section43TimePositiveQuotientMap_eq_of_eqOn_region
+eqOn_region_of_section43TimePositiveQuotientMap_eq
+section43TimeProductTensor
+section43TimeAsOnePointCLE
+section43TimeAsOnePoint_productTensor
+section43TimeAsOnePoint_symm_productTensor
+section43TimeAsOnePoint_comp_symm
+section43TimeAsOnePoint_symm_comp
+section43_timeProductTensor_span_dense
+section43_timeProductTensor_span_dense_of_factor_dense
+Section43CompactStrictPositiveTimeSource
+Section43CompactStrictPositiveTimeSource.instZero
+Section43CompactStrictPositiveTimeSource.instAdd
+Section43CompactStrictPositiveTimeSource.instSMulNat
+Section43CompactStrictPositiveTimeSource.instAddCommMonoid
+Section43CompactStrictPositiveTimeSource.instSMul
+Section43CompactStrictPositiveTimeSource.instModule
+exists_positive_margin_of_isCompact_subset_Ioi
+exists_positive_margin_of_compact_time_tsupport_subset_strictPositive
+exists_time_closedBall_of_compact_tsupport
+continuous_cmlm_apply_time
+tsupport_section43TimeProductTensor_subset_pi_tsupport
+hasCompactSupport_section43TimeProductTensor
+section43TimeProductSource
+section43IteratedLaplaceRaw
+section43IteratedLaplaceCutoffFun
+section43IteratedLaplaceCutoffFun_eq_raw_of_mem
+contDiff_section43IteratedLaplaceRaw_integrand_sigma
+hasFDerivAt_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft
+section43IteratedLaplaceRaw_iteratedFDerivCandidate
+section43TimeProductSource_integral_eq_product_raw
+section43TimeProductTensor_oneSidedLaplaceRepresentative_eq_integral
+section43IteratedLaplaceRepresentative
+section43TimeProductTensor_oneSidedLaplaceRepresentative
+exists_section43IteratedLaplaceRepresentative_productSource
+```
+
+This closes Layer 2A and the product-source support/factorization half of
+Layer 2B.  The remaining Layer 2B implementation starts at the honest multitime
+Laplace transform package:
+
+```lean
+section43IteratedLaplaceRepresentative
+exists_section43IteratedLaplaceRepresentative
+section43IteratedLaplaceCompactTransform
+section43IteratedLaplaceCompactTransform_eq_quotient
+section43IteratedLaplaceCompactTransform_productSource
+```
+
+### Layer 2B-0: Arbitrary Multitime Representative Existence
+
+The theorem
+
+```lean
+theorem exists_section43IteratedLaplaceRepresentative
+    (n : ℕ)
+    (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ Φ : SchwartzMap (Fin n → ℝ) ℂ,
+      section43IteratedLaplaceRepresentative n g Φ
+```
+
+must not be proved by the old vague "coordinate induction" sketch.  The
+implementation-ready route is the time-only analogue of the already compiled
+production theorem
+`exists_section43FourierLaplaceRepresentative_eq_integral_of_compact_orderedSupport_of_margin`.
+The architecture is:
+
+1. Build a time-only product cutoff.
+2. Prove the raw multitime Laplace integral is smooth.
+3. Prove its derivatives are rapidly decaying on the one-sided collar
+   `{σ | ∀ i, -1 ≤ σ i}`.
+4. Apply the compiled general constructor
+   `schwartzMap_of_temperate_mul_rapid_on_derivSupport`.
+
+Use these exact definitions:
+
+```lean
+def section43TimePositiveThickening (n : ℕ) (ε : ℝ) :
+    Set (Fin n → ℝ) :=
+  {σ | ∀ i : Fin n, -ε ≤ σ i}
+
+noncomputable def section43TimePositiveCutoff (n : ℕ) :
+    (Fin n → ℝ) → ℂ :=
+  fun σ => ∏ i : Fin n, (SCV.smoothCutoff (σ i) : ℂ)
+
+noncomputable def section43IteratedLaplaceRaw
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) : ℂ :=
+  ∫ τ : Fin n → ℝ,
+    Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+      g.f τ
+
+noncomputable def section43IteratedLaplaceCutoffFun
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) : ℂ :=
+  section43TimePositiveCutoff n σ *
+    section43IteratedLaplaceRaw n g σ
+```
+
+The cutoff packet is a direct copy of the compiled
+`section43PositiveEnergyCutoff` packet, with `section43QTime` replaced by the
+coordinate projection `fun σ => σ i`:
+
+```lean
+theorem section43TimePositiveCutoff_eq_one_of_mem
+    {σ : Fin n → ℝ} :
+    σ ∈ section43TimePositiveRegion n →
+      section43TimePositiveCutoff n σ = 1
+
+theorem section43TimePositiveCutoff_eq_zero_of_time_le_neg_one
+    {σ : Fin n → ℝ} {i : Fin n} :
+    σ i ≤ -1 → section43TimePositiveCutoff n σ = 0
+
+theorem section43TimePositiveCutoff_eq_zero_of_not_mem_thickening_one
+    {σ : Fin n → ℝ} :
+    σ ∉ section43TimePositiveThickening n 1 →
+      section43TimePositiveCutoff n σ = 0
+
+theorem section43TimePositiveCutoff_contDiff :
+    ContDiff ℝ (↑(⊤ : ℕ∞)) (section43TimePositiveCutoff n)
+
+theorem section43TimePositiveCutoff_hasTemperateGrowth :
+    Function.HasTemperateGrowth (section43TimePositiveCutoff n)
+
+theorem section43TimePositiveCutoff_iteratedFDeriv_support_subset_thickening_one
+    (r : ℕ) :
+    ∀ σ : Fin n → ℝ,
+      iteratedFDeriv ℝ r (section43TimePositiveCutoff n) σ ≠ 0 →
+        σ ∈ section43TimePositiveThickening n 1
+```
+
+The proof uses only:
+
+```lean
+SCV.smoothCutoff_one_of_nonneg
+SCV.smoothCutoff_zero_of_le_neg_one
+SCV.smoothCutoff_contDiff
+SCV.smoothCutoff_complex_hasTemperateGrowth
+iteratedFDeriv_eq_zero_of_eventuallyEq_zero
+```
+
+For source geometry, isolate the compact-support consequences before doing
+any differentiation:
+
+```lean
+theorem exists_positive_margin_of_compact_time_tsupport_subset_strictPositive
+    (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ δ, 0 < δ ∧
+      tsupport (g.f : (Fin n → ℝ) → ℂ) ⊆
+        {τ | ∀ i : Fin n, δ ≤ τ i}
+
+theorem exists_time_closedBall_of_compact_tsupport
+    (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ R, 0 ≤ R ∧
+      tsupport (g.f : (Fin n → ℝ) → ℂ) ⊆
+        Metric.closedBall (0 : Fin n → ℝ) R
+```
+
+For the margin theorem, the Lean proof should use the compact set
+`K := tsupport (g.f : (Fin n → ℝ) → ℂ)`.  For each coordinate `i`, the image
+`(fun τ => τ i) '' K` is compact and contained in `Set.Ioi 0`; apply the
+one-dimensional compact-positive margin argument to that image.  If
+`Fin n` is empty, choose `δ = 1` and the coordinate condition is vacuous.  If
+`Fin n` is nonempty, take the finite minimum of the coordinate margins and use
+positivity of a finite minimum of positive numbers.  The closed-ball theorem
+comes from `g.compact.isCompact.exists_bound_of_continuousOn` applied to
+`fun τ => ‖τ‖`, followed by replacing the bound with `max bound 0`.
+
+For smoothness, use the same integrated-candidate architecture already used in
+`Section43FourierLaplaceCompactDifferentiation.lean`.  Define the candidate by
+integrating the pointwise iterated derivative, rather than expanding all
+finite words by hand:
+
+```lean
+noncomputable def section43IteratedLaplaceRaw_iteratedFDerivCandidate
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    ContinuousMultilinearMap ℝ (fun _ : Fin r => Fin n → ℝ) ℂ :=
+  ∫ τ : Fin n → ℝ,
+    iteratedFDeriv ℝ r
+      (fun σ' : Fin n → ℝ =>
+        Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+          g.f τ)
+      σ
+```
+
+Then prove the following analogues of the compiled ordered-support theorems:
+
+```lean
+theorem integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    Integrable
+      (fun τ : Fin n → ℝ =>
+        iteratedFDeriv ℝ r
+          (fun σ' : Fin n → ℝ =>
+            Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ' i : ℂ))) *
+              g.f τ)
+          σ)
+
+theorem section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    HasFDerivAt
+      (fun σ' : Fin n → ℝ =>
+        section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ')
+      ((section43IteratedLaplaceRaw_iteratedFDerivCandidate n (r + 1) g σ).curryLeft)
+      σ
+
+theorem section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate
+    (n r : ℕ) (g : Section43CompactStrictPositiveTimeSource n)
+    (σ : Fin n → ℝ) :
+    iteratedFDeriv ℝ r (section43IteratedLaplaceRaw n g) σ =
+      section43IteratedLaplaceRaw_iteratedFDerivCandidate n r g σ
+
+theorem section43IteratedLaplaceRaw_contDiff
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    ContDiff ℝ (↑(⊤ : ℕ∞)) (section43IteratedLaplaceRaw n g)
+```
+
+The local dominated-convergence proof for
+`section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt` should be a
+time-only copy of
+`section43FourierLaplaceIntegral_iteratedFDerivCandidate_hasFDerivAt_of_compact_orderedSupport`:
+use `hasFDerivAt_integral_of_dominated_of_fderiv_le`, the local ball
+`Metric.closedBall σ 1`, and the compact time bound
+`tsupport g.f ⊆ Metric.closedBall 0 R`.  The pointwise derivative
+`HasFDerivAt` is obtained from smoothness of
+`fun σ' => Complex.exp (-(∑ i, (τ i : ℂ) * (σ' i : ℂ))) * g.f τ`.
+
+For rapid decay on the cutoff-derivative support, reuse the already compiled
+time-only estimates:
+
+```lean
+norm_exp_neg_timePair_le_exp_thickened_margin_sum
+exp_margin_sum_controls_thickened_time_polynomial
+```
+
+With `ε = 1`, `δ` from the strict-positive support margin, and `R` from the
+compact closed-ball bound, they give:
+
+```lean
+theorem section43IteratedLaplaceRaw_iteratedFDeriv_rapid_on_timeThickening
+    (n r s : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ C : ℝ, 0 ≤ C ∧
+      ∀ σ ∈ section43TimePositiveThickening n 1,
+        (1 + ‖σ‖) ^ s *
+          ‖iteratedFDeriv ℝ r (section43IteratedLaplaceRaw n g) σ‖ ≤ C
+```
+
+The proof first rewrites the derivative by
+`section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate`, bounds the pointwise
+candidate by a compact-support integrable majorant, applies
+`norm_exp_neg_timePair_le_exp_thickened_margin_sum`, and then absorbs the
+remaining polynomial in `σ` using
+`exp_margin_sum_controls_thickened_time_polynomial`.
+
+The final representative is then:
+
+```lean
+noncomputable def section43IteratedLaplaceSchwartzRepresentative
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    SchwartzMap (Fin n → ℝ) ℂ :=
+  schwartzMap_of_temperate_mul_rapid_on_derivSupport
+    (χ := section43TimePositiveCutoff n)
+    (F := section43IteratedLaplaceRaw n g)
+    (S := section43TimePositiveThickening n 1)
+    (section43TimePositiveCutoff_hasTemperateGrowth n)
+    (fun r σ hne =>
+      section43TimePositiveCutoff_iteratedFDeriv_support_subset_thickening_one
+        (n := n) r σ hne)
+    (section43IteratedLaplaceRaw_contDiff n g)
+    (by
+      intro r s
+      exact section43IteratedLaplaceRaw_iteratedFDeriv_rapid_on_timeThickening
+        n r s g)
+
+theorem section43IteratedLaplaceSchwartzRepresentative_apply_of_mem
+    (g : Section43CompactStrictPositiveTimeSource n)
+    {σ : Fin n → ℝ} :
+    σ ∈ section43TimePositiveRegion n →
+      section43IteratedLaplaceSchwartzRepresentative n g σ =
+        section43IteratedLaplaceRaw n g σ
+
+theorem exists_section43IteratedLaplaceRepresentative
+    (n : ℕ) (g : Section43CompactStrictPositiveTimeSource n) :
+    ∃ Φ : SchwartzMap (Fin n → ℝ) ℂ,
+      section43IteratedLaplaceRepresentative n g Φ
+```
+
+The last theorem is just
+`⟨section43IteratedLaplaceSchwartzRepresentative n g, ...⟩`, unfolding
+`section43IteratedLaplaceRepresentative`, rewriting by
+`section43IteratedLaplaceSchwartzRepresentative_apply_of_mem`, and unfolding
+`section43IteratedLaplaceRaw`.
+
+Production status, 2026-04-18: the low-risk first half of this package is
+compiled in `Section43FourierLaplaceTimeProduct.lean`:
+
+```lean
+section43TimePositiveThickening
+section43TimePositiveCutoff
+section43TimePositiveCutoff_eq_one_of_mem
+section43TimePositiveCutoff_eq_zero_of_time_le_neg_one
+section43TimePositiveCutoff_eq_zero_of_not_mem_thickening_one
+section43TimePositiveCutoff_contDiff
+section43TimePositiveCutoff_hasTemperateGrowth
+section43TimePositiveCutoff_iteratedFDeriv_eq_zero_of_not_mem_thickening_one
+section43TimePositiveCutoff_iteratedFDeriv_support_subset_thickening_one
+exists_positive_margin_of_isCompact_subset_Ioi
+exists_positive_margin_of_compact_time_tsupport_subset_strictPositive
+exists_time_closedBall_of_compact_tsupport
+continuous_cmlm_apply_time
+section43IteratedLaplaceRaw
+section43IteratedLaplaceCutoffFun
+section43IteratedLaplaceCutoffFun_eq_raw_of_mem
+contDiff_section43IteratedLaplaceRaw_integrand_sigma
+hasFDerivAt_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft
+section43IteratedLaplaceRaw_iteratedFDerivCandidate
+```
+
+The remaining implementation frontier in this package is now exactly the
+integrated derivative candidate estimates and their consequences:
+
+```lean
+integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt
+section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate
+section43IteratedLaplaceRaw_contDiff
+section43IteratedLaplaceRaw_iteratedFDeriv_rapid_on_timeThickening
+section43IteratedLaplaceSchwartzRepresentative
+exists_section43IteratedLaplaceRepresentative
+```
+
+### Layer 2B: Product Sources
+
+For factorwise compact positive sources, define the product source:
+
+```lean
+noncomputable def section43TimeProductSource
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    Section43CompactStrictPositiveTimeSource n :=
+{ f := section43TimeProductTensor (fun i => (gs i).f)
+  positive := ...
+  compact := ... }
+```
+
+Support proof transcript:
+
+1. If
+   `x ∈ tsupport ((section43TimeProductTensor fun i => (gs i).f) :
+      (Fin n → ℝ) → ℂ)`,
+   then for every `i`, `x i ∈ tsupport ((gs i).f : ℝ → ℂ)`.
+2. Prove the contrapositive: if `x i` is outside the one-variable tsupport,
+   choose a neighborhood of `x i` on which `(gs i).f` is zero; the cylinder
+   neighborhood in `Fin n → ℝ` makes the product tensor zero.
+3. Apply `(gs i).positive` to get `0 < x i`.
+4. Compactness follows from support containment in the finite product of the
+   compact one-variable tsupports.  In Lean this is:
+   `HasCompactSupport.of_support_subset_isCompact`,
+   `subset_tsupport`, and `isCompact_univ_pi (fun i => (gs i).compact.isCompact)`.
+
+Needed helper theorem names:
+
+```lean
+theorem tsupport_section43TimeProductTensor_subset_pi_tsupport
+    (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    tsupport
+      ((section43TimeProductTensor (fun i => (gs i).f) :
+          SchwartzMap (Fin n → ℝ) ℂ) : (Fin n → ℝ) → ℂ)
+      ⊆ {x | ∀ i, x i ∈ tsupport ((gs i).f : ℝ → ℂ)}
+
+theorem hasCompactSupport_section43TimeProductTensor
+    (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    HasCompactSupport
+      ((section43TimeProductTensor (fun i => (gs i).f) :
+          SchwartzMap (Fin n → ℝ) ℂ) : (Fin n → ℝ) → ℂ)
+
+noncomputable def section43TimeProductSource
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    Section43CompactStrictPositiveTimeSource n
+```
+
+For `n = 0`, the positive condition is vacuous and compact support is compact
+support on the one-point space.  Keep the same theorem statements; the finite
+product compactness proof should handle this case.
+
+The product-source support packet is now compiled in
+`Section43FourierLaplaceTimeProduct.lean`.  The compactness proof uses the
+finite product set
+
+```lean
+Set.pi Set.univ (fun i => tsupport ((gs i).f : ℝ → ℂ))
+```
+
+and does not require any OS or Wightman input.
+
+The product-source representative theorem is now compiled:
+
+```lean
+theorem section43TimeProductTensor_oneSidedLaplaceRepresentative
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    section43IteratedLaplaceRepresentative n (section43TimeProductSource gs)
+      (section43TimeProductTensor
+        (fun i : Fin n =>
+          section43OneSidedLaplaceSchwartzRepresentative1D (gs i)))
+
+theorem exists_section43IteratedLaplaceRepresentative_productSource
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    ∃ Φ : SchwartzMap (Fin n → ℝ) ℂ,
+      section43IteratedLaplaceRepresentative n (section43TimeProductSource gs) Φ
+```
+
+After the arbitrary-source compact transform is defined, prove the transform
+compatibility:
+
+```lean
+theorem section43IteratedLaplaceCompactTransform_productSource
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D) :
+    section43IteratedLaplaceCompactTransform n
+        (section43TimeProductSource gs) =
+      section43TimePositiveQuotientMap n
+        (section43TimeProductTensor
+          (fun i =>
+            section43OneSidedLaplaceSchwartzRepresentative1D (gs i)))
+```
+
+Proof transcript:
+
+1. Apply `section43IteratedLaplaceCompactTransform_eq_quotient` with
+   `Φ := section43TimeProductTensor
+      (fun i => section43OneSidedLaplaceSchwartzRepresentative1D (gs i))`.
+2. The representative proof argument is the compiled theorem
+   `section43TimeProductTensor_oneSidedLaplaceRepresentative gs`.
+3. No further analysis is needed at this stage; all pointwise analysis has
+   already been compiled in
+   `section43TimeProductTensor_oneSidedLaplaceRepresentative_eq_integral`.
+
+For reference, the pointwise theorem proved the following finite-product
+calculation.  The multitime representative integral for
+`section43TimeProductSource gs` has integrand
+
+```lean
+fun τ =>
+  ∏ i,
+    Complex.exp (-((τ i : ℂ) * (σ i : ℂ))) * (gs i).f (τ i)
+```
+
+after rewriting the exponential of a finite sum as a product with
+`Complex.exp_sum`.  The exact Mathlib theorem used for the finite-product
+Fubini calculation is:
+
+```lean
+MeasureTheory.integral_fintype_prod_volume_eq_prod
+```
+
+In the compiled product-source theorem, it gives
+
+```lean
+theorem section43TimeProductSource_integral_eq_product_raw
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D)
+    (σ : Fin n → ℝ) :
+    (∫ τ : Fin n → ℝ,
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        (section43TimeProductSource gs).f τ) =
+      ∏ i : Fin n,
+        ∫ t : ℝ, Complex.exp (-(t : ℂ) * (σ i : ℂ)) * (gs i).f t
+```
+
+The proof rewrites
+`Complex.exp (-(∑ i, (τ i : ℂ) * (σ i : ℂ)))` as
+`∏ i, Complex.exp (-(τ i : ℂ) * (σ i : ℂ))` using
+`Complex.exp_sum`, `Finset.sum_neg_distrib`, and a per-coordinate `ring`.
+It then rewrites each factor by
+`section43OneSidedLaplaceSchwartzRepresentative1D_apply` and
+`section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg`, finishing with
+`SchwartzMap.productTensor_apply`.
+
+The pointwise product-source representative identity on the closed positive
+orthant is also compiled:
+
+```lean
+theorem section43TimeProductTensor_oneSidedLaplaceRepresentative_eq_integral
+    {n : ℕ} (gs : Fin n → Section43CompactPositiveTimeSource1D)
+    {σ : Fin n → ℝ} (hσ : σ ∈ section43TimePositiveRegion n) :
+    (section43TimeProductTensor
+      (fun i : Fin n => section43OneSidedLaplaceSchwartzRepresentative1D (gs i)) :
+        SchwartzMap (Fin n → ℝ) ℂ) σ =
+    ∫ τ : Fin n → ℝ,
+      Complex.exp (-(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ))) *
+        (section43TimeProductSource gs).f τ
+```
+
+No bespoke finite-`Fin n` induction is needed here: the existing
+`MeasureTheory.integral_fintype_prod_volume_eq_prod` theorem is exactly the
+finite product-integral statement.
+
+The factorwise preimage theorem is then short:
+
+```lean
+def section43OneSidedCompactPreimageSet :
+    Set (SchwartzMap ℝ ℂ) :=
+  section43PositiveEnergyQuotientMap1D ⁻¹'
+    Set.range section43OneSidedLaplaceCompactTransform1D
+
+def section43IteratedCompactPreimageSet (n : ℕ) :
+    Set (SchwartzMap (Fin n → ℝ) ℂ) :=
+  section43TimePositiveQuotientMap n ⁻¹'
+    Set.range (section43IteratedLaplaceCompactTransform n)
+
+theorem section43TimeProductTensor_mem_iteratedCompactPreimageSet
+    {n : ℕ} {fs : Fin n → SchwartzMap ℝ ℂ}
+    (hfs : ∀ i : Fin n, fs i ∈ section43OneSidedCompactPreimageSet) :
+    section43TimeProductTensor fs ∈
+      section43IteratedCompactPreimageSet n
+```
+
+Proof transcript:
+
+1. Choose `gs i` from `hfs i`, so
+   `section43PositiveEnergyQuotientMap1D (fs i) =
+    section43OneSidedLaplaceCompactTransform1D (gs i)`.
+2. Convert each quotient equality into equality on `Set.Ici 0` using the
+   one-variable quotient extensionality theorem
+   `eqOn_nonneg_of_section43PositiveEnergyQuotientMap1D_eq`.
+3. On `σ ∈ section43TimePositiveRegion n`, multiply those coordinatewise
+   equalities to show
+
+```lean
+section43TimeProductTensor fs σ =
+section43TimeProductTensor
+  (fun i => section43OneSidedLaplaceSchwartzRepresentative1D (gs i)) σ
+```
+
+4. Apply `section43IteratedLaplaceCompactTransform_productSource`.
+
+### Layer 2C: Dense Preimage Theorem
+
 Main theorem:
 
 ```lean
@@ -1265,20 +2256,41 @@ theorem dense_section43IteratedLaplaceCompactTransform_preimage
         Set.range (section43IteratedLaplaceCompactTransform n))
 ```
 
-Proof:
+Proof transcript:
 
-1. `n = 0`: the quotient is one-dimensional.  Choose the constant scalar
-   source on the one-point domain.
-2. `n + 1`: split `Fin (n + 1) → ℝ` by
-   `MeasurableEquiv.piFinSuccAbove`.  Use the one-coordinate transform formula
-   and apply the one-variable dense theorem in the distinguished coordinate.
-3. Preserve strict compact support by choosing approximants with support in a
-   compact subinterval of `(0,∞)` and multiplying by the already compact
-   background support in the remaining coordinates.
-4. Use finite induction over coordinates.
+1. Let
 
-This is the formal version of the OS I Lemma-4.1 reduction from the
-multivariate transform to Lemma 8.2.
+```lean
+S1 := section43OneSidedCompactPreimageSet
+Sn := section43IteratedCompactPreimageSet n
+```
+
+2. `S1` is dense by the compiled theorem
+   `dense_section43OneSidedLaplaceCompactTransform1D_preimage`.
+3. `Sn` is a submodule carrier:
+
+```lean
+let Ln := section43IteratedLaplaceCompactTransformLinearMap n
+let qn := section43TimePositiveQuotientMap n
+let Mn : Submodule ℂ (Section43TimePositiveComponent n) := LinearMap.range Ln
+let SnSub : Submodule ℂ (SchwartzMap (Fin n → ℝ) ℂ) :=
+  Mn.comap qn.toLinearMap
+```
+
+   Prove `Sn = (SnSub : Set _)` by extensionality.
+4. Apply
+   `section43_timeProductTensor_span_dense_of_factor_dense
+     (hS := dense_section43OneSidedLaplaceCompactTransform1D_preimage) n`.
+5. The product-tensor generating set is contained in `Sn` by
+   `section43TimeProductTensor_mem_iteratedCompactPreimageSet`.
+6. Since `SnSub` is a submodule, its carrier contains the span of those product
+   tensors.
+7. A dense subset contained in `Sn` proves `Dense Sn`.
+
+This proof handles `n = 0` automatically if the product-source and
+product-integral lemmas handle the empty finite product.  Do not split the main
+density theorem unless Lean's finite-product integral API forces a local
+`n = 0` helper.
 
 ## Layer 3: Add Spatial Fourier Transform
 

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -3439,16 +3439,202 @@ theorem dense_section43FourierLaplace_compact_ordered_preimage_raw
 
 Proof:
 
-1. Pull ordered sources to difference coordinates with
-   `section43DiffPullbackCLM d n`.
-2. `OrderedPositiveTimeRegion` becomes strict positive time-difference support
-   under `section43DiffCoordRealCLE`.
-3. Compact support is preserved by the continuous linear equivalence.
-4. The formula
-   `section43FourierLaplaceIntegral_eq_time_spatial_integral` identifies the
-   resulting transform with the Layer-3 representative.
-5. Convert representatives to production quotient classes using
-   `section43FourierLaplaceTransformComponent_has_representative`.
+Implementation file: use a new downstream companion
+`Section43FourierLaplaceOrderedDensity.lean` importing both
+`Section43FourierLaplaceSpatialDensity` and
+`Section43FourierLaplaceClosure`.  This avoids reopening the large transform
+or closure files while giving access to the compiled Layer-3 dense target and
+the existing component map `section43FourierLaplaceTransformComponentMap`.
+
+The required ordered-transport packet is:
+
+1. Prove the strict-positive-differences-to-ordered-times lemma:
+   ```lean
+   theorem section43DiffCoordRealCLE_symm_mem_orderedPositiveTimeRegion_of_pos_time
+       (d n : ℕ) [NeZero d]
+       {δ : NPointDomain d n}
+       (hδ : ∀ i : Fin n, 0 < δ i 0) :
+       (section43DiffCoordRealCLE d n).symm δ ∈
+         OrderedPositiveTimeRegion d n
+   ```
+   Proof route: unfold `OrderedPositiveTimeRegion`; use
+   `section43DiffCoordRealCLE_symm_apply` to rewrite each ordered time as a
+   partial sum of `δ r 0`.  Positivity of the first time is
+   `Finset.sum_pos` over `Fin (i.val + 1)`, with witness `0`.  For `i < j`,
+   prove the difference of partial sums is the sum of the nonempty block
+   `r = i.val + 1, ..., j.val`; this sum is positive by `Finset.sum_pos`.
+   Equivalently, use an auxiliary Nat-indexed lemma:
+   ```lean
+   lemma partialSum_strictMono_of_pos
+       {n : ℕ} {a : Fin n → ℝ}
+       (ha : ∀ i, 0 < a i) :
+       StrictMono fun k : Fin n =>
+         ∑ r : Fin (k.val + 1), a ⟨r.val, by omega⟩
+   ```
+   Then apply it to `a i = δ i 0`.
+   Lean skeleton for the strict inequality case.  The concrete implementation
+   uses an auxiliary Nat-indexed function `fj` for the larger partial sum; this
+   avoids trying to form the dependent term `δ ⟨r, by omega⟩` before Lean knows
+   the required bound from `r < j.val + 1`.
+   ```lean
+   intro i j hij
+   rw [section43DiffCoordRealCLE_symm_apply,
+     section43DiffCoordRealCLE_symm_apply]
+   rw [Finset.sum_fin_eq_sum_range, Finset.sum_fin_eq_sum_range]
+   have hijv : i.val < j.val := by exact hij
+   have hle : i.val + 1 ≤ j.val + 1 := Nat.succ_le_succ hijv.le
+   let fj : ℕ → ℝ := fun r =>
+     if h : r < j.val + 1 then
+       δ ⟨(⟨r, h⟩ : Fin (j.val + 1)).val, by
+         have hj := j.isLt
+         omega⟩ 0
+     else 0
+   have hblock_nonempty : (Finset.Ico (i.val + 1) (j.val + 1)).Nonempty := by
+     refine ⟨i.val + 1, ?_⟩
+     exact Finset.mem_Ico.mpr ⟨le_rfl, Nat.succ_lt_succ hijv⟩
+   have hleft :
+       (∑ r ∈ Finset.range (i.val + 1),
+         if h : r < i.val + 1 then
+           δ ⟨(⟨r, h⟩ : Fin (i.val + 1)).val, by
+             have hi := i.isLt
+             omega⟩ 0
+         else 0) =
+       (∑ r ∈ Finset.range (i.val + 1), fj r) := by
+     refine Finset.sum_congr rfl ?_
+     intro r hr
+     have hri : r < i.val + 1 := Finset.mem_range.mp hr
+     have hrj : r < j.val + 1 := lt_of_lt_of_le hri hle
+     have hrjle : r ≤ j.val := Nat.lt_succ_iff.mp hrj
+     rw [dif_pos hri]
+     simp [fj, hrjle]
+   have hblock_pos :
+       0 < ∑ r ∈ Finset.Ico (i.val + 1) (j.val + 1), fj r := by
+     refine Finset.sum_pos ?_ hblock_nonempty
+     intro r hr
+     have hrj : r < j.val + 1 := (Finset.mem_Ico.mp hr).2
+     have hrjle : r ≤ j.val := Nat.lt_succ_iff.mp hrj
+     simpa [fj, hrjle] using hδ ⟨r, by
+       have hj := j.isLt
+       omega⟩
+   rw [hleft]
+   change (∑ r ∈ Finset.range (i.val + 1), fj r) <
+     ∑ r ∈ Finset.range (j.val + 1), fj r
+   rw [← Finset.sum_range_add_sum_Ico fj hle]
+   exact lt_add_of_pos_right _ hblock_pos
+   ```
+   The positivity case is the same `Finset.sum_fin_eq_sum_range` rewrite plus
+   `Finset.sum_pos` on `range (i.val + 1)`.
+
+2. Define the ordered pushforward of a compact strict-positive difference
+   source:
+   ```lean
+   noncomputable def section43OrderedSourceOfTimeSpatialSource
+       (d n : ℕ) [NeZero d]
+       (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+       Section43CompactOrderedSource d n
+   ```
+   with carrier
+   ```lean
+   f :=
+     SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+       (section43DiffCoordRealCLE d n) G.f
+   ```
+   so pointwise
+   `f y = G.f (section43DiffCoordRealCLE d n y)`.
+   Ordered support proof: if `y ∈ tsupport f`, use
+   `tsupport_comp_subset_preimage` to get
+   `section43DiffCoordRealCLE d n y ∈ tsupport G.f`, apply `G.positive`, and
+   then apply the strict-positive-differences-to-ordered-times lemma to
+   `δ := section43DiffCoordRealCLE d n y`.
+   Compactness proof: use `tsupport_comp_eq_preimage` for
+   `(section43DiffCoordRealCLE d n).toHomeomorph`, rewrite the preimage as
+   `(section43DiffCoordRealCLE d n).symm '' tsupport G.f`, and use
+   `G.compact.isCompact.image`.
+
+3. Prove the pullback of this ordered pushforward is the original
+   difference-coordinate source:
+   ```lean
+   theorem section43DiffPullbackCLM_orderedSourceOfTimeSpatialSource
+       (d n : ℕ) [NeZero d]
+       (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+       section43DiffPullbackCLM d n
+         ⟨(section43OrderedSourceOfTimeSpatialSource d n G).f,
+          (section43OrderedSourceOfTimeSpatialSource d n G).ordered⟩ =
+       G.f
+   ```
+   Proof route: ext `δ`; unfold `section43DiffPullbackCLM_apply` and the
+   pushforward carrier; simplify
+   `section43DiffCoordRealCLE d n ((section43DiffCoordRealCLE d n).symm δ)`.
+
+4. Convert a Layer-3 time/spatial representative to the existing OS-I
+   Fourier-Laplace representative:
+   ```lean
+   theorem section43FourierLaplaceRepresentative_of_timeSpatialRepresentative
+       (d n : ℕ) [NeZero d]
+       {G : Section43CompactStrictPositiveTimeSpatialSource d n}
+       {Ψ : SchwartzNPoint d n}
+       (hΨ :
+         section43TimeLaplaceSpatialFourierRepresentative d n G Ψ) :
+       section43FourierLaplaceRepresentative d n
+         ⟨(section43OrderedSourceOfTimeSpatialSource d n G).f,
+          (section43OrderedSourceOfTimeSpatialSource d n G).ordered⟩ Ψ
+   ```
+   Proof route: for `q ∈ section43PositiveEnergyRegion`, rewrite
+   `section43FourierLaplaceIntegral`; use
+   `section43DiffPullbackCLM_orderedSourceOfTimeSpatialSource` so the integrand
+   is definitionally the same as in `hΨ q hq`.
+
+5. Convert a Layer-3 target witness into membership in the component-map
+   preimage:
+   ```lean
+   theorem section43TimeLaplaceSpatialFourierTarget_subset_component_preimage
+       (d n : ℕ) [NeZero d] :
+       section43TimeLaplaceSpatialFourierTarget d n ⊆
+         (section43PositiveEnergyQuotientMap (d := d) n) ⁻¹'
+           Set.range (section43FourierLaplaceTransformComponentMap d n)
+   ```
+   Proof route: take `Φ` with witness `G, Ψ, hΨ, hΦq`.  Let
+   `src := section43OrderedSourceOfTimeSpatialSource d n G`.  Get
+   `hΨ_FL` from step 4.  Obtain
+   `⟨Φc, hΦc_FL, hΦc_q⟩` from
+   `section43FourierLaplaceTransformComponent_has_representative` for
+   `src.f src.ordered src.compact`.  Since `Ψ` and `Φc` are both
+   `section43FourierLaplaceRepresentative` for the same ordered source, use
+   `section43PositiveEnergyQuotientMap_eq_of_eqOn_region` to prove
+   `section43PositiveEnergyQuotientMap Ψ =
+    section43PositiveEnergyQuotientMap Φc`.  Then combine with `hΦq` and
+   `hΦc_q`, and use
+   `⟨src, by simp [section43FourierLaplaceTransformComponentMap]⟩` for the
+   range witness.
+
+6. Prove the raw ordered preimage density theorem:
+   ```lean
+   theorem dense_section43FourierLaplace_compact_ordered_preimage_raw
+       (d n : ℕ) [NeZero d] :
+       Dense
+         ((section43PositiveEnergyQuotientMap (d := d) n) ⁻¹'
+           Set.range (section43FourierLaplaceTransformComponentMap d n))
+   ```
+   Proof route:
+   ```lean
+   exact Dense.mono
+     (section43TimeLaplaceSpatialFourierTarget_subset_component_preimage d n)
+     (by
+       simpa [section43TimeLaplaceSpatialFourierTarget] using
+         dense_section43TimeLaplaceSpatialFourier_compact_preimage d n)
+   ```
+
+Production update, 2026-04-18: this ordered-density bridge is compiled in the
+new companion file
+`OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceOrderedDensity.lean`:
+```lean
+section43DiffCoordRealCLE_symm_mem_orderedPositiveTimeRegion_of_pos_time
+section43OrderedSourceOfTimeSpatialSource
+section43DiffPullbackCLM_orderedSourceOfTimeSpatialSource
+section43FourierLaplaceRepresentative_of_timeSpatialRepresentative
+section43TimeLaplaceSpatialFourierTarget_subset_component_preimage
+dense_section43FourierLaplace_compact_ordered_preimage_raw
+```
 
 ## Final Production Theorem
 

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -101,6 +101,34 @@ section43OneSidedAnnihilatorFL
 section43OneSidedAnnihilatorFL_eq_fourierLaplaceExt_to_oneSided
 section43OneSidedAnnihilatorFLOnImag
 section43ImagAxisPsiKernel
+section43ImagAxisPsiKernel_of_pos
+section43ImagAxisPsiKernel_of_not_pos
+section43ImagAxisPsiKernel_apply_of_not_pos
+section43ImagAxisPsiKernel_apply_of_pos_of_nonneg
+section43ImagAxisPsiKernel_apply_mul_source_of_nonneg
+section43ImagAxisPsiKernel_apply_mul_source
+Section43CompactPositiveTimeSource1D.pos_of_ne_zero
+Section43CompactPositiveTimeSource1D.eq_zero_of_not_pos
+section43OneSidedLaplaceCutoffFun_eq_integral_imagAxisPsiKernel
+section43OneSidedLaplaceRaw_eq_integral_imagAxisPsiKernel_of_nonneg
+section43OneSidedLaplaceSchwartzRepresentative1D_eq_integral_imagAxisPsiKernel_of_nonneg
+section43OneSidedLaplaceSchwartzRepresentative1D_eq_integral_imagAxisPsiKernel
+section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_formula
+section43ImagAxisPsiKernel_iteratedDeriv_mul_source
+section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_eq_integral_kernel_iteratedDeriv
+section43PolyWeight
+section43PolyWeight_hasTemperateGrowth
+section43IteratedDerivCLM
+section43IteratedDerivCLM_apply
+section43WeightedDerivToBCFCLM
+section43WeightedDerivToBCFCLM_apply
+section43_abs_pow_le_polyWeight
+section43ProbeCLM
+section43SchwartzSeminorm_le_probe_component_norm
+section43SchwartzSeminorm_le_probe_norm
+section43SchwartzFunctional_bound_by_probeNorm
+section43_exists_probe_factorization
+section43WeightedDerivToBCFCLM_representative_eq_integral_kernel_apply
 section43OneSidedAnnihilatorFLOnImag_of_pos
 section43OneSidedAnnihilatorFLOnImag_of_not_pos
 section43OneSidedAnnihilatorFLOnImag_eq_apply_kernel
@@ -707,6 +735,44 @@ Proof split:
   positivity proofs.
 - If `¬ 0 < t`, both sides are zero.
 
+Production status, 2026-04-17: the branch/evaluation subpacket is compiled.
+The important representatives are:
+
+```lean
+theorem Section43CompactPositiveTimeSource1D.eq_zero_of_not_pos
+    (g : Section43CompactPositiveTimeSource1D)
+    {t : ℝ} (ht : ¬ 0 < t) :
+    g.f t = 0
+
+theorem section43ImagAxisPsiKernel_apply_of_pos_of_nonneg
+    {t σ : ℝ} (ht : 0 < t) (hσ : 0 ≤ σ) :
+    section43ImagAxisPsiKernel t σ =
+      Complex.exp (-(t : ℂ) * (σ : ℂ))
+
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_eq_integral_imagAxisPsiKernel_of_nonneg
+    (g : Section43CompactPositiveTimeSource1D)
+    {σ : ℝ} (hσ : 0 ≤ σ) :
+    section43OneSidedLaplaceSchwartzRepresentative1D g σ =
+      ∫ t : ℝ, section43ImagAxisPsiKernel t σ * g.f t
+
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_eq_integral_imagAxisPsiKernel
+    (g : Section43CompactPositiveTimeSource1D)
+    (σ : ℝ) :
+    section43OneSidedLaplaceSchwartzRepresentative1D g σ =
+      ∫ t : ℝ, section43ImagAxisPsiKernel t σ * g.f t
+```
+
+The last theorem is global in `σ`, not merely a nonnegative-axis statement:
+`SCV.psiZ z σ` is `(SCV.smoothCutoff σ : ℂ) * exp (I * z * σ)`, so along
+`z = t * I` it equals the same cutoff times `exp (-t * σ)` on all of `ℝ`.
+This removes the branch-support and `SCV.psiZ` exponential-identification seam
+from the weak-Fubini bridge.
+
+This global value identity is still not enough by itself for an arbitrary
+continuous functional `T : SchwartzMap ℝ ℂ →L[ℂ] ℂ`.  Such a `T` may depend on
+derivatives and polynomial weights, so the next bridge must identify finitely
+many weighted derivative probes under the compact `t`-integral.
+
 Important formalization correction: do **not** define a Bochner integral valued
 in `SchwartzMap ℝ ℂ`.  In this repository `SchwartzMap` carries the locally
 convex Schwartz topology, but it is not a `NormedAddCommGroup`, so
@@ -744,12 +810,204 @@ Then combine with
 
 Lean proof plan for `section43OneSidedLaplace_scalar_fubini_apply`:
 
-1. Use `SCV.schwartz_functional_bound T` to choose a finite set of Schwartz
-   seminorms and a constant controlling `‖T φ‖`.
-2. Use `exists_positive_Icc_bounds_of_compactPositiveTimeSource g` to reduce
-   all source-time integrals to a compact interval `[δ,R]` with `0 < δ`.
-3. Prove a compact-vertical-segment seminorm bound for the imaginary-axis
-   kernels:
+1. Introduce local public copies of the finite-probe machinery currently used
+   privately in `SCV.PaleyWiener`: a polynomial weight, iterated derivative CLM,
+   weighted derivative BCF CLM, and finite product probe.
+
+```lean
+def section43PolyWeight (k : ℕ) (σ : ℝ) : ℂ := ((1 + σ^2) ^ k : ℝ)
+
+def section43IteratedDerivCLM :
+    ℕ → SchwartzMap ℝ ℂ →L[ℂ] SchwartzMap ℝ ℂ
+
+def section43WeightedDerivToBCFCLM
+    (k n : ℕ) : SchwartzMap ℝ ℂ →L[ℂ] ℝ →ᵇ ℂ
+
+def section43ProbeCLM (s : Finset (ℕ × ℕ)) :
+    SchwartzMap ℝ ℂ →L[ℂ] ((p : ↑s.attach) → (ℝ →ᵇ ℂ))
+```
+
+   This is not a wrapper around the theorem statement; it is the finite
+   normed target where Bochner integration is legal.
+
+2. Prove a public factorization theorem for continuous Schwartz functionals,
+   parallel to the private `exists_probe_factorization` in `SCV.PaleyWiener`:
+
+```lean
+theorem section43_exists_probe_factorization
+    (T : SchwartzMap ℝ ℂ →L[ℂ] ℂ) :
+    ∃ s : Finset (ℕ × ℕ),
+    ∃ G : ((p : ↑s.attach) → (ℝ →ᵇ ℂ)) →L[ℂ] ℂ,
+      T = G.comp (section43ProbeCLM s)
+```
+
+   Proof transcript:
+
+   - Use `SCV.schwartz_functional_bound T`.
+   - Show each selected Schwartz seminorm is bounded by the norm of the
+     corresponding probe component, exactly as in
+     `schwartzSeminorm_le_probe_component_norm`.
+   - Bound `‖T f‖` by `C * ‖section43ProbeCLM s f‖`.
+   - Show `ker (section43ProbeCLM s) ≤ ker T`.
+   - Define the linear map on the range of `section43ProbeCLM s`.
+   - Apply Hahn-Banach `exists_extension_norm_eq` to extend it to the finite
+     Banach product.
+
+Production status, 2026-04-17: Steps 1 and 2 are compiled in
+`Section43FourierLaplaceDensity.lean`.
+
+3. Prove the derivative-level kernel identity, not only the value identity:
+
+```lean
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_eq_integral_kernel_iteratedDeriv
+    (g : Section43CompactPositiveTimeSource1D) (n : ℕ) (σ : ℝ) :
+    iteratedDeriv n (section43OneSidedLaplaceSchwartzRepresentative1D g) σ =
+      ∫ t : ℝ,
+        iteratedDeriv n (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+          g.f t
+```
+
+   Proof transcript:
+
+   - Let `χ σ := (SCV.smoothCutoff σ : ℂ)`.
+   - For the left side, use
+     `section43OneSidedLaplaceSchwartzRepresentative1D_apply`,
+     `section43OneSidedLaplaceCutoffFun`, and `iteratedDeriv_mul` to get
+
+```lean
+∑ i ∈ Finset.range (n + 1),
+  (n.choose i : ℂ) *
+    iteratedDeriv i χ σ *
+      section43OneSidedLaplaceRawDerivCandidate g (n - i) σ
+```
+
+   - For the right side, use
+     `section43ImagAxisPsiKernel_apply_mul_source`: on `0 < t` the kernel is
+     `χ σ * exp (-(t : ℂ) * σ)`, while on `¬ 0 < t` the source value is zero.
+   - Apply `iteratedDeriv_mul` to the product
+     `χ σ * exp (-(t : ℂ) * σ)`.
+   - Use `iteratedDeriv_cexp_const_mul_real` to rewrite the exponential
+     derivative as `(-(t : ℂ)) ^ (n - i) * exp (-(t : ℂ) * σ)`.
+   - Move the finite sum through the scalar integral using `integral_finset_sum`
+     and use `section43OneSidedLaplaceRawDerivCandidate_integrable` for each
+     summand.
+   - Pull constants independent of `t` out with `integral_const_mul`.
+
+Production status, 2026-04-17: Step 3 is compiled as:
+
+```lean
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_formula
+    (g : Section43CompactPositiveTimeSource1D) (n : ℕ) (σ : ℝ) :
+    iteratedDeriv n (section43OneSidedLaplaceSchwartzRepresentative1D g) σ =
+      ∑ i ∈ Finset.range (n + 1),
+        n.choose i *
+          iteratedDeriv i (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ *
+            section43OneSidedLaplaceRawDerivCandidate g (n - i) σ
+
+theorem section43ImagAxisPsiKernel_iteratedDeriv_mul_source
+    (g : Section43CompactPositiveTimeSource1D)
+    (n : ℕ) (σ t : ℝ) :
+    iteratedDeriv n (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+        g.f t =
+      ∑ i ∈ Finset.range (n + 1),
+        n.choose i *
+          iteratedDeriv i (fun σ : ℝ => (SCV.smoothCutoff σ : ℂ)) σ *
+            ((-(t : ℂ)) ^ (n - i) *
+              Complex.exp (-(t : ℂ) * (σ : ℂ)) * g.f t)
+
+theorem section43OneSidedLaplaceSchwartzRepresentative1D_iteratedDeriv_eq_integral_kernel_iteratedDeriv
+    (g : Section43CompactPositiveTimeSource1D) (n : ℕ) (σ : ℝ) :
+    iteratedDeriv n (section43OneSidedLaplaceSchwartzRepresentative1D g) σ =
+      ∫ t : ℝ,
+        iteratedDeriv n (fun σ : ℝ => section43ImagAxisPsiKernel t σ) σ *
+          g.f t
+```
+
+The remaining weak-Fubini work now starts at Step 4: packaging these scalar
+derivative identities into equality after applying `section43ProbeCLM s`.
+
+4. Upgrade the derivative identity to finite probes:
+
+```lean
+theorem section43Probe_integral_imagAxisPsiKernel
+    (s : Finset (ℕ × ℕ))
+    (g : Section43CompactPositiveTimeSource1D) :
+    section43ProbeCLM s (section43OneSidedLaplaceSchwartzRepresentative1D g) =
+      ∫ t : ℝ,
+        g.f t • section43ProbeCLM s (section43ImagAxisPsiKernel t)
+```
+
+   This is a Banach-valued Bochner integral in the finite product of bounded
+   continuous functions, not a Schwartz-valued integral.  Prove by extensionality
+   in `p : s.attach` and `σ : ℝ`, using the derivative identity from Step 3.
+
+Production status, 2026-04-17: the scalar component/evaluation form of Step 4
+is compiled:
+
+```lean
+theorem section43WeightedDerivToBCFCLM_representative_eq_integral_kernel_apply
+    (g : Section43CompactPositiveTimeSource1D)
+    (k n : ℕ) (σ : ℝ) :
+    section43WeightedDerivToBCFCLM k n
+        (section43OneSidedLaplaceSchwartzRepresentative1D g) σ =
+      ∫ t : ℝ,
+        g.f t *
+          section43WeightedDerivToBCFCLM k n
+            (section43ImagAxisPsiKernel t) σ
+```
+
+The remaining part of Step 4 is the Banach-valued packaging:
+
+```lean
+section43ProbeCLM s (section43OneSidedLaplaceSchwartzRepresentative1D g) =
+  ∫ t : ℝ, g.f t • section43ProbeCLM s (section43ImagAxisPsiKernel t)
+```
+
+This should now be placed in a small companion file, because
+`Section43FourierLaplaceDensity.lean` is already around 1600 lines.
+
+5. Prove integrability of the finite-probe family:
+
+```lean
+theorem integrable_section43Probe_imagAxisPsiKernel_source
+    (s : Finset (ℕ × ℕ))
+    (g : Section43CompactPositiveTimeSource1D) :
+    Integrable
+      (fun t : ℝ =>
+        g.f t • section43ProbeCLM s (section43ImagAxisPsiKernel t))
+```
+
+   Use `exists_positive_Icc_bounds_of_compactPositiveTimeSource g` to reduce to
+   `[δ,R]`; outside this compact support the factor `g.f t` is zero.  On
+   `[δ,R]`, the explicit derivative formula in Step 3 gives a uniform bound for
+   each selected weighted derivative probe.
+
+6. Combine finite-probe Fubini with the factorization:
+
+```lean
+obtain ⟨s, G, hTG⟩ := section43_exists_probe_factorization T
+calc
+  T (section43OneSidedLaplaceSchwartzRepresentative1D g)
+      = G (section43ProbeCLM s
+          (section43OneSidedLaplaceSchwartzRepresentative1D g)) := by
+          rw [hTG]
+  _ = G (∫ t, g.f t • section43ProbeCLM s (section43ImagAxisPsiKernel t)) := by
+          rw [section43Probe_integral_imagAxisPsiKernel]
+  _ = ∫ t, G (g.f t • section43ProbeCLM s (section43ImagAxisPsiKernel t)) := by
+          exact (G.integral_comp_comm
+            (integrable_section43Probe_imagAxisPsiKernel_source s g)).symm
+  _ = ∫ t, T (section43ImagAxisPsiKernel t) * g.f t := by
+          apply integral_congr_ae
+          filter_upwards with t
+          rw [hTG]
+          simp [map_smul, smul_eq_mul, mul_comm]
+```
+
+The older compact-vertical-segment seminorm bound remains useful as a possible
+way to prove Step 5, but it is not sufficient alone.  The finite-probe identity
+requires derivative-level equality under the compact scalar integral.
+
+Earlier seminorm-bound target, retained as a support lemma:
 
 ```lean
 theorem section43ImagAxisPsiKernel_seminorm_le_on_Icc
@@ -768,7 +1026,7 @@ theorem section43ImagAxisPsiKernel_seminorm_le_on_Icc
    If direct proof is too large, first prove the bound by continuity of
    `t ↦ weightedDerivToBCFCLM k n (section43ImagAxisPsiKernel t)` on compact
    `[δ,R]`, following the horizontal-continuity pattern in `SCV.PaleyWiener`.
-4. Prove scalar integrability:
+7. Prove scalar integrability as a corollary of Steps 2 and 5:
 
 ```lean
 theorem integrable_section43_scalar_kernel_after_functional
@@ -779,17 +1037,10 @@ theorem integrable_section43_scalar_kernel_after_functional
 
    Use the seminorm bound from Step 3, the functional bound from Step 1, and
    compact support/integrability of `g.f`.
-5. Prove the weak integral identity by approximating the compactly supported
-   parameter integral in the Schwartz topology using Riemann sums or a standard
-   parameter-integral theorem formulated in terms of the finite seminorm family
-   from Step 1.  The statement should avoid constructing a
-   `SchwartzMap`-valued Bochner integral; it only needs convergence after
-   applying `T`.
-6. On the nonnegative axis, rewrite the explicit representative with
-   `section43OneSidedLaplaceCutoffFun_eq_raw_of_nonneg`,
-   `SCV.schwartzPsiZ_apply`, and `SCV.psiZ_eq_exp_of_nonneg`.  On
-   `¬ 0 < t`, use `g.f t = 0`, which follows from `g.positive` and
-   `Function.support_subset_tsupport`.
+8. The global scalar rewrite is already compiled as
+   `section43OneSidedLaplaceSchwartzRepresentative1D_eq_integral_imagAxisPsiKernel`.
+   It should be used as the `n = 0`, `k = 0` sanity check for Step 3, not as a
+   substitute for the derivative-level probe identity.
 
 Then convert integral vanishing against every compact strict-positive source to
 pointwise vanishing on the strict half-line using the existing local

--- a/docs/section43_fourier_laplace_density.md
+++ b/docs/section43_fourier_laplace_density.md
@@ -2737,14 +2737,135 @@ Construction and obligations:
 
 1. In `(τ, η)` variables the underlying Schwartz function is
    `g.f τ * κ.1 η`, transported through `nPointTimeSpatialSchwartzCLE`.
-2. Strict positive-time support follows because if the product is nonzero then
-   `τ ∈ tsupport g.f`, hence `g.positive` gives
-   `∀ i, 0 < τ i`.
-3. Compact support follows from
-   `tsupport (g.f τ * κ η) ⊆ tsupport g.f ×ˢ tsupport κ` and compactness of
-   both factors, transported through the time/spatial continuous linear
-   equivalence.
-4. The spatial Fourier slice factorizes:
+2. Strict positive-time support should be proved by the following explicit
+   local lemma, using the compiled pointwise formula for the transported
+   tensor:
+   ```lean
+   theorem tsupport_section43NPointTimeSpatialTensor_subset_time_preimage
+       (d n : ℕ) [NeZero d]
+       (φ : SchwartzMap (Fin n → ℝ) ℂ)
+       (χ : SchwartzMap (Section43SpatialSpace d n) ℂ) :
+       tsupport
+         ((section43NPointTimeSpatialTensor d n φ χ :
+             SchwartzNPoint d n) : NPointDomain d n → ℂ)
+         ⊆
+       (section43QTime (d := d) (n := n)) ⁻¹'
+         tsupport (φ : (Fin n → ℝ) → ℂ)
+   ```
+   Proof skeleton:
+   ```lean
+   intro q hq
+   have hfun :
+       (((section43NPointTimeSpatialTensor d n φ χ :
+           SchwartzNPoint d n) : NPointDomain d n → ℂ)) =
+         fun q : NPointDomain d n =>
+           φ (section43QTime (d := d) (n := n) q) *
+             χ (section43QSpatial (d := d) (n := n) q) := by
+     funext q
+     simp
+   have hprod :
+       q ∈ tsupport
+         (fun q : NPointDomain d n =>
+           φ (section43QTime (d := d) (n := n) q) *
+             χ (section43QSpatial (d := d) (n := n) q)) := by
+     simpa [hfun] using hq
+   have ht_pullback :
+       q ∈ tsupport
+         (fun q : NPointDomain d n =>
+           φ (section43QTime (d := d) (n := n) q)) :=
+     (tsupport_mul_subset_left
+       (f := fun q : NPointDomain d n =>
+         φ (section43QTime (d := d) (n := n) q))
+       (g := fun q : NPointDomain d n =>
+         χ (section43QSpatial (d := d) (n := n) q))) hprod
+   exact
+     (tsupport_comp_subset_preimage
+       (φ : (Fin n → ℝ) → ℂ)
+       (f := section43QTime (d := d) (n := n))
+       (by simpa [section43QTimeCLM_apply] using
+         (section43QTimeCLM d n).continuous)) ht_pullback
+   ```
+   Then `positive` is:
+   ```lean
+   intro q hq i
+   exact g.positive
+     (tsupport_section43NPointTimeSpatialTensor_subset_time_preimage
+       d n g.f κ.1 hq) i
+   ```
+3. Compact support should not be attempted by taking a generic preimage of a
+   compact set.  The safe Lean route is to work with ordinary `support`, place
+   it inside the image of a compact product under the inverse time/spatial
+   homeomorphism, and use `HasCompactSupport.of_support_subset_isCompact`.
+   The helper lemma should be:
+   ```lean
+   theorem hasCompactSupport_section43NPointTimeSpatialTensor
+       (d n : ℕ) [NeZero d]
+       (φ : SchwartzMap (Fin n → ℝ) ℂ)
+       (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+       (hφ : HasCompactSupport (φ : (Fin n → ℝ) → ℂ))
+       (hχ : HasCompactSupport (χ : Section43SpatialSpace d n → ℂ)) :
+       HasCompactSupport
+         ((section43NPointTimeSpatialTensor d n φ χ :
+             SchwartzNPoint d n) : NPointDomain d n → ℂ)
+   ```
+   Proof skeleton:
+   ```lean
+   let e := nPointTimeSpatialCLE (d := d) n
+   let K : Set (NPointDomain d n) :=
+     e.symm '' (tsupport (φ : (Fin n → ℝ) → ℂ) ×ˢ
+       tsupport (χ : Section43SpatialSpace d n → ℂ))
+   have hKcompact : IsCompact K := by
+     exact (hφ.isCompact.prod hχ.isCompact).image e.symm.continuous
+   refine HasCompactSupport.of_support_subset_isCompact hKcompact ?_
+   intro q hq
+   rw [Function.mem_support] at hq
+   have hφq : φ (section43QTime (d := d) (n := n) q) ≠ 0 := by
+     intro hzero
+     apply hq
+     simp [section43NPointTimeSpatialTensor_apply, hzero]
+   have hχq : χ (section43QSpatial (d := d) (n := n) q) ≠ 0 := by
+     intro hzero
+     apply hq
+     simp [section43NPointTimeSpatialTensor_apply, hzero]
+   refine ⟨(section43QTime (d := d) (n := n) q,
+       section43QSpatial (d := d) (n := n) q), ?_, ?_⟩
+   · exact ⟨subset_tsupport _ (Function.mem_support.mpr hφq),
+       subset_tsupport _ (Function.mem_support.mpr hχq)⟩
+   · simp [e, section43QTime, section43QSpatial]
+   ```
+4. The fixed-time slice should be separated from the Fourier theorem:
+   ```lean
+   theorem partialEval₂_section43TimeSpatialProductSource
+       (d n : ℕ) [NeZero d]
+       (g : Section43CompactStrictPositiveTimeSource n)
+       (κ : Section43SpatialCompactSource d n)
+       (τ : Fin n → ℝ) :
+       SchwartzMap.partialEval₂
+         (nPointSpatialTimeSchwartzCLE (d := d) (n := n)
+           (section43TimeSpatialProductSource d n g κ).f) τ =
+       g.f τ • κ.1
+   ```
+   Proof skeleton:
+   ```lean
+   ext η
+   change
+     nPointSpatialTimeSchwartzCLE (d := d) (n := n)
+       (section43TimeSpatialProductSource d n g κ).f (η, τ) =
+     (g.f τ • κ.1) η
+   rw [nPointSpatialTimeSchwartzCLE_apply]
+   change
+     nPointTimeSpatialSchwartzCLE (d := d) (n := n)
+       (section43NPointTimeSpatialTensor d n g.f κ.1) (τ, η) =
+     (g.f τ • κ.1) η
+   change section43TimeSpatialTensor d n g.f κ.1 (τ, η) =
+     (g.f τ • κ.1) η
+   simp [smul_eq_mul]
+   ```
+   The orientation check is essential: `partialEval₂` fixes the second
+   coordinate of the spatial-time Schwartz map, so
+   `nPointSpatialTimeSchwartzCLE_apply` rewrites `(η, τ)` to the
+   time-spatial value `(τ, η)`.
+5. The spatial Fourier slice factorizes:
    ```lean
    theorem partialFourierSpatial_fun_section43TimeSpatialProductSource
        (g : Section43CompactStrictPositiveTimeSource n)
@@ -2756,8 +2877,19 @@ Construction and obligations:
          (τ, ξ) =
        g.f τ * (SchwartzMap.fourierTransformCLM ℂ κ.1) ξ
    ```
-   Implementation route: unfold `partialFourierSpatial_fun`; the fixed-time
-   slice is `g.f τ • κ.1`; apply `(SchwartzMap.fourierTransformCLM ℂ).map_smul`.
+   Proof skeleton:
+   ```lean
+   rw [partialFourierSpatial_fun]
+   change
+     (SchwartzMap.fourierTransformCLM ℂ
+       (SchwartzMap.partialEval₂
+         (nPointSpatialTimeSchwartzCLE (d := d) (n := n)
+           (section43TimeSpatialProductSource d n g κ).f) τ)) ξ =
+       g.f τ * (SchwartzMap.fourierTransformCLM ℂ κ.1) ξ
+   rw [partialEval₂_section43TimeSpatialProductSource]
+   rw [(SchwartzMap.fourierTransformCLM ℂ).map_smul]
+   simp [smul_eq_mul]
+   ```
    This avoids manual Fourier-integral normalization.
 
 Main theorem:

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -25047,6 +25047,21 @@ using `section43QTime` and `section43QSpatial`.  The product-source definition
 and `partialFourierSpatial_fun_section43TimeSpatialProductSource` should follow
 that transport; they are not yet compiled.
 
+Production update, 2026-04-18: the `SchwartzNPoint d n` transport has now also
+compiled in
+`OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean`:
+
+```lean
+section43NPointTimeSpatialTensor
+section43NPointTimeSpatialTensor_apply
+dense_section43NPointTimeSpatialTensor_span_of_factor_dense
+dense_section43NPointTimeSpatialTensor_span_compactLaplace_spatialFourier
+```
+
+The next implementation target is now the source-side half:
+`section43TimeSpatialProductSource` and
+`partialFourierSpatial_fun_section43TimeSpatialProductSource`.
+
 The public Layer-3 target remains:
 
 Use this representative predicate rather than introducing an opaque

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -25318,8 +25318,133 @@ Proof transcript:
    `section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq`
    and
    `section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget`.
-   Then the restricted dense span is contained in the target preimage, so
-   density follows by `Dense.mono`.
+   Production update, 2026-04-18: the finite-span bridge is now compiled as a
+   linear-closure packet, not as a new analytic identification.  The production
+   declarations are:
+   ```lean
+   namespace Section43CompactStrictPositiveTimeSpatialSource
+
+   instance (d n : ℕ) [NeZero d] :
+       Zero (Section43CompactStrictPositiveTimeSpatialSource d n)
+   instance (d n : ℕ) [NeZero d] :
+       Add (Section43CompactStrictPositiveTimeSpatialSource d n)
+   instance (d n : ℕ) [NeZero d] :
+       AddCommMonoid (Section43CompactStrictPositiveTimeSpatialSource d n)
+   instance (d n : ℕ) [NeZero d] :
+       SMul ℂ (Section43CompactStrictPositiveTimeSpatialSource d n)
+   instance (d n : ℕ) [NeZero d] :
+       Module ℂ (Section43CompactStrictPositiveTimeSpatialSource d n)
+
+   end Section43CompactStrictPositiveTimeSpatialSource
+
+   theorem section43TimeSpatialSource_tsupport_subset_positiveEnergy
+       (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+       tsupport (G.f : NPointDomain d n → ℂ) ⊆
+         section43PositiveEnergyRegion d n
+
+   theorem integrable_section43TimeLaplaceSpatialFourier_timeIntegrand
+       (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+       (q : NPointDomain d n)
+       (hq : q ∈ section43PositiveEnergyRegion d n) :
+       Integrable
+         (fun τ : Fin n → ℝ =>
+           Complex.exp
+             (-(∑ i : Fin n,
+               (τ i : ℂ) *
+                 (section43QTime (d := d) (n := n) q i : ℂ))) *
+           partialFourierSpatial_fun
+             (d := d) (n := n) G.f
+             (τ, section43QSpatial (d := d) (n := n) q))
+
+   theorem section43TimeLaplaceSpatialFourierRepresentative_add
+       {G H : Section43CompactStrictPositiveTimeSpatialSource d n}
+       {Φ Ψ : SchwartzNPoint d n}
+       (hΦ : section43TimeLaplaceSpatialFourierRepresentative d n G Φ)
+       (hΨ : section43TimeLaplaceSpatialFourierRepresentative d n H Ψ) :
+       section43TimeLaplaceSpatialFourierRepresentative d n (G + H) (Φ + Ψ)
+
+   theorem section43TimeLaplaceSpatialFourierRepresentative_smul
+       (c : ℂ)
+       {G : Section43CompactStrictPositiveTimeSpatialSource d n}
+       {Φ : SchwartzNPoint d n}
+       (hΦ : section43TimeLaplaceSpatialFourierRepresentative d n G Φ) :
+       section43TimeLaplaceSpatialFourierRepresentative d n (c • G) (c • Φ)
+
+   def section43TimeLaplaceSpatialFourierTarget
+       (d n : ℕ) [NeZero d] : Set (SchwartzNPoint d n)
+
+   theorem section43TimeLaplaceSpatialFourierTarget_zero
+       (d n : ℕ) [NeZero d] :
+       (0 : SchwartzNPoint d n) ∈
+         section43TimeLaplaceSpatialFourierTarget d n
+
+   theorem section43TimeLaplaceSpatialFourierTarget_add
+       (d n : ℕ) [NeZero d]
+       {Φ Ψ : SchwartzNPoint d n}
+       (hΦ : Φ ∈ section43TimeLaplaceSpatialFourierTarget d n)
+       (hΨ : Ψ ∈ section43TimeLaplaceSpatialFourierTarget d n) :
+       Φ + Ψ ∈ section43TimeLaplaceSpatialFourierTarget d n
+
+   theorem section43TimeLaplaceSpatialFourierTarget_smul
+       (d n : ℕ) [NeZero d]
+       (c : ℂ)
+       {Φ : SchwartzNPoint d n}
+       (hΦ : Φ ∈ section43TimeLaplaceSpatialFourierTarget d n) :
+       c • Φ ∈ section43TimeLaplaceSpatialFourierTarget d n
+
+   theorem section43NPointTimeSpatialTensor_span_le_timeLaplaceSpatialFourierTarget
+       (d n : ℕ) [NeZero d] :
+       ((Submodule.span ℂ
+         {F : SchwartzNPoint d n |
+           ∃ φ : SchwartzMap (Fin n → ℝ) ℂ,
+           φ ∈
+             ((section43TimePositiveQuotientMap n) ⁻¹'
+               Set.range (section43IteratedLaplaceCompactTransform n)) ∧
+           ∃ χ : SchwartzMap (Section43SpatialSpace d n) ℂ,
+           χ ∈ section43SpatialFourierCompactRange d n ∧
+             F = section43NPointTimeSpatialTensor d n φ χ}) :
+         Set (SchwartzNPoint d n)) ⊆
+           section43TimeLaplaceSpatialFourierTarget d n
+
+   theorem dense_section43TimeLaplaceSpatialFourier_compact_preimage
+       (d n : ℕ) [NeZero d] :
+       Dense
+         {Φ : SchwartzNPoint d n |
+           ∃ (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+             (Ψ : SchwartzNPoint d n),
+             section43TimeLaplaceSpatialFourierRepresentative d n G Ψ ∧
+             section43PositiveEnergyQuotientMap (d := d) n Φ =
+               section43PositiveEnergyQuotientMap (d := d) n Ψ}
+   ```
+   The source algebra is copied from
+   `Section43CompactStrictPositiveTimeSource`; support closure uses
+   `tsupport_add`, `tsupport_smul_subset_right`, `HasCompactSupport.add`, and
+   `HasCompactSupport.smul_left`.  The integrability proof is the existing
+   `integrable_section43FourierLaplace_timeIntegrand` argument with
+   `section43DiffPullbackCLM d n f` replaced by `G.f` and negative-time
+   vanishing supplied by
+   `section43PartialFourierSpatial_fun_eq_zero_of_neg_time_of_support_positiveEnergy`
+   plus `section43TimeSpatialSource_tsupport_subset_positiveEnergy`.
+   Representative add/smul are pointwise `calc` proofs using
+   `MeasureTheory.integral_add`, `MeasureTheory.integral_const_mul`,
+   `partialFourierSpatial_fun_add`, and `partialFourierSpatial_fun_smul`.
+
+   The target set is:
+   ```lean
+   def section43TimeLaplaceSpatialFourierTarget
+       (d n : ℕ) [NeZero d] : Set (SchwartzNPoint d n) :=
+     {Φ |
+       ∃ (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+         (Ψ : SchwartzNPoint d n),
+         section43TimeLaplaceSpatialFourierRepresentative d n G Ψ ∧
+         section43PositiveEnergyQuotientMap (d := d) n Φ =
+           section43PositiveEnergyQuotientMap (d := d) n Ψ}
+   ```
+   Add/smul closure of this target uses `map_add` and `map_smul` for
+   `section43PositiveEnergyQuotientMap`.  The span containment uses
+   `Submodule.span_induction` with the compiled generator-containment theorem
+   as the base case.  Density follows by `Dense.mono` from
+   `dense_section43NPointTimeSpatialTensor_span_compactLaplace_spatialFourier`.
 7. Treat `n = 0` explicitly if the finite-dimensional tensor construction does
    not simplify by `simp`: the time integral is over the unique point and the
    density is purely the spatial Fourier compact-range density.

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -25242,6 +25242,33 @@ Proof transcript:
    `partialFourierSpatial_fun_section43TimeSpatialProductSource` and
    `section43IteratedLaplaceSchwartzRepresentative_apply_of_mem` to prove
    `section43TimeLaplaceSpatialFourierRepresentative d n G Ψ`.
+   The first compiled theorem should be the product-generator case:
+   ```lean
+   theorem section43TimeLaplaceSpatialFourierRepresentative_productSource
+       (d n : ℕ) [NeZero d]
+       (g : Section43CompactStrictPositiveTimeSource n)
+       (κ : Section43SpatialCompactSource d n) :
+       section43TimeLaplaceSpatialFourierRepresentative d n
+         (section43TimeSpatialProductSource d n g κ)
+         (section43NPointTimeSpatialTensor d n
+           (section43IteratedLaplaceSchwartzRepresentative n g)
+           (SchwartzMap.fourierTransformCLM ℂ κ.1))
+   ```
+   Proof route: for `q ∈ section43PositiveEnergyRegion d n`, obtain
+   `section43QTime q ∈ section43TimePositiveRegion n` by unfolding
+   `section43PositiveEnergyRegion`, `section43QTime`, and
+   `nPointTimeSpatialCLE`.  Rewrite the target tensor by
+   `section43NPointTimeSpatialTensor_apply`, rewrite the time representative by
+   `section43IteratedLaplaceSchwartzRepresentative_apply_of_mem`, unfold
+   `section43IteratedLaplaceRaw`, rewrite the integrand by
+   `partialFourierSpatial_fun_section43TimeSpatialProductSource`, and pull the
+   constant spatial Fourier factor outside the time integral by applying
+   `MeasureTheory.integral_mul_const` explicitly to the spatial Fourier scalar
+   and the base finite-time Laplace integrand.
+   Production update, 2026-04-18: both
+   `section43TimeLaplaceSpatialFourierRepresentative` and
+   `section43TimeLaplaceSpatialFourierRepresentative_productSource` are
+   compiled in `Section43FourierLaplaceSpatialDensity.lean`.
 6. Package the time-spatial compact transform as a linear map, or prove the
    representative target is closed under finite linear combinations directly.
    Then the restricted dense span is contained in the target preimage, so

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -24933,8 +24933,121 @@ Fourier variables and identify the resulting representative with
 7. Keep the target as a quotient by vanishing on `∀ i, 0 ≤ τ i`; this avoids a
    false support-restricted dense-range theorem.
 
-Third, insert the spatial Fourier transform.  This is a homeomorphism on the
-spatial Schwartz variables, so density is preserved:
+Third, insert the spatial Fourier transform.  This step has a critical compact
+support correction: the dense spatial-frequency factors must be Fourier
+transforms of compactly supported spatial Schwartz sources.  It is not enough
+to take `FourierTransform.fourierInv χ` for an arbitrary spatial-frequency
+factor `χ`, because that inverse Fourier transform is generally not compactly
+supported and would not produce a valid compact spacetime source.
+
+The detailed implementation transcript is maintained in
+`docs/section43_fourier_laplace_density.md`, Layer 3.  The exact subpacket is:
+
+```lean
+abbrev Section43SpatialSpace (d n : ℕ) [NeZero d] :=
+  EuclideanSpace ℝ (Fin n × Fin d)
+
+def Section43SpatialCompactSource (d n : ℕ) [NeZero d] :=
+  {κ : SchwartzMap (Section43SpatialSpace d n) ℂ //
+    HasCompactSupport (κ : Section43SpatialSpace d n → ℂ)}
+
+def section43SpatialFourierCompactRange
+    (d n : ℕ) [NeZero d] :
+    Set (SchwartzMap (Section43SpatialSpace d n) ℂ) :=
+  Set.range fun κ : Section43SpatialCompactSource d n =>
+    SchwartzMap.fourierTransformCLM ℂ κ.1
+
+theorem dense_section43SpatialFourierCompactRange
+    (d n : ℕ) [NeZero d] :
+    Dense (section43SpatialFourierCompactRange d n)
+
+noncomputable def section43TimeSpatialTensor
+    (d n : ℕ) [NeZero d]
+    (Φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ) :
+    SchwartzNPoint d n
+
+theorem section43TimeSpatialTensor_apply
+    (d n : ℕ) [NeZero d]
+    (Φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+    (q : NPointDomain d n) :
+    section43TimeSpatialTensor d n Φ χ q =
+      Φ (section43QTime (d := d) (n := n) q) *
+      χ (section43QSpatial (d := d) (n := n) q)
+
+theorem dense_section43TimeSpatialTensor_span_of_factor_dense
+    (d n : ℕ) [NeZero d]
+    {St : Set (SchwartzMap (Fin n → ℝ) ℂ)}
+    {Sx : Set (SchwartzMap (Section43SpatialSpace d n) ℂ)}
+    (hSt : Dense St) (hSx : Dense Sx) :
+    Dense
+      (((Submodule.span ℂ
+        {F : SchwartzNPoint d n |
+          ∃ Φ ∈ St, ∃ χ ∈ Sx,
+            F = section43TimeSpatialTensor d n Φ χ}) :
+        Submodule ℂ (SchwartzNPoint d n)) :
+        Set (SchwartzNPoint d n))
+
+noncomputable def section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n) :
+    Section43CompactStrictPositiveTimeSpatialSource d n
+
+theorem partialFourierSpatial_fun_section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n)
+    (τ : Fin n → ℝ) (ξ : Section43SpatialSpace d n) :
+    partialFourierSpatial_fun
+      (d := d) (n := n)
+      (section43TimeSpatialProductSource d n g κ).f
+      (τ, ξ) =
+    g.f τ * (SchwartzMap.fourierTransformCLM ℂ κ.1) ξ
+```
+
+The spatial density proof uses the compiled compact-support density theorem
+`SchwartzMap.dense_hasCompactSupport`, transported from
+`SchwartzMap (Fin (n*d) → ℝ) ℂ` to
+`SchwartzMap (Section43SpatialSpace d n) ℂ` through
+`EuclideanSpace.equiv` and `finProdFinEquiv`.  Then for any spatial target
+`χ`, approximate `FourierTransform.fourierInv χ` by compactly supported
+spatial Schwartz functions and use continuity of
+`SchwartzMap.fourierTransformCLM ℂ` plus
+`FourierTransform.fourier_fourierInv_eq`.
+
+The time-spatial density proof uses
+`dense_section43IteratedLaplaceCompactTransform_preimage n` for the time
+factor and `dense_section43SpatialFourierCompactRange d n` for the spatial
+factor, then transports the restricted simple-tensor span through
+`nPointTimeSpatialSchwartzCLE`.  The representative identification is by
+unfolding `partialFourierSpatial_fun`: the fixed-time slice of
+`section43TimeSpatialProductSource d n g κ` is `g.f τ • κ.1`, so the spatial
+Fourier transform is obtained from `(SchwartzMap.fourierTransformCLM ℂ).map_smul`
+with no manual Fourier-normalization rewrite.
+
+Production status, 2026-04-18: the product-space density half of this Layer-3
+packet is compiled in
+`OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean`.
+It proves the compact spatial Fourier range density, the time/spatial product
+flattening, the pointwise product tensor formula, unrestricted block-tensor
+density, restricted dense-factor tensor density, and the route-relevant
+specialization:
+
+```lean
+dense_section43TimeSpatialTensor_span_compactLaplace_spatialFourier
+```
+
+This compiled theorem still lives on
+`SchwartzMap ((Fin n → ℝ) × Section43SpatialSpace d n) ℂ`.  The next
+implementation step is the honest transport through
+`nPointTimeSpatialSchwartzCLE` to `SchwartzNPoint d n`, with a pointwise formula
+using `section43QTime` and `section43QSpatial`.  The product-source definition
+and `partialFourierSpatial_fun_section43TimeSpatialProductSource` should follow
+that transport; they are not yet compiled.
+
+The public Layer-3 target remains:
 
 Use this representative predicate rather than introducing an opaque
 placeholder map:
@@ -24981,13 +25094,33 @@ theorem dense_section43TimeLaplaceSpatialFourier_compact_preimage
 
 Proof transcript:
 
-1. Identify `NPointDomain d n` with
-   `(Fin n → ℝ) × EuclideanSpace ℝ (Fin n × Fin d)` using
-   `nPointTimeSpatialCLE`.
-2. Apply the iterated time-Laplace theorem in the first factor.
-3. Compose with the spatial Fourier CLM/equivalence in the second factor.
-4. Use continuity and open-quotient transport to move density through these
-   continuous linear equivalences.
+1. Let
+   `St := (section43TimePositiveQuotientMap n) ⁻¹'
+     Set.range (section43IteratedLaplaceCompactTransform n)` and
+   `Sx := section43SpatialFourierCompactRange d n`.
+2. Use
+   `dense_section43IteratedLaplaceCompactTransform_preimage n` and
+   `dense_section43SpatialFourierCompactRange d n`, then apply
+   `dense_section43TimeSpatialTensor_span_of_factor_dense`.
+3. For a generator `section43TimeSpatialTensor d n Φ χ` with
+   `Φ ∈ St` and `χ ∈ Sx`, choose
+   `g : Section43CompactStrictPositiveTimeSource n` and
+   `κ : Section43SpatialCompactSource d n` witnessing those memberships.
+4. Define `Ψt := section43IteratedLaplaceSchwartzRepresentative n g` and
+   `Ψ := section43TimeSpatialTensor d n Ψt χ`.  Quotient equality for the time
+   factor gives `Φ = Ψt` on `section43TimePositiveRegion n`, hence the full
+   tensors agree on `section43PositiveEnergyRegion d n`.
+5. Define `G := section43TimeSpatialProductSource d n g κ`.  Use
+   `partialFourierSpatial_fun_section43TimeSpatialProductSource` and
+   `section43IteratedLaplaceSchwartzRepresentative_apply_of_mem` to prove
+   `section43TimeLaplaceSpatialFourierRepresentative d n G Ψ`.
+6. Package the time-spatial compact transform as a linear map, or prove the
+   representative target is closed under finite linear combinations directly.
+   Then the restricted dense span is contained in the target preimage, so
+   density follows by `Dense.mono`.
+7. Treat `n = 0` explicitly if the finite-dimensional tensor construction does
+   not simplify by `simp`: the time integral is over the unique point and the
+   density is purely the spatial Fourier compact-range density.
 
 Fourth, transport from difference coordinates back to ordered Euclidean
 coordinates.  This is the already compiled map

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -24793,6 +24793,110 @@ section43IteratedLaplaceSchwartzRepresentative
 exists_section43IteratedLaplaceRepresentative
 ```
 
+Implementation correction for the local dominated-differentiation seam:
+
+The local-bound theorem for
+`section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt` should be
+proved from the explicit finite-time Laplace linear functional, not by copying
+the spatial derivative-word expansion from the ordered-support
+Fourier-Laplace proof.  The σ-dependence is
+
+```lean
+fun σ => Complex.exp (section43TimeLaplaceLinearCLM n τ σ)
+```
+
+where
+
+```lean
+section43TimeLaplaceLinearCLM n τ σ =
+  -(∑ i : Fin n, (τ i : ℂ) * (σ i : ℂ)).
+```
+
+The exact helper packet to compile before the local-bound theorem is:
+
+```lean
+section43TimeLaplaceLinearCLM
+section43TimeLaplaceLinearCLM_apply
+norm_time_le_norm_add_one_of_mem_closedBall
+norm_section43TimeLaplaceLinearCLM_le
+norm_exp_neg_timePair_le_local_time_closedBall
+exists_norm_bound_section43CompactStrictPositiveTimeSource_on_time_closedBall
+section43IteratedLaplaceRaw_integrand_iteratedFDeriv_eq_zero_of_not_mem_tsupport
+section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+```
+
+The bound is
+
+```lean
+Set.indicator (Metric.closedBall (0 : Fin n → ℝ) R)
+  (fun _ =>
+    (r + 1).factorial *
+      Real.exp (∑ _ : Fin n, R * (‖σ‖ + 1)) *
+      (∑ _ : Fin n, R) ^ (r + 1) *
+      Cg)
+```
+
+where `R` bounds `tsupport g.f` and `Cg` bounds `‖g.f τ‖` on that closed
+ball.  On the closed ball, use
+`norm_iteratedFDeriv_cexp_comp_clm_le` plus
+`iteratedFDeriv_smul_const_apply`; off the closed ball, use
+`tsupport g.f ⊆ Metric.closedBall 0 R` to show `g.f τ = 0`, hence every
+pointwise σ-derivative is zero.  This is the implementation-ready replacement
+for any older sketch involving finite-height shells, spatial derivative words,
+or wrapper reductions.
+
+Production status, 2026-04-18: the local-bound packet above is compiled in
+`Section43FourierLaplaceTimeProduct.lean`, including
+
+```lean
+section43IteratedLaplaceRaw_integrand_iteratedFDeriv_curryLeft_local_bound_of_compact
+integrable_section43IteratedLaplaceRaw_integrand_of_compact
+```
+
+The next theorem is
+
+```lean
+integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+```
+
+and the remaining proof-doc gap is the all-order measurability side.  The
+successor integrability proof should reuse the compiled local bound exactly as
+the ordered-support theorem does, but it must first prove that
+
+```lean
+fun τ =>
+  iteratedFDeriv ℝ r
+    (fun σ' =>
+      Complex.exp (-(∑ i, (τ i : ℂ) * (σ' i : ℂ))) * g.f τ)
+    σ
+```
+
+is AEStronglyMeasurable.  The preferred route is an explicit continuity lemma
+in `τ`, proved from the finite-dimensional formula for the σ-derivatives of
+the exponential linear functional and continuity of `g.f`.  Do not add a
+measurability hypothesis to the theorem statement.
+
+Updated production status, 2026-04-18: the full arbitrary compact
+strict-positive finite-time representative packet is now compiled in
+`Section43FourierLaplaceTimeProduct.lean`.  In particular, the following
+previously planned theorems are no longer blockers:
+
+```lean
+integrable_section43IteratedLaplaceRaw_integrand_iteratedFDeriv_of_compact
+section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt
+section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate
+section43IteratedLaplaceRaw_contDiff
+section43IteratedLaplaceRaw_iteratedFDeriv_rapid_on_timeThickening
+section43IteratedLaplaceSchwartzRepresentative
+exists_section43IteratedLaplaceRepresentative
+section43IteratedLaplaceCompactTransform
+section43IteratedLaplaceCompactTransform_productSource
+```
+
+Next stage: prove the finite-product dense-preimage theorem for
+`section43IteratedLaplaceCompactTransform` in a new small companion file rather
+than extending `Section43FourierLaplaceTimeProduct.lean` further.
+
 5. The rapid-decay proof must reuse the compiled time-only estimates
    `norm_exp_neg_timePair_le_exp_thickened_margin_sum` and
    `exp_margin_sum_controls_thickened_time_polynomial`; do not introduce a new

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -25453,50 +25453,122 @@ Fourth, transport from difference coordinates back to ordered Euclidean
 coordinates.  This is the already compiled map
 `section43DiffCoordRealCLE d n`.
 
+Implementation file: add a new downstream companion
+`Section43FourierLaplaceOrderedDensity.lean` importing
+`Section43FourierLaplaceSpatialDensity` and `Section43FourierLaplaceClosure`.
+Do not reopen the large transform or closure files for this packet.
+
 ```lean
 theorem dense_section43FourierLaplace_compact_ordered_preimage_raw
     (d n : ℕ) [NeZero d] :
     Dense
-      {Φ : SchwartzNPoint d n |
-        ∃ (f : SchwartzNPoint d n)
-          (hf_ord :
-            tsupport (f : NPointDomain d n → ℂ) ⊆
-              OrderedPositiveTimeRegion d n)
-          (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ)),
-          section43PositiveEnergyQuotientMap (d := d) n Φ =
-            section43FourierLaplaceTransformComponent d n
-              f hf_ord hf_compact}
+      ((section43PositiveEnergyQuotientMap (d := d) n) ⁻¹'
+        Set.range (section43FourierLaplaceTransformComponentMap d n))
 ```
 
 Proof transcript:
 
-1. Use `section43DiffCoordRealCLE d n` to rewrite ordered positive-time support
-   of `f` as positive-orthant support of
-   `section43DiffPullbackCLM d n ⟨f, hf_ord⟩`.
-2. Use
-   `section43FourierLaplaceIntegral_eq_time_spatial_integral` to identify the
-   transformed representative with the time-Laplace / spatial-Fourier
-   transform from the previous lemma.
-3. For compact sources, use
-   `section43FourierLaplaceTransformComponent_has_representative` to replace
-   the abstract representative by the production quotient class.  If two
-   representatives satisfy `section43FourierLaplaceRepresentative` for the
-   same source, their quotient classes are equal by
-   `section43PositiveEnergyQuotientMap_eq_of_eqOn_region`.
+1. Prove the order lemma:
+   ```lean
+   theorem section43DiffCoordRealCLE_symm_mem_orderedPositiveTimeRegion_of_pos_time
+       (d n : ℕ) [NeZero d]
+       {δ : NPointDomain d n}
+       (hδ : ∀ i : Fin n, 0 < δ i 0) :
+       (section43DiffCoordRealCLE d n).symm δ ∈
+         OrderedPositiveTimeRegion d n
+   ```
+   Use `section43DiffCoordRealCLE_symm_apply`: ordered coordinates are partial
+   sums of positive difference times.  First-coordinate positivity is
+   `Finset.sum_pos`; strict ordering follows because the later partial sum is
+   the earlier one plus a nonempty positive block.  If Lean needs it, isolate:
+   ```lean
+   lemma partialSum_strictMono_of_pos
+       {n : ℕ} {a : Fin n → ℝ}
+       (ha : ∀ i, 0 < a i) :
+       StrictMono fun k : Fin n =>
+         ∑ r : Fin (k.val + 1), a ⟨r.val, by omega⟩
+   ```
+	   The concrete strict-order proof should rewrite both finite sums by
+	   `Finset.sum_fin_eq_sum_range`, decompose the larger range with
+	   `Finset.sum_range_add_sum_Ico`, prove the interval
+	   `Finset.Ico (i.val + 1) (j.val + 1)` is nonempty using `i < j`, and close
+	   with `lt_add_of_pos_right` plus `Finset.sum_pos`.  The compiled proof uses
+	   a local Nat-indexed function `fj` for the larger partial sum and rewrites
+	   the smaller partial sum into `fj` before applying
+	   `← Finset.sum_range_add_sum_Ico fj hle`; this is the robust Lean shape
+	   because the dependent coordinate `δ ⟨r, _⟩` needs the `r ≤ j.val` bound
+	   extracted from `r < j.val + 1`.
+2. Define the ordered pushforward source:
+   ```lean
+   noncomputable def section43OrderedSourceOfTimeSpatialSource
+       (d n : ℕ) [NeZero d]
+       (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+       Section43CompactOrderedSource d n
+   ```
+   Carrier:
+   ```lean
+   SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
+     (section43DiffCoordRealCLE d n) G.f
+   ```
+   Ordered support: map support through
+   `tsupport_comp_subset_preimage`, apply `G.positive`, then step 1.
+   Compactness: use `tsupport_comp_eq_preimage`, rewrite the preimage as the
+   image of `tsupport G.f` under `(section43DiffCoordRealCLE d n).symm`, and
+   apply compact image.
+3. Prove the pullback identity:
+   ```lean
+   theorem section43DiffPullbackCLM_orderedSourceOfTimeSpatialSource
+       (d n : ℕ) [NeZero d]
+       (G : Section43CompactStrictPositiveTimeSpatialSource d n) :
+       section43DiffPullbackCLM d n
+         ⟨(section43OrderedSourceOfTimeSpatialSource d n G).f,
+          (section43OrderedSourceOfTimeSpatialSource d n G).ordered⟩ =
+       G.f
+   ```
+   This is an `ext δ` proof using `section43DiffPullbackCLM_apply` and
+   `ContinuousLinearEquiv.apply_symm_apply`.
+4. Convert Layer-3 representatives to OS-I representatives:
+   ```lean
+   theorem section43FourierLaplaceRepresentative_of_timeSpatialRepresentative
+       (d n : ℕ) [NeZero d]
+       {G : Section43CompactStrictPositiveTimeSpatialSource d n}
+       {Ψ : SchwartzNPoint d n}
+       (hΨ :
+         section43TimeLaplaceSpatialFourierRepresentative d n G Ψ) :
+       section43FourierLaplaceRepresentative d n
+         ⟨(section43OrderedSourceOfTimeSpatialSource d n G).f,
+          (section43OrderedSourceOfTimeSpatialSource d n G).ordered⟩ Ψ
+   ```
+   For `q ∈ section43PositiveEnergyRegion`, unfold
+   `section43FourierLaplaceIntegral` and rewrite the pullback by step 3; the
+   resulting integral is exactly `hΨ q hq`.
+5. Prove target containment:
+   ```lean
+   theorem section43TimeLaplaceSpatialFourierTarget_subset_component_preimage
+       (d n : ℕ) [NeZero d] :
+       section43TimeLaplaceSpatialFourierTarget d n ⊆
+         (section43PositiveEnergyQuotientMap (d := d) n) ⁻¹'
+           Set.range (section43FourierLaplaceTransformComponentMap d n)
+   ```
+   Given `Φ` with witness `G, Ψ, hΨ, hΦq`, set
+   `src := section43OrderedSourceOfTimeSpatialSource d n G`.  Step 4 makes
+   `Ψ` a `section43FourierLaplaceRepresentative` for `src`.  Use
+   `section43FourierLaplaceTransformComponent_has_representative` to obtain the
+   chosen component representative `Φc`; quotient equality between `Ψ` and
+   `Φc` follows by `section43PositiveEnergyQuotientMap_eq_of_eqOn_region`.
+   Combine that equality with `hΦq` and provide the range witness `src`.
+6. Conclude by `Dense.mono` from
+   `dense_section43TimeLaplaceSpatialFourier_compact_preimage`.
 
-Finally, prove the production theorem by unfolding the `Section43CompactOrderedSource`
-wrapper:
-
+Production update, 2026-04-18: this ordered-density bridge is compiled in
+`Section43FourierLaplaceOrderedDensity.lean`:
 ```lean
-theorem dense_section43FourierLaplaceTransformComponentMap_preimage
-    (d n : ℕ) [NeZero d] :
-    Dense
-      ((section43PositiveEnergyQuotientMap (d := d) n) ⁻¹'
-        Set.range (section43FourierLaplaceTransformComponentMap d n)) := by
-  -- use `dense_section43FourierLaplace_compact_ordered_preimage_raw`;
-  -- convert the raw existential `(f, hf_ord, hf_compact)` into
-  -- `Section43CompactOrderedSource`;
-  -- unfold `section43FourierLaplaceTransformComponentMap`.
+section43DiffCoordRealCLE_symm_mem_orderedPositiveTimeRegion_of_pos_time
+section43OrderedSourceOfTimeSpatialSource
+section43DiffPullbackCLM_orderedSourceOfTimeSpatialSource
+section43FourierLaplaceRepresentative_of_timeSpatialRepresentative
+section43TimeLaplaceSpatialFourierTarget_subset_component_preimage
+dense_section43FourierLaplace_compact_ordered_preimage_raw
 ```
 
 Implementation guardrails:

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -25027,6 +25027,119 @@ unfolding `partialFourierSpatial_fun`: the fixed-time slice of
 Fourier transform is obtained from `(SchwartzMap.fourierTransformCLM ℂ).map_smul`
 with no manual Fourier-normalization rewrite.
 
+The source-side product construction must use the following Lean-ready support
+packet; this is the next production target after the compiled
+`SchwartzNPoint` tensor-density transport.
+
+First, introduce the time-support control lemma:
+
+```lean
+theorem tsupport_section43NPointTimeSpatialTensor_subset_time_preimage
+    (d n : ℕ) [NeZero d]
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ) :
+    tsupport
+      ((section43NPointTimeSpatialTensor d n φ χ :
+          SchwartzNPoint d n) : NPointDomain d n → ℂ)
+      ⊆
+    (section43QTime (d := d) (n := n)) ⁻¹'
+      tsupport (φ : (Fin n → ℝ) → ℂ)
+```
+
+Proof route: rewrite by `section43NPointTimeSpatialTensor_apply`, apply
+`tsupport_mul_subset_left` to the product
+`φ (section43QTime q) * χ (section43QSpatial q)`, and then use
+`tsupport_comp_subset_preimage` with the continuity supplied by
+`section43QTimeCLM d n`.  In Lean, first insert the explicit function
+equality
+`((section43NPointTimeSpatialTensor d n φ χ : SchwartzNPoint d n) :
+NPointDomain d n → ℂ) = fun q => φ (section43QTime q) *
+χ (section43QSpatial q)` by `funext; simp`, then call
+`tsupport_comp_subset_preimage (φ : (Fin n → ℝ) → ℂ)
+(f := section43QTime (d := d) (n := n)) ...`.
+
+Second, prove compact support without relying on a false generic compact
+preimage statement:
+
+```lean
+theorem hasCompactSupport_section43NPointTimeSpatialTensor
+    (d n : ℕ) [NeZero d]
+    (φ : SchwartzMap (Fin n → ℝ) ℂ)
+    (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+    (hφ : HasCompactSupport (φ : (Fin n → ℝ) → ℂ))
+    (hχ : HasCompactSupport (χ : Section43SpatialSpace d n → ℂ)) :
+    HasCompactSupport
+      ((section43NPointTimeSpatialTensor d n φ χ :
+          SchwartzNPoint d n) : NPointDomain d n → ℂ)
+```
+
+Proof route: set `e := nPointTimeSpatialCLE (d := d) n` and
+`K := e.symm '' (tsupport φ ×ˢ tsupport χ)`.  Compactness is
+`(hφ.isCompact.prod hχ.isCompact).image e.symm.continuous`.  For the support
+subset, if the product value at `q` is nonzero, then both factors are nonzero;
+convert them to topological-support membership with `subset_tsupport _` and
+`Function.mem_support.mpr`, then witness `q ∈ K` by
+`(section43QTime q, section43QSpatial q)`.
+
+Third, define:
+
+```lean
+noncomputable def section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n) :
+    Section43CompactStrictPositiveTimeSpatialSource d n
+```
+
+with underlying function `section43NPointTimeSpatialTensor d n g.f κ.1`.
+The `positive` field is the time-support lemma followed by `g.positive`; the
+`compact` field is the compact-support lemma applied to `g.compact` and
+`κ.2`.
+
+Fourth, prove the fixed-time slice identity before the Fourier identity:
+
+```lean
+theorem partialEval₂_section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n)
+    (τ : Fin n → ℝ) :
+    SchwartzMap.partialEval₂
+      (nPointSpatialTimeSchwartzCLE (d := d) (n := n)
+        (section43TimeSpatialProductSource d n g κ).f) τ =
+    g.f τ • κ.1
+```
+
+Proof route: extensionality in the spatial variable, then simp using
+`nPointSpatialTimeSchwartzCLE_apply` and `smul_eq_mul`.  In compiled Lean this
+is clearest with explicit `change` steps:
+`partialEval₂` becomes evaluation of the spatial-time Schwartz map at
+`(η, τ)`, `nPointSpatialTimeSchwartzCLE_apply` rewrites it to the time-spatial
+value `(τ, η)`, and the transported tensor reduces to
+`section43TimeSpatialTensor d n g.f κ.1 (τ, η)`.  This confirms the
+orientation: `partialEval₂` fixes the time coordinate of the spatial-time
+Schwartz map.
+
+Finally:
+
+```lean
+theorem partialFourierSpatial_fun_section43TimeSpatialProductSource
+    (d n : ℕ) [NeZero d]
+    (g : Section43CompactStrictPositiveTimeSource n)
+    (κ : Section43SpatialCompactSource d n)
+    (τ : Fin n → ℝ) (ξ : Section43SpatialSpace d n) :
+    partialFourierSpatial_fun
+      (d := d) (n := n)
+      (section43TimeSpatialProductSource d n g κ).f
+      (τ, ξ) =
+    g.f τ * (SchwartzMap.fourierTransformCLM ℂ κ.1) ξ
+```
+
+Proof route: unfold `partialFourierSpatial_fun`, rewrite the slice by
+`partialEval₂_section43TimeSpatialProductSource`, apply
+`(SchwartzMap.fourierTransformCLM ℂ).map_smul`, and normalize scalar
+multiplication with `simp [smul_eq_mul]`.
+
 Production status, 2026-04-18: the product-space density half of this Layer-3
 packet is compiled in
 `OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceSpatialDensity.lean`.

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -25571,6 +25571,14 @@ section43TimeLaplaceSpatialFourierTarget_subset_component_preimage
 dense_section43FourierLaplace_compact_ordered_preimage_raw
 ```
 
+Production update, 2026-04-18: the public theorem-3 positivity frontier
+`bvt_W_positive` in `OSToWightmanBoundaryValues.lean` is now closed by applying
+`OSReconstruction.bvt_W_positive_of_component_dense_preimage` to
+`OSReconstruction.dense_section43FourierLaplace_compact_ordered_preimage_raw`.
+This is the planned OS-route endpoint for Section 4.3 positivity: all analysis
+is in the Section 4.3 density/closure files, and the public frontier only
+connects the compiled density theorem to the closed-set positivity bridge.
+
 Implementation guardrails:
 
 1. Do not use `os1TransportComponent`; it is the raw quotient of the Euclidean

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -24897,6 +24897,30 @@ Next stage: prove the finite-product dense-preimage theorem for
 `section43IteratedLaplaceCompactTransform` in a new small companion file rather
 than extending `Section43FourierLaplaceTimeProduct.lean` further.
 
+Updated production status, 2026-04-18: the finite-product dense-preimage stage
+is now compiled in
+`Section43FourierLaplaceTimeProductDensity.lean`.  The new file proves:
+
+```lean
+section43IteratedLaplaceCompactTransform_map_add
+section43IteratedLaplaceCompactTransform_map_smul
+section43IteratedLaplaceCompactTransformLinearMap
+section43TimeProductTensor_mem_iteratedLaplaceCompactTransform_preimage
+dense_section43IteratedLaplaceCompactTransform_preimage
+denseRange_section43IteratedLaplaceCompactTransformLinearMap
+```
+
+The key correction is that the finite-time transform range is used through the
+compiled linear map, so the span-density argument is mathematically sound:
+product tensors with one-variable compact-Laplace preimage factors lie in the
+finite-time preimage, and the finite-time preimage is the comap of the linear
+range submodule under `section43TimePositiveQuotientMap`.
+
+The next stage is not to attack `bvt_W_positive` directly.  First make Layer 3
+implementation-ready: transport the finite-time dense range through the spatial
+Fourier variables and identify the resulting representative with
+`partialFourierSpatial_fun`.
+
 5. The rapid-decay proof must reuse the compiled time-only estimates
    `norm_exp_neg_timePair_le_exp_thickened_margin_sum` and
    `exp_margin_sum_controls_thickened_time_polynomial`; do not introduce a new

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -25271,6 +25271,53 @@ Proof transcript:
    compiled in `Section43FourierLaplaceSpatialDensity.lean`.
 6. Package the time-spatial compact transform as a linear map, or prove the
    representative target is closed under finite linear combinations directly.
+   The next compiled subpacket should first avoid any span closure issue and
+   prove generator containment.  The key quotient lemma is:
+   ```lean
+   theorem section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq
+       (d n : ℕ) [NeZero d]
+       {φ ψ : SchwartzMap (Fin n → ℝ) ℂ}
+       (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+       (hφψ :
+         section43TimePositiveQuotientMap n φ =
+           section43TimePositiveQuotientMap n ψ) :
+       section43PositiveEnergyQuotientMap (d := d) n
+         (section43NPointTimeSpatialTensor d n φ χ) =
+       section43PositiveEnergyQuotientMap (d := d) n
+         (section43NPointTimeSpatialTensor d n ψ χ)
+   ```
+   It is just `section43PositiveEnergyQuotientMap_eq_of_eqOn_region` plus
+   `eqOn_region_of_section43TimePositiveQuotientMap_eq` evaluated at
+   `section43QTime q`.
+
+   Then prove:
+   ```lean
+   theorem section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget
+       (d n : ℕ) [NeZero d]
+       (φ : SchwartzMap (Fin n → ℝ) ℂ)
+       (χ : SchwartzMap (Section43SpatialSpace d n) ℂ)
+       (hφ :
+         φ ∈ ((section43TimePositiveQuotientMap n) ⁻¹'
+           Set.range (section43IteratedLaplaceCompactTransform n)))
+       (hχ : χ ∈ section43SpatialFourierCompactRange d n) :
+       ∃ (G : Section43CompactStrictPositiveTimeSpatialSource d n)
+         (Ψ : SchwartzNPoint d n),
+         section43TimeLaplaceSpatialFourierRepresentative d n G Ψ ∧
+         section43PositiveEnergyQuotientMap (d := d) n
+           (section43NPointTimeSpatialTensor d n φ χ) =
+         section43PositiveEnergyQuotientMap (d := d) n Ψ
+   ```
+   Here `hφ` chooses `g` with
+   `section43IteratedLaplaceCompactTransform n g =
+   section43TimePositiveQuotientMap n φ`, `hχ` chooses `κ`, the representative
+   is the product-source theorem above, and quotient equality follows from
+   `section43IteratedLaplaceCompactTransform_eq_quotient` for
+   `section43IteratedLaplaceSchwartzRepresentative n g`.
+   Production update, 2026-04-18: this generator-containment subpacket is
+   compiled in `Section43FourierLaplaceSpatialDensity.lean`:
+   `section43NPointTimeSpatialTensor_positiveEnergyQuotient_eq_of_timeQuotient_eq`
+   and
+   `section43NPointTimeSpatialTensor_mem_timeLaplaceSpatialFourierTarget`.
    Then the restricted dense span is contained in the target preimage, so
    density follows by `Dense.mono`.
 7. Treat `n = 0` explicitly if the finite-dimensional tensor construction does

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -24756,17 +24756,53 @@ theorem dense_section43IteratedLaplaceCompactTransform_preimage
 with continuity from `isOpenQuotientMap_mkQ`, exactly as in
 `section43PositiveEnergyQuotientMap`.
 
-Proof transcript:
+Updated proof transcript, 2026-04-18:
 
-1. For `n = 0`, the positive orthant is a singleton quotient; choose the
-   degree-zero compact source with the required scalar value.
-2. For `n + 1`, use the already documented iterated one-coordinate formula.
-   Apply the one-variable dense-preimage theorem in the distinguished
-   coordinate and use finite-product / currying continuity to lift the
-   approximation to `Fin (n + 1) → ℝ`.
-3. Iterate over all time coordinates.  This is OS I's Lemma-8.2 induction
-   inside Lemma 4.1; no Wightman support theorem enters.
-4. Keep the target as a quotient by vanishing on `∀ i, 0 ≤ τ i`; this avoids a
+The old coordinate-induction sketch is not implementation-ready and should not
+be used as the Lean route.  The current route is the tensor-density route
+documented in `docs/section43_fourier_laplace_density.md`.
+
+1. Use the compiled one-variable compact-Laplace dense preimage theorem in each
+   factor.
+2. Use the compiled transported product-tensor density theorem
+   `section43_timeProductTensor_span_dense_of_factor_dense`.
+3. Use the compiled product-source support and finite-product Fubini packet:
+   `section43TimeProductSource`,
+   `section43TimeProductSource_integral_eq_product_raw`, and
+   `section43TimeProductTensor_oneSidedLaplaceRepresentative`.
+4. Before defining the full arbitrary-source map
+   `section43IteratedLaplaceCompactTransform`, prove the time-only analogue of
+   `exists_section43FourierLaplaceRepresentative_eq_integral_of_compact_orderedSupport_of_margin`.
+   Its required sublemmas are:
+
+```lean
+section43TimePositiveThickening
+section43TimePositiveCutoff
+section43TimePositiveCutoff_eq_one_of_mem
+section43TimePositiveCutoff_hasTemperateGrowth
+section43TimePositiveCutoff_iteratedFDeriv_support_subset_thickening_one
+section43IteratedLaplaceRaw
+exists_positive_margin_of_compact_time_tsupport_subset_strictPositive
+exists_time_closedBall_of_compact_tsupport
+section43IteratedLaplaceRaw_iteratedFDerivCandidate
+section43IteratedLaplaceRaw_iteratedFDerivCandidate_hasFDerivAt
+section43IteratedLaplaceRaw_iteratedFDeriv_eq_candidate
+section43IteratedLaplaceRaw_contDiff
+section43IteratedLaplaceRaw_iteratedFDeriv_rapid_on_timeThickening
+section43IteratedLaplaceSchwartzRepresentative
+exists_section43IteratedLaplaceRepresentative
+```
+
+5. The rapid-decay proof must reuse the compiled time-only estimates
+   `norm_exp_neg_timePair_le_exp_thickened_margin_sum` and
+   `exp_margin_sum_controls_thickened_time_polynomial`; do not introduce a new
+   analytic route.
+6. After `exists_section43IteratedLaplaceRepresentative` is compiled, define
+   `section43IteratedLaplaceCompactTransform` by choosing this representative,
+   prove `section43IteratedLaplaceCompactTransform_eq_quotient`, and discharge
+   `section43IteratedLaplaceCompactTransform_productSource` by applying the
+   already compiled product-source representative theorem.
+7. Keep the target as a quotient by vanishing on `∀ i, 0 ≤ τ i`; this avoids a
    false support-restricted dense-range theorem.
 
 Third, insert the spatial Fourier transform.  This is a homeomorphism on the


### PR DESCRIPTION
## Summary

- prove the Section 4.3 ordered compact Fourier-Laplace component dense-preimage theorem
- wire the compiled density theorem into the public boundary-values frontier
- close the theorem-3 positivity `bvt_W_positive` production sorry
- update the theorem-3 OS-route proof docs with the compiled endpoint

## Verification

- `lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/Section43FourierLaplaceOrderedDensity.lean`
- `lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean`
- `lake build OSReconstruction.Wightman.Reconstruction.WickRotation.OSToWightmanBoundaryValues`

The narrow module build completed successfully with 8486 jobs. The remaining `sorry` warnings in `OSToWightmanBoundaryValues.lean` are the separate theorem-2 locality and theorem-4 cluster frontiers, not theorem 3.