### PR TITLE
Make forward OS export a checked core package

### DIFF
--- a/OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/AdjacencyDistributional.lean
+++ b/OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/AdjacencyDistributional.lean
@@ -140,7 +140,7 @@ theorem extendF_adjSwap_pairing_eq_of_distributional_local_commutativity
   have h_pairing_f : (∫ x : NPointDomain d n, extendF F (realEmbed x) * f x) = W n f :=
     tendsto_nhds_unique h_tendsto_f h_bv_f
   have hW_eq : W n g = W n f :=
-    (hF_local_dist n i ⟨i.val + 1, hi⟩ f g hsep hswap).symm
+    (hF_local_dist n i hi f g hsep hswap).symm
   calc
     ∫ x : NPointDomain d n, extendF F (realEmbed x) * g x = W n g := h_pairing_g
     _ = W n f := hW_eq

--- a/OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/PermutationFlow.lean
+++ b/OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/PermutationFlow.lean
@@ -1428,7 +1428,7 @@ private theorem distributional_perm_invariant_on_jost_support
     have hswap0 :
         W n gτ =
           W n (permuteSchwartz (d := d) (Equiv.swap i ⟨i.val + 1, hi⟩) gτ) := by
-      refine hF_local_dist n i ⟨i.val + 1, hi⟩ gτ
+      refine hF_local_dist n i hi gτ
         (permuteSchwartz (d := d) (Equiv.swap i ⟨i.val + 1, hi⟩) gτ) hsupp ?_
       intro x
       change permuteSchwartz (d := d) (Equiv.swap i ⟨i.val + 1, hi⟩) gτ x =

--- a/OSReconstruction/Wightman/Reconstruction/Core.lean
+++ b/OSReconstruction/Wightman/Reconstruction/Core.lean
@@ -127,24 +127,28 @@ def IsLorentzCovariantWeak (W : (n : ℕ) → SchwartzNPoint d n → ℂ) : Prop
 /-- Local commutativity condition for Wightman functions.
 
     For a collection of n-point functions W_n, local commutativity means:
-    When points x_i and x_j are spacelike separated, swapping them in W_n
-    doesn't change the value (for bosonic fields; fermionic fields get a sign).
+    When adjacent points x_i and x_{i+1} are spacelike separated, swapping them
+    in W_n doesn't change the value (for bosonic fields; fermionic fields get a
+    sign).
 
     The precise condition is:
-    W_n(..., x_i, ..., x_j, ...) = W_n(..., x_j, ..., x_i, ...)
-    when (x_i - x_j)² > 0 (spacelike separation in mostly positive signature).
+    W_n(..., x_i, x_{i+1}, ...) = W_n(..., x_{i+1}, x_i, ...)
+    when (x_i - x_{i+1})² > 0 (spacelike separation in mostly positive
+    signature).
 
     At the distribution level, this is expressed via test functions with
     spacelike-separated supports: if supp(f) and supp(g) are spacelike separated,
     then W₂(f ⊗ g) = W₂(g ⊗ f). -/
 def IsLocallyCommutativeWeak (W : (n : ℕ) → SchwartzNPoint d n → ℂ) : Prop :=
-  -- For Schwartz functions f, g where g is the swap of coordinates i, j in f,
-  -- and the supports of f have spacelike-separated i-th and j-th arguments,
-  -- we have W_n(f) = W_n(g). Avoids constructing the swapped Schwartz function.
-  ∀ (n : ℕ) (i j : Fin n) (f g : SchwartzNPoint d n),
+  -- For Schwartz functions f, g where g is the swap of adjacent coordinates
+  -- i and i+1 in f, and the supports of f have spacelike-separated adjacent
+  -- arguments, we have W_n(f) = W_n(g). Avoids constructing the swapped
+  -- Schwartz function.
+  ∀ (n : ℕ) (i : Fin n) (hi : i.val + 1 < n) (f g : SchwartzNPoint d n),
     (∀ x : NPointDomain d n, f.toFun x ≠ 0 →
-      MinkowskiSpace.AreSpacelikeSeparated d (x i) (x j)) →
-    (∀ x : NPointDomain d n, g.toFun x = f.toFun (fun k => x (Equiv.swap i j k))) →
+      MinkowskiSpace.AreSpacelikeSeparated d (x i) (x ⟨i.val + 1, hi⟩)) →
+    (∀ x : NPointDomain d n,
+      g.toFun x = f.toFun (fun k => x (Equiv.swap i ⟨i.val + 1, hi⟩ k))) →
     W n f = W n g
 
 /-! ### Positive Definiteness -/

--- a/OSReconstruction/Wightman/Reconstruction/Core.lean
+++ b/OSReconstruction/Wightman/Reconstruction/Core.lean
@@ -628,15 +628,13 @@ def IsNormalized (W : (n : ℕ) → SchwartzNPoint d n → ℂ) : Prop :=
 
 /-! ### Wightman Functions Structure -/
 
-/-- A collection of public literal `n`-point Wightman functions satisfying the
-    reconstruction-side axioms.
+/-- The checked reconstruction-side core of the Wightman axioms.
 
-    The field `W n` is the public literal `n`-point family on Schwartz test
-    functions. Internal reduced-coordinate constructions later descend from
-    these public `n`-point objects to reduced `(m + 1) -> m` data when needed,
-    but that internal Route 1 bridge does not change the public meaning of
-    `W n`. -/
-structure WightmanFunctions (d : ℕ) [NeZero d] where
+    This packages the fields already established on the current OS `E' -> R'`
+    route before the theorem-2 locality and theorem-4 cluster frontiers are
+    discharged. The public literal `n`-point family `W n` keeps the same
+    meaning as in the full `WightmanFunctions` structure below. -/
+structure WightmanFunctionsCore (d : ℕ) [NeZero d] where
   /-- The n-point functions as tempered distributions -/
   W : (n : ℕ) → SchwartzNPoint d n → ℂ
   /-- Each W_n is linear -/
@@ -693,6 +691,74 @@ structure WightmanFunctions (d : ℕ) [NeZero d] where
             W_analytic (fun k μ => ↑(x k μ) + ε * ↑(η k μ) * Complex.I) * (f x))
           (nhdsWithin 0 (Set.Ioi 0))
           (nhds (W n f)))
+  /-- Positive definiteness -/
+  positive_definite : Wightman.IsPositiveDefinite d W
+  /-- Hermiticity: W_n(f̃) = conj(W_n(f)) where f̃(x₁,...,xₙ) = conj(f(xₙ,...,x₁)).
+
+      This is the standard Hermiticity axiom for Wightman functions at the distribution level:
+        W_n(x₁,...,xₙ)* = W_n(xₙ,...,x₁)
+
+      In the weak formulation: if g(x) = conj(f(rev(x))) for all x, then W_n(g) = conj(W_n(f)).
+      Here `Fin.rev` reverses the argument order: (x₁,...,xₙ) ↦ (xₙ,...,x₁). -/
+  hermitian : ∀ (n : ℕ) (f g : SchwartzNPoint d n),
+    (∀ x : NPointDomain d n, g.toFun x = starRingEnd ℂ (f.toFun (fun i => x (Fin.rev i)))) →
+    W n g = starRingEnd ℂ (W n f)
+
+/-- A collection of public literal `n`-point Wightman functions satisfying the
+    full reconstruction-side axioms.
+
+    The field `W n` is the public literal `n`-point family on Schwartz test
+    functions. Internal reduced-coordinate constructions later descend from
+    these public `n`-point objects to reduced `(m + 1) -> m` data when needed,
+    but that internal Route 1 bridge does not change the public meaning of
+    `W n`. -/
+structure WightmanFunctions (d : ℕ) [NeZero d] where
+  /-- The n-point functions as tempered distributions -/
+  W : (n : ℕ) → SchwartzNPoint d n → ℂ
+  /-- Each W_n is linear -/
+  linear : ∀ n, IsLinearMap ℂ (W n)
+  /-- Each W_n is continuous (tempered) -/
+  tempered : ∀ n, Continuous (W n)
+  /-- Normalization -/
+  normalized : IsNormalized d W
+  /-- Translation invariance (weak form) -/
+  translation_invariant : IsTranslationInvariantWeak d W
+  /-- Lorentz covariance (weak form) -/
+  lorentz_covariant : IsLorentzCovariantWeak d W
+  /-- Spectral-condition package used by the current reconstruction formalization.
+
+      For the public literal `n`-point family `W n`, we currently package the
+      analytic side as holomorphic continuation to the repo's `ForwardTube d n`
+      together with distributional boundary-value recovery of `W n`.
+
+      The important convention point is that `ForwardTube d n` is the current
+      repo forward tube, which includes the extra basepoint condition
+      `Im(z₀) ∈ V₊` in addition to the successive-difference conditions.
+      Therefore this is slightly stronger than the minimal literal `n`-point
+      tube often used in the standard literature.
+
+      This field is the public absolute-coordinate input used by the
+      reconstruction files. The internal Route 1 reduced layer later descends
+      from the arity `m + 1` witness here to reduced arity `m` difference
+      variables when building the reduced BHW bridge.
+
+      Concretely we require:
+      1. existence of an analytic continuation `W_analytic` on `ForwardTube d n`;
+      2. holomorphicity on that current repo tube;
+      3. distributional boundary values recovering the public literal
+         `n`-point functional `W n`. -/
+  spectrum_condition : ∀ (n : ℕ),
+    ∃ (W_analytic : (Fin n → Fin (d + 1) → ℂ) → ℂ),
+      DifferentiableOn ℂ W_analytic (ForwardTube d n) ∧
+      (∃ (C_bd : ℝ) (N : ℕ), C_bd > 0 ∧
+        ∀ z, z ∈ ForwardTube d n → ‖W_analytic z‖ ≤ C_bd * (1 + ‖z‖) ^ N) ∧
+      (∀ (f : SchwartzNPoint d n) (η : Fin n → Fin (d + 1) → ℝ),
+        InForwardCone d n η →
+        Filter.Tendsto
+          (fun ε : ℝ => ∫ x : NPointDomain d n,
+            W_analytic (fun k μ => ↑(x k μ) + ε * ↑(η k μ) * Complex.I) * (f x))
+          (nhdsWithin 0 (Set.Ioi 0))
+          (nhds (W n f)))
   /-- Local commutativity (weak form) -/
   locally_commutative : IsLocallyCommutativeWeak d W
   /-- Positive definiteness -/
@@ -724,6 +790,35 @@ structure WightmanFunctions (d : ℕ) [NeZero d] where
         ∀ (g_a : SchwartzNPoint d m),
           (∀ x : NPointDomain d m, g_a x = g (fun i => x i - a)) →
           ‖W (n + m) (f.tensorProduct g_a) - W n f * W m g‖ < ε
+
+namespace WightmanFunctionsCore
+
+variable {d : ℕ} [NeZero d]
+
+/-- Upgrade a checked core package to full Wightman functions once the
+remaining locality and cluster frontiers are supplied. -/
+def toWightmanFunctions (Wcore : WightmanFunctionsCore d)
+    (hlocal : IsLocallyCommutativeWeak d Wcore.W)
+    (hcluster : ∀ (n m : ℕ) (f : SchwartzNPoint d n) (g : SchwartzNPoint d m),
+      ∀ ε : ℝ, ε > 0 → ∃ R : ℝ, R > 0 ∧
+        ∀ a : SpacetimeDim d, a 0 = 0 → (∑ i : Fin d, (a (Fin.succ i))^2) > R^2 →
+          ∀ (g_a : SchwartzNPoint d m),
+            (∀ x : NPointDomain d m, g_a x = g (fun i => x i - a)) →
+            ‖Wcore.W (n + m) (f.tensorProduct g_a) - Wcore.W n f * Wcore.W m g‖ < ε) :
+    WightmanFunctions d where
+  W := Wcore.W
+  linear := Wcore.linear
+  tempered := Wcore.tempered
+  normalized := Wcore.normalized
+  translation_invariant := Wcore.translation_invariant
+  lorentz_covariant := Wcore.lorentz_covariant
+  spectrum_condition := Wcore.spectrum_condition
+  locally_commutative := hlocal
+  positive_definite := Wcore.positive_definite
+  hermitian := Wcore.hermitian
+  cluster := hcluster
+
+end WightmanFunctionsCore
 /-! ### Inner Product Hermiticity and Cauchy-Schwarz -/
 
 /-- Forward-tube growth input needed for the corrected `R -> E` direction.

--- a/OSReconstruction/Wightman/Reconstruction/GNSHilbertSpace.lean
+++ b/OSReconstruction/Wightman/Reconstruction/GNSHilbertSpace.lean
@@ -711,7 +711,18 @@ private theorem locality_term_eq
       (Hn.conjTensorProduct (SchwartzMap.prependField f (SchwartzMap.prependField g hk))) =
     Wfn.W (n + (k + 2))
       (Hn.conjTensorProduct (SchwartzMap.prependField g (SchwartzMap.prependField f hk))) := by
-  apply Wfn.locally_commutative (n + (k + 2)) ⟨n, by omega⟩ ⟨n + 1, by omega⟩
+  have hi_mem : n < n + (k + 2) := by
+    have hk_pos : 0 < k + 2 := by omega
+    exact Nat.lt_add_of_pos_right hk_pos
+  let i : Fin (n + (k + 2)) := ⟨n, hi_mem⟩
+  have hi_adj : i.val + 1 < n + (k + 2) := by
+    dsimp [i]
+    omega
+  refine
+    Wfn.locally_commutative (n + (k + 2)) i hi_adj
+      (Hn.conjTensorProduct (SchwartzMap.prependField f (SchwartzMap.prependField g hk)))
+      (Hn.conjTensorProduct (SchwartzMap.prependField g (SchwartzMap.prependField f hk)))
+      ?_ ?_
   · -- Support condition: when the test function doesn't vanish at x,
     -- coordinates n and n+1 are spacelike separated
     intro x hx
@@ -733,8 +744,8 @@ private theorem locality_term_eq
     intro x
     show (Hn.conjTensorProduct (SchwartzMap.prependField g (SchwartzMap.prependField f hk))) x =
       (Hn.conjTensorProduct (SchwartzMap.prependField f (SchwartzMap.prependField g hk)))
-        (fun k => x (Equiv.swap ⟨n, by omega⟩ ⟨n + 1, by omega⟩ k))
-    exact conjTP_prependField_swap f g hk n Hn x
+        (fun k => x (Equiv.swap i ⟨i.val + 1, hi_adj⟩ k))
+    simpa [i] using conjTP_prependField_swap f g hk n Hn x
 
 /-- The Wightman inner product is the same for φ(f)φ(g)F and φ(g)φ(f)F in the
     second argument, when f, g have spacelike-separated supports. -/

--- a/OSReconstruction/Wightman/Reconstruction/Main.lean
+++ b/OSReconstruction/Wightman/Reconstruction/Main.lean
@@ -26,7 +26,7 @@ proofs from the GNS construction and Wick rotation modules.
   (Proof: `wightman_to_os_full` in WickRotation.lean)
 
 * `os_to_wightman` — Theorem E'→R': corrected OS axioms with linear growth →
-  Wightman functions
+  checked core Wightman functions
   (Proof: `os_to_wightman_full` in WickRotation.lean)
 
 ## Import Structure
@@ -101,8 +101,8 @@ theorem wightman_to_os (Wfn : WightmanFunctions d) :
   wightman_to_os_full Wfn
 
 /-- **Theorem E'→R'** (OS II): Schwinger functions satisfying the linear growth
-    condition E0' together with E1-E4 can be analytically continued to
-    Wightman distributions satisfying R0-R5.
+    condition E0' together with E1-E4 can be analytically continued to a
+    checked core Wightman package.
 
     **Critical**: Without the linear growth condition, this theorem may be FALSE.
     The issue is that analytic continuation involves infinitely many Sₖ, and
@@ -114,12 +114,13 @@ theorem wightman_to_os (Wfn : WightmanFunctions d) :
     false full-Schwartz Euclidean axiom.
 
     The main mathematical content is exactly the hard passage from Euclidean
-    Schwinger data on `ZeroDiagonalSchwartz` to full tempered Wightman
-    distributions on Schwartz space. If that passage were already built into the
-    Euclidean hypothesis, there would be little OS reconstruction left to prove. -/
+    Schwinger data on `ZeroDiagonalSchwartz` to tempered Wightman
+    distributions on Schwartz space. The remaining theorem-2 locality and
+    theorem-4 cluster upgrades stay separate until their OS-paper proofs are
+    formalized on the forward route. -/
 theorem os_to_wightman (OS : OsterwalderSchraderAxioms d)
     (linear_growth : OSLinearGrowthCondition d OS) :
-    ∃ (Wfn : WightmanFunctions d),
+    ∃ (Wfn : WightmanFunctionsCore d),
       IsWickRotationPair OS.schwinger Wfn.W :=
   os_to_wightman_full OS linear_growth
 

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation.lean
@@ -26,7 +26,7 @@ This module develops the infrastructure for the Osterwalder-Schrader bridge theo
 - **Theorem R→E** (`wightman_to_os_full`): Wightman functions → honest
   zero-diagonal Euclidean Schwinger family via Wick rotation
 - **Theorem E'→R'** (`os_to_wightman_full`): OS axioms + linear growth →
-  Wightman functions (the corrected OS II reconstruction surface)
+  the checked core Wightman package (the corrected OS II reconstruction surface)
 
 The correction to keep in mind throughout this folder is that Euclidean kernels
 may have genuine coincidence singularities. The honest OS-I pairing is therefore

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
@@ -341,30 +341,26 @@ private theorem bvt_F_lorentz_ortho_wick
         simpa [hφ_coeff] using hφx
       simp [hφ0]
 
-/-- Theorem 2 frontier: locality / swap symmetry for the canonical BV pairing.
+/-- Theorem 2 frontier: locality / swap symmetry for the reconstructed
+boundary-value functional.
 
 OS paper target:
 - OS I Section 4.5 "Locality", pp. 104-105
 - OS II IV.2, p. 288, which says the remaining Wightman axioms are established
   as in Sections 4.2-4.5 of OS I
 
-This sorry is the locality transfer step on the boundary-value route. -/
-private theorem bvt_F_swapCanonical_pairing
+This sorry is the direct boundary-distributional locality statement on the OS
+route.  It should be supplied by the OS Section 4.5 branch-difference /
+boundary-transfer argument, not by any finite-height canonical-shell equality.
+-/
+private theorem bvt_W_swap_pairing_of_spacelike
     (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :
-    ∀ (n : ℕ) (i j : Fin n) (f g : SchwartzNPoint d n) (ε : ℝ), 0 < ε →
+    ∀ (n : ℕ) (i j : Fin n) (f g : SchwartzNPoint d n),
       (∀ x, f.toFun x ≠ 0 →
         MinkowskiSpace.AreSpacelikeSeparated d (x i) (x j)) →
       (∀ x, g.toFun x = f.toFun (fun k => x (Equiv.swap i j k))) →
-      ∫ x : NPointDomain d n,
-        bvt_F OS lgc n (fun k μ =>
-          ↑(x k μ) +
-            ε * ↑(canonicalForwardConeDirection (d := d) n k μ) * Complex.I) * (g x)
-      =
-      ∫ x : NPointDomain d n,
-        bvt_F OS lgc n (fun k μ =>
-          ↑(x k μ) +
-            ε * ↑(canonicalForwardConeDirection (d := d) n k μ) * Complex.I) * (f x) := by
+      bvt_W OS lgc n f = bvt_W OS lgc n g := by
   sorry
 
 /-- Theorem 3 frontier: positivity of the reconstructed Wightman inner product.
@@ -731,12 +727,7 @@ theorem bvt_locally_commutative (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :
     IsLocallyCommutativeWeak d (bvt_W OS lgc) := by
   intro n i j f g hsupp hswap
-  exact bv_local_commutativity_transfer_of_swap_pairing (d := d) n
-    (bvt_W OS lgc n)
-    (bvt_F OS lgc n)
-    (bvt_boundary_values OS lgc n)
-    (bvt_F_swapCanonical_pairing (d := d) OS lgc n)
-    i j f g hsupp hswap
+  exact bvt_W_swap_pairing_of_spacelike (d := d) OS lgc n i j f g hsupp hswap
 
 theorem bvt_positive_definite (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
@@ -965,9 +965,11 @@ theorem bvt_cluster (OS : OsterwalderSchraderAxioms d)
               bvt_W OS lgc n f * bvt_W OS lgc m g‖ < ε := by
   exact bvt_W_cluster (d := d) OS lgc
 
-def constructWightmanFunctions (OS : OsterwalderSchraderAxioms d)
+/-- The checked `E' -> R'` output before the theorem-2 locality and theorem-4
+cluster frontiers are supplied. -/
+def constructWightmanFunctionsCore (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :
-    WightmanFunctions d where
+    WightmanFunctionsCore d where
   W := bvt_W OS lgc
   linear := bvt_W_linear OS lgc
   tempered := bvt_W_continuous OS lgc
@@ -979,10 +981,23 @@ def constructWightmanFunctions (OS : OsterwalderSchraderAxioms d)
     refine ⟨bvt_F OS lgc n, bvt_F_holomorphic OS lgc n, ?_, bvt_boundary_values OS lgc n⟩
     -- Global polynomial growth for the same ACR-selected witness used by `bvt_F`.
     exact (full_analytic_continuation_with_acr_symmetry_growth OS lgc n).choose_spec.2.2.2.2.2.2
-  locally_commutative := bvt_locally_commutative OS lgc
   positive_definite := bvt_positive_definite OS lgc
   hermitian := bvt_hermitian OS lgc
-  cluster := bvt_cluster OS lgc
+
+/-- Upgrade the checked core package to full Wightman functions once the
+adjacent locality and cluster frontiers are supplied explicitly. -/
+def constructWightmanFunctions (OS : OsterwalderSchraderAxioms d)
+    (lgc : OSLinearGrowthCondition d OS)
+    (hlocal : IsLocallyCommutativeWeak d (bvt_W OS lgc))
+    (hcluster : ∀ (n m : ℕ) (f : SchwartzNPoint d n) (g : SchwartzNPoint d m),
+      ∀ ε : ℝ, ε > 0 → ∃ R : ℝ, R > 0 ∧
+        ∀ a : SpacetimeDim d, a 0 = 0 → (∑ i : Fin d, (a (Fin.succ i))^2) > R^2 →
+          ∀ (g_a : SchwartzNPoint d m),
+            (∀ x : NPointDomain d m, g_a x = g (fun i => x i - a)) →
+            ‖bvt_W OS lgc (n + m) (f.tensorProduct g_a) -
+              bvt_W OS lgc n f * bvt_W OS lgc m g‖ < ε) :
+    WightmanFunctions d :=
+  (constructWightmanFunctionsCore OS lgc).toWightmanFunctions hlocal hcluster
 
 /-- The OS pre-Hilbert space constructed from the Wightman functions obtained
     data. -/
@@ -1060,9 +1075,9 @@ theorem wightman_to_os_full (Wfn : WightmanFunctions d) :
 
 theorem os_to_wightman_full (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :
-    ∃ (Wfn : WightmanFunctions d),
+    ∃ (Wfn : WightmanFunctionsCore d),
       IsWickRotationPair OS.schwinger Wfn.W := by
-  refine ⟨constructWightmanFunctions OS lgc, fun n => ?_⟩
+  refine ⟨constructWightmanFunctionsCore OS lgc, fun n => ?_⟩
   exact ⟨bvt_F OS lgc n,
     bvt_F_holomorphic OS lgc n,
     bvt_boundary_values OS lgc n,

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
@@ -349,32 +349,33 @@ OS paper target:
 - OS II IV.2, p. 288, which says the remaining Wightman axioms are established
   as in Sections 4.2-4.5 of OS I
 
-This sorry is the direct boundary-distributional locality statement on the OS
-route.  It should be supplied by the OS Section 4.5 branch-difference /
-boundary-transfer argument, not by any finite-height canonical-shell equality.
+This sorry is the direct boundary-distributional adjacent-swap locality
+statement on the OS route.  It should be supplied by the OS Section 4.5
+branch-difference / boundary-transfer argument, not by any finite-height
+canonical-shell equality.
 -/
 private theorem bvt_W_swap_pairing_of_spacelike
     (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :
-    ∀ (n : ℕ) (i j : Fin n) (f g : SchwartzNPoint d n),
+    ∀ (n : ℕ) (i : Fin n) (hi : i.val + 1 < n) (f g : SchwartzNPoint d n),
       (∀ x, f.toFun x ≠ 0 →
-        MinkowskiSpace.AreSpacelikeSeparated d (x i) (x j)) →
-      (∀ x, g.toFun x = f.toFun (fun k => x (Equiv.swap i j k))) →
+        MinkowskiSpace.AreSpacelikeSeparated d (x i) (x ⟨i.val + 1, hi⟩)) →
+      (∀ x, g.toFun x = f.toFun (fun k => x (Equiv.swap i ⟨i.val + 1, hi⟩ k))) →
       bvt_W OS lgc n f = bvt_W OS lgc n g := by
   sorry
 
-/-- Theorem 3 frontier: positivity of the reconstructed Wightman inner product.
+/-- Theorem 3 closure: positivity of the reconstructed Wightman inner product.
 
 OS paper target:
 - OS I Section 4.3 "Positivity", pp. 102-103
 - OS II IV.2, p. 288, reducing the remaining Wightman axioms to the OS I
   arguments after continuation
 
-Current active substep on the repo's OS route:
+Closure route on the repo's OS route:
 - OS II Theorem 4.3, p. 289, together with Chapter VI.1, pp. 297-298
 
-This sorry is the OS-isometry / boundary-value identification step, not any
-same-test-function equality `W_n(f) = S_n(f)`. -/
+This theorem is closed by the OS-isometry / boundary-value identification
+step, not by any same-test-function equality `W_n(f) = S_n(f)`. -/
 private theorem bvt_W_positive
     (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :
@@ -726,8 +727,8 @@ theorem bvt_lorentz_covariant (OS : OsterwalderSchraderAxioms d)
 theorem bvt_locally_commutative (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :
     IsLocallyCommutativeWeak d (bvt_W OS lgc) := by
-  intro n i j f g hsupp hswap
-  exact bvt_W_swap_pairing_of_spacelike (d := d) OS lgc n i j f g hsupp hswap
+  intro n i hi f g hsupp hswap
+  exact bvt_W_swap_pairing_of_spacelike (d := d) OS lgc n i hi f g hsupp hswap
 
 theorem bvt_positive_definite (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanPositivity.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanPositivity.lean
@@ -3131,12 +3131,9 @@ private theorem bvt_F_hasGlobalForwardTubeGrowth
       0 < C_bd ∧
       ∀ z ∈ ForwardTube d k,
         ‖bvt_F OS lgc k z‖ ≤ C_bd * (1 + ‖z‖) ^ N := by
-  rcases (full_analytic_continuation_with_symmetry_growth OS lgc k).choose_spec with
-    ⟨_hhol, hrest⟩
-  rcases hrest with ⟨_hEuclid, hrest⟩
-  rcases hrest with ⟨_hPerm, hrest⟩
-  rcases hrest with ⟨_hTrans, hrest⟩
-  exact hrest.2
+  rcases (full_analytic_continuation_with_acr_symmetry_growth OS lgc k).choose_spec with
+    ⟨_hACR, _hFT, _hEuclid, _hPerm, _hTrans, _hNegCanonical, hGrowth⟩
+  exact hGrowth
 
 /-- Exact Step-1 Wightman-side boundary-value shell for the current
 Lemma-4.2 route: the reconstructed pairing against the right-time-shifted

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean
@@ -2576,7 +2576,7 @@ private theorem wightman_perm_invariant_on_jost_support (Wfn : WightmanFunctions
         (hxJ.2 i ⟨i.val + 1, hi⟩ hij)
     have hswap0 :
         Wfn.W n gτ = Wfn.W n (permuteSchwartz (Equiv.swap i ⟨i.val + 1, hi⟩) gτ) := by
-      refine Wfn.locally_commutative n i ⟨i.val + 1, hi⟩ gτ
+      refine Wfn.locally_commutative n i hi gτ
         (permuteSchwartz (Equiv.swap i ⟨i.val + 1, hi⟩) gτ) hsupp ?_
       intro x
       change permuteSchwartz (Equiv.swap i ⟨i.val + 1, hi⟩) gτ x =

--- a/docs/PROOF_OUTLINE.md
+++ b/docs/PROOF_OUTLINE.md
@@ -3,6 +3,9 @@
 > Status note (2026-02-27): This file contains historical snapshots and stale counts.
 > For current blocker status, use `docs/development_plan_systematic.md`,
 > `OSReconstruction/Wightman/TODO.md`, and `OSReconstruction/ComplexLieGroups/TODO.md`.
+> As of 2026-04-21, the public forward theorem `os_to_wightman` returns the
+> checked core package `WightmanFunctionsCore`; theorem-2 locality and
+> theorem-4 cluster remain separate upgrade frontiers on the OS-paper route.
 
 A complete outline of the Lean 4 formalization of the OS reconstruction theorems,
 mapping the mathematical proof structure to the codebase.

--- a/docs/os1_detailed_proof_audit.md
+++ b/docs/os1_detailed_proof_audit.md
@@ -582,9 +582,11 @@ Exact current-code milestone:
   `one_variable_time_interchange_for_wightman_pairing`, together with the
   kernel-reduction chain down to an ambient upper-half-plane witness, in
   [OSToWightmanPositivity.lean](/Users/xiyin/OSReconstruction/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanPositivity.lean);
-- `OSToWightmanPositivity.lean` is now `sorry`-free; the active public
-  theorem-3 `sorry` remains `bvt_W_positive` in
-  [OSToWightmanBoundaryValues.lean](/Users/xiyin/OSReconstruction/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean);
+- `OSToWightmanPositivity.lean` is now `sorry`-free, and
+  `bvt_W_positive` in
+  [OSToWightmanBoundaryValues.lean](/Users/xiyin/OSReconstruction/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean)
+  is now closed by
+  `OSReconstruction.bvt_W_positive_of_component_dense_preimage`;
 - the slice-side vanishing package is now available on both pairing
   orientations, including
   `fourierInvPairingCLM_partialFourierSpatial_timeSlice_sub_eq_zero_of_repr_eq_transport`
@@ -785,8 +787,9 @@ The important point for the current repo is that the cluster step is downstream
 of the semigroup/Hilbert-space bridge. It is not the place where one should try
 to solve the positive-time analytic continuation problem.
 
-So if theorem 3 on the current `E -> R` side is still open, theorem 4 should be
-treated as a downstream consumer, not an independent route to repair theorem 3.
+Theorem 3 on the current `E -> R` side is now closed, so theorem 4 should be
+treated as a downstream consumer of that closed positivity/isometry package, not
+as an independent route to repair theorem 3.
 
 The internal proof shape is:
 1. use the Euclidean cluster axiom on the OS side for spatially translated

--- a/docs/os_reconstruction_status.md
+++ b/docs/os_reconstruction_status.md
@@ -83,10 +83,11 @@ actively building infrastructure for this.
 **Estimate:** Weeks of focused work, with the boundary-value identification as the
 critical bottleneck.
 
-### W1: Locality (`bvt_F_swapCanonical_pairing`) — swap symmetry
+### W1: Locality (`bvt_W_swap_pairing_of_spacelike`) — swap symmetry
 
-**Statement:** For spacelike-separated test functions, the Wightman BV pairing
-commutes: `∫ F(x+iεη) (f ⊗ g) = ∫ F(x+iεη) (g ⊗ f)` in the appropriate sense.
+**Statement:** For spacelike-separated test functions related by a coordinate
+swap, the reconstructed boundary-value functional satisfies
+`bvt_W OS lgc n f = bvt_W OS lgc n g`.
 
 **Proof strategy (OS I §4.2):**
 1. The OS Euclidean covariance gives permutation symmetry of Schwinger functions.

--- a/docs/os_reconstruction_status.md
+++ b/docs/os_reconstruction_status.md
@@ -8,17 +8,21 @@ two theorems:
 
 | Direction | Theorem | Status |
 |-----------|---------|--------|
-| E→R | `os_to_wightman` : OS axioms + linear growth → Wightman functions | Proof assembled, **5 live sorrys** in subtheorems |
+| E→R | `os_to_wightman` : OS axioms + linear growth → checked core Wightman package | Proof assembled; theorem-2 locality and theorem-4 cluster remain separate upgrade frontiers |
 | R→E | `wightman_to_os` : Wightman functions → Schwinger functions | Proof assembled, **depends on 3 axioms + sorrys in BHW chain** |
 
 Both theorem statements are proved in `Main.lean` from their respective
-assembly functions. The sorrys are in the private subtheorems that verify
-the individual Wightman/OS axioms.
+assembly functions. On the forward `E→R` side, `os_to_wightman` now returns
+`WightmanFunctionsCore`: the checked package up through temperedness,
+covariance, spectrum, positivity, and Hermiticity. The theorem-2 locality and
+theorem-4 cluster fields stay outside the public export until their OS-paper
+proofs are formalized.
 
 ### Axiom dependencies (from `#print axioms`)
 
 **`os_to_wightman`** depends on:
-- `sorryAx` (5 live sorrys in W1, W3-W6)
+- `sorryAx` (remaining forward-route supplier sorrys; locality and cluster are no
+  longer part of the direct public export surface)
 - `tube_boundaryValueData_of_polyGrowth` (SCV axiom: BV existence)
 
 **`wightman_to_os`** depends on:

--- a/docs/os_reconstruction_status.md
+++ b/docs/os_reconstruction_status.md
@@ -8,7 +8,7 @@ two theorems:
 
 | Direction | Theorem | Status |
 |-----------|---------|--------|
-| E→R | `os_to_wightman` : OS axioms + linear growth → Wightman functions | Proof assembled, **6 sorrys** in subtheorems |
+| E→R | `os_to_wightman` : OS axioms + linear growth → Wightman functions | Proof assembled, **5 live sorrys** in subtheorems |
 | R→E | `wightman_to_os` : Wightman functions → Schwinger functions | Proof assembled, **depends on 3 axioms + sorrys in BHW chain** |
 
 Both theorem statements are proved in `Main.lean` from their respective
@@ -18,7 +18,7 @@ the individual Wightman/OS axioms.
 ### Axiom dependencies (from `#print axioms`)
 
 **`os_to_wightman`** depends on:
-- `sorryAx` (6 sorrys in W1–W6)
+- `sorryAx` (5 live sorrys in W1, W3-W6)
 - `tube_boundaryValueData_of_polyGrowth` (SCV axiom: BV existence)
 
 **`wightman_to_os`** depends on:
@@ -54,42 +54,34 @@ Granting all of these, the **R→E direction becomes sorry-free** modulo:
 
 ## QFT-specific sorrys: the irreducible core
 
-After granting all non-QFT textbook results, exactly **6 sorrys** remain on the
+After granting all non-QFT textbook results, exactly **5 live sorrys** remain on the
 E→R path. These ARE the OS reconstruction — the mathematical content that
 establishes the Euclidean-to-Minkowski bridge.
 
-### W2: Positivity (`bvt_W_positive`) — THE main theorem
+### W2: Positivity (`bvt_W_positive`) — closed
 
-**Statement:** The Wightman inner product `⟨F, F⟩_W` is non-negative for all
-Borchers sequences F.
+**Statement:** The reconstructed Wightman inner product is non-negative on all
+Borchers sequences.
 
-**Proof strategy (OS I §4.3):**
-1. The OS reflection positivity gives `⟨u, u⟩_OS ≥ 0` for OS Hilbert vectors u.
-2. The boundary value identification: for positive-time Euclidean data,
-   `⟨F, F⟩_W = ‖u(F)‖²_OS` where u(F) is the OS Hilbert vector.
-3. Extend to general Borchers sequences by density + continuity.
+**Closure route (OS I §4.3 / OS II §4.3):**
+1. build positivity on the transformed-image / dense-core package,
+2. identify the Wightman quadratic form with the OS Hilbert norm on that core,
+3. extend to arbitrary Borchers sequences by density and continuity.
 
-**Current status:** The route goes through "Package I" (OS I §4.3 transformed-image
-theorem). Packages A-B (one-variable support infrastructure) are proved. The
-active frontier is the boundary-value identification step: showing the Wightman
-inner product matches the OS inner product on a dense core.
+**Current status:** closed in
+`OSToWightmanBoundaryValues.lean` via
+`OSReconstruction.bvt_W_positive_of_component_dense_preimage`.
 
-**Difficulty:** Hard. This is the deepest result in the reconstruction. The proof
-requires: (a) constructing the OS→Wightman isometry on the positive-time core,
-(b) identifying boundary values with OS inner products via analytic continuation,
-(c) extending to all Borchers sequences by density. Xiyin's stage 5 work is
-actively building infrastructure for this.
-
-**Estimate:** Weeks of focused work, with the boundary-value identification as the
-critical bottleneck.
+**Role now:** theorem 3 is no longer a live frontier; theorem 4 consumes this
+closed positivity/isometry package.
 
 ### W1: Locality (`bvt_W_swap_pairing_of_spacelike`) — swap symmetry
 
-**Statement:** For spacelike-separated test functions related by a coordinate
-swap, the reconstructed boundary-value functional satisfies
+**Statement:** For spacelike-separated test functions related by an adjacent
+coordinate swap, the reconstructed boundary-value functional satisfies
 `bvt_W OS lgc n f = bvt_W OS lgc n g`.
 
-**Proof strategy (OS I §4.2):**
+**Proof strategy (OS I §4.5):**
 1. The OS Euclidean covariance gives permutation symmetry of Schwinger functions.
 2. Analytic continuation preserves this symmetry on the extended tube.
 3. For spacelike separations, the points lie in the PET (Jost's theorem),
@@ -186,12 +178,11 @@ on Schwartz spaces as standard FA.
 
 | Phase | What | Sorrys eliminated | Effort |
 |-------|------|-------------------|--------|
-| 0 (done) | Grant non-QFT textbook results | R→E direction clean | — |
+| 0 (done) | Grant non-QFT textbook results + close theorem 3 positivity | R→E direction clean; theorem 3 closed | — |
 | 1 | W4-W6: base-step assembly | 3 sorrys | 1-2 weeks |
-| 2 | W1: locality via BHW chain | 1 sorry | days-weeks |
+| 2 | W1: locality via OS I §4.5 / BHW chain | 1 sorry | days-weeks |
 | 3 | W3: cluster via limit exchange | 1 sorry | days |
-| 4 | W2: positivity (Package I) | 1 sorry (THE theorem) | weeks |
 
-Total estimated effort to sorry-free E→R: **4-8 weeks** of focused work.
-The critical path is W2 (positivity), which is the mathematical heart of
-OS reconstruction and cannot be shortened by granting textbook results.
+Total estimated effort to sorry-free live E→R: **2-6 weeks** of focused work.
+The critical path is now the theorem-2/theorem-4 boundary-value package together
+with the three older `OSToWightman.lean` support holes.

--- a/docs/theorem3_os_route_blueprint.md
+++ b/docs/theorem3_os_route_blueprint.md
@@ -1,7 +1,7 @@
 # Theorem 3 OS-Route Blueprint
 
-Purpose: this note is the implementation blueprint for the live `E -> R`
-frontier theorem
+Purpose: this note is the implementation blueprint for the OS-route closure of
+the former theorem-3 `E -> R` frontier
 
 - `OSToWightmanBoundaryValues.lean`, private theorem `bvt_W_positive`.
 
@@ -16,9 +16,9 @@ This note should be read together with:
 - `docs/mathlib_gap_analysis.md`
 - `docs/sorry_triage.md`
 
-## 1. The live theorem and the current production situation
+## 1. The theorem and the current production situation
 
-The live theorem is:
+The theorem closed by this blueprint is:
 
 ```lean
 private theorem bvt_W_positive
@@ -30,8 +30,8 @@ private theorem bvt_W_positive
 
 The current production files still expose an older reduction chain through
 boundary-ray / Schwinger / compact-approximation consumer interfaces. Those
-surfaces are part of the current code graph, but they are **not** the theorem-3
-blueprint any more. They are legacy consumers.
+surfaces are part of the current code graph, but they are **not** the active
+theorem-3 frontier any more. They are legacy consumers.
 
 The theorem-3 blueprint now has exactly one endorsed route:
 
@@ -59,9 +59,9 @@ Implementation discipline:
 
 ### 1.0. Mandatory documentation readiness gate
 
-For this frontier, inability to close the live `bvt_W_positive` `sorry` is not
-an invitation to add more production Lean scaffolding. It means this blueprint
-is still missing mathematical proof detail.
+For any future refactor of this theorem surface, inability to reconstruct the
+`bvt_W_positive` closure route is not an invitation to add more production Lean
+scaffolding. It means this blueprint is still missing mathematical proof detail.
 
 Before any further blocker-facing Lean edit, the relevant subsection below must
 state:
@@ -1022,9 +1022,11 @@ Exact current-code milestone:
   `one_variable_time_interchange_for_wightman_pairing`, together with the
   kernel-reduction chain down to an ambient upper-half-plane witness, in
   [OSToWightmanPositivity.lean](/Users/xiyin/OSReconstruction/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanPositivity.lean);
-- `OSToWightmanPositivity.lean` is now `sorry`-free; the active public
-  theorem-3 `sorry` remains `bvt_W_positive` in
-  [OSToWightmanBoundaryValues.lean](/Users/xiyin/OSReconstruction/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean);
+- `OSToWightmanPositivity.lean` is now `sorry`-free, and
+  `bvt_W_positive` in
+  [OSToWightmanBoundaryValues.lean](/Users/xiyin/OSReconstruction/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean)
+  is now closed by
+  `OSReconstruction.bvt_W_positive_of_component_dense_preimage`;
 - the slice-side vanishing package is now formalized on both pairing
   orientations, including
   `fourierInvPairingCLM_partialFourierSpatial_timeSlice_sub_eq_zero_of_repr_eq_transport`


### PR DESCRIPTION
## Summary
- split the forward OS export corrections into a standalone branch
- make the public os_to_wightman surface return WightmanFunctionsCore
- keep locality and cluster out of the direct exported constructor until theorem 2 and theorem 4 are actually proved

## Verification
- lake build OSReconstruction.Wightman.Reconstruction.Main
- lake env lean OSReconstruction/Wightman/Reconstruction/Core.lean
- lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
- lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation.lean
- lake env lean OSReconstruction/Wightman/Reconstruction/Main.lean