### PR TITLE
Refactor false OS-W bridge theorem surface

### DIFF
--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean
@@ -2345,89 +2345,43 @@ private theorem hermitianRealOverlap_nonempty_of_two_le
     ⟨x, _, hxET, hrevET⟩
   exact ⟨x, hxET, by simpa [BHW.realEmbed] using hrevET⟩
 
-/-- Each (n,m)-term of the OS inner product with the constructed Schwinger functions
-    equals the corresponding term of the Wightman inner product.
+/-- Reflection positivity for the Wick-restricted Schwinger family.
 
-    The proof uses three key ingredients:
-    1. **Change of variables** (time reflection θ in first n coordinates):
-       converts osConj(f_n) = conj(f_n(θ·)) to conj(f_n(·)), and changes
-       F_ext evaluation from forward-tube to backward-tube for first n args.
+    This is the honest replacement for the deleted same-test-function bridge
+    `OSInnerProduct = WightmanInnerProduct`.  That bridge is false: the
+    Euclidean side pairs the Wick-restricted kernel with Laplace-in-time /
+    Fourier-in-space wave packets, while `Wfn.W` pairs the Minkowski boundary
+    value with Fourier-in-time wave packets.  A valid Hilbert-space comparison
+    would need a nontrivial wave-packet/isometry map `V`, not the identity on
+    coordinate Schwartz test functions.
 
-    2. **F_ext permutation invariance** (BHW property 4): allows reordering
-       the first n arguments, converting conj(f_n(y₁,...,yₙ)) to
-       conj(f_n(yₙ,...,y₁)) = borchersConj(f_n)(y₁,...,yₙ).
+    The mathematical content of this theorem is the OS I Section 3/5 spectral
+    argument: for test functions supported in strictly ordered positive
+    Euclidean time, rewrite the OS quadratic form as a positive spectral
+    measure integral of the corresponding Laplace-Fourier wave packet.  The
+    support hypothesis supplies the required time ordering, exponential
+    damping, and avoidance of coincidence singularities.
 
-    3. **Boundary value identity**: the integral of F_ext at mixed
-       backward/forward Euclidean points against a test function equals
-       the Wightman distributional pairing W(n+m)(·).
+    This is a genuine theorem boundary, not a wrapper around Wightman
+    positivity on the same Borchers sequence.  Any future stronger
+    Hilbert-space-isomorphism theorem must state the intervening map explicitly.
 
-    Steps 1-2 are provable from existing infrastructure. Step 3 is the
-    deep analytic content requiring the distributional boundary value theory
-    (Fourier-Laplace representation + Paley-Wiener).
-
-    Blocked by: `boundary_values_tempered` and distributional BV infrastructure.
-
-    Ref: OS I, Section 5; Streater-Wightman §3.4 -/
-theorem schwingerExtension_os_term_eq_wightman_term (Wfn : WightmanFunctions d)
-    (n m : ℕ) (f_n : SchwartzNPoint d n) (f_m : SchwartzNPoint d m)
-    (hsupp_n : tsupport ((f_n : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
-      OrderedPositiveTimeRegion d n)
-    (hsupp_m : tsupport ((f_m : SchwartzNPoint d m) : NPointDomain d m → ℂ) ⊆
-      OrderedPositiveTimeRegion d m) :
-    wickRotatedBoundaryPairing Wfn (n + m) (f_n.osConjTensorProduct f_m) =
-    Wfn.W (n + m) (f_n.conjTensorProduct f_m) := by
-  sorry
-
-/-- The OS inner product for Wick-rotated Schwinger functions equals the
-    Wightman inner product for test functions supported at positive times.
-
-    This is the key identity: ⟨F,F⟩_OS = ⟨F,F⟩_W when F is supported at τ > 0.
-    Combined with Wightman positive definiteness (R2), this gives E2.
-
-    Proof: each (n,m)-term of the OS sum equals the (n,m)-term of the Wightman sum
-    (by `schwinger_os_term_eq_wightman_term`), so the sums are equal.
-
-    Ref: OS I, Section 5 -/
-theorem schwingerExtension_os_inner_product_eq_wightman (Wfn : WightmanFunctions d)
-    (F : BorchersSequence d)
-    (hsupp : ∀ n, tsupport ((F.funcs n : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
-      OrderedPositiveTimeRegion d n) :
-    OSInnerProduct d (constructSchwingerFunctions Wfn) F F =
-    WightmanInnerProduct d Wfn.W F F := by
-  have hzero : OSTensorAdmissible d F F :=
-    OSTensorAdmissible_of_tsupport_subset_orderedPositiveTimeRegion (d := d) F F hsupp hsupp
-  simp only [OSInnerProduct, WightmanInnerProduct]
-  congr 1
-  ext n
-  congr 1
-  ext m
-  rw [ZeroDiagonalSchwartz.ofClassical_of_vanishes
-    (f := (F.funcs n).osConjTensorProduct (F.funcs m)) (hzero n m)]
-  exact schwingerExtension_os_term_eq_wightman_term Wfn n m (F.funcs n) (F.funcs m)
-    (hsupp n) (hsupp m)
-
-/-- The OS inner product for Wick-rotated Schwinger functions reduces to
-    the Wightman positivity form after the rotation.
-
-    For test functions F supported in τ > 0, the OS inner product equals
-    the Wightman inner product (by `os_inner_product_eq_wightman`), which
-    is non-negative by R2 (positive definiteness).
-
-    Ref: OS I, Section 5 (proof that E2 follows from R2); Glimm-Jaffe Ch. 19 -/
-theorem schwingerExtension_os_inner_product_eq_wightman_positivity (Wfn : WightmanFunctions d)
+    Ref: OS I, Section 3 and Section 5; Glimm-Jaffe Ch. 19;
+    Reed-Simon II, Section IX.8. -/
+theorem schwingerExtension_os_reflection_positive_from_spectralLaplace
+    (Wfn : WightmanFunctions d)
     (F : BorchersSequence d)
     (hsupp : ∀ n, tsupport ((F.funcs n : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
       OrderedPositiveTimeRegion d n) :
     (OSInnerProduct d (constructSchwingerFunctions Wfn) F F).re ≥ 0 := by
-  rw [schwingerExtension_os_inner_product_eq_wightman Wfn F hsupp]
-  exact Wfn.positive_definite F
+  sorry
 
 theorem wickRotatedBoundaryPairing_reflection_positive (Wfn : WightmanFunctions d)
     (F : BorchersSequence d)
     (hsupp : ∀ n, tsupport ((F.funcs n : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
       OrderedPositiveTimeRegion d n) :
     (OSInnerProduct d (constructSchwingerFunctions Wfn) F F).re ≥ 0 :=
-  schwingerExtension_os_inner_product_eq_wightman_positivity Wfn F hsupp
+  schwingerExtension_os_reflection_positive_from_spectralLaplace Wfn F hsupp
 
 /-- F_ext is permutation-invariant on TranslatedPET. Same sorry pattern. -/
 theorem F_ext_permutation_invariant_translated (Wfn : WightmanFunctions d) (n : ℕ)

--- a/docs/cluster_property_analysis.md
+++ b/docs/cluster_property_analysis.md
@@ -183,26 +183,32 @@ configurations cannot become Jost points under real shifts.
 
 ### The actual dependency chain
 
+The old dependency chain through
+`schwingerExtension_os_term_eq_wightman_term` has been deleted from the active
+route.  That theorem asserted a false same-test-function equality between the
+Euclidean Wick-restricted pairing and the Minkowski Wightman pairing.
+
+The honest R→E cluster blocker is therefore:
+
 ```
 W_analytic_cluster_integral
-  ← schwingerExtension_os_term_eq_wightman_term  (SchwingerAxioms.lean:2371, sorry)
-        bridge: wickRotatedBoundaryPairing = Wfn.W on OrderedPositiveTimeRegion supports
-  ← boundary_values_tempered + distributional BV infrastructure  (E→R lane)
-  ← Fourier-Laplace + Paley-Wiener + the OSToWightmanBoundaryValues plan
+  ← pointwise Schwinger/Euclidean cluster for the Wick-restricted kernel
+  ← dominated convergence + Fubini on strictly ordered positive-time supports
+  ← BHW pointwise cluster and translated-PET a.e. support infrastructure
 ```
 
-So the R→E cluster blocker is **structurally downstream of E→R
-boundary-values work**. The OS-W bridge theorem (sorried at line 2371)
-requires the same Edge-of-the-Wedge / Vitali / boundary-values plumbing
-that the E→R lane is building. Closing R→E cluster in isolation requires
-re-deriving this infrastructure.
+So the R→E cluster blocker is **not** a corollary of a coordinate-level
+OS-W equality.  It is a direct Euclidean/Wick-restricted cluster theorem,
+parallel in spirit to the direct spectral/Laplace proof now used for
+reflection positivity.
 
-### Recommended path (Option 1)
+### Recommended path
 
-Wait for `boundary_values_tempered` to land via the E→R lane, then close
-`schwingerExtension_os_term_eq_wightman_term` for tensor-product test
-functions, then `W_analytic_cluster_integral` is a ~30-line corollary of
-`Wfn.cluster` + the bridge.
+Do not wait for or attempt to close the deleted
+`schwingerExtension_os_term_eq_wightman_term` bridge.  Prove
+`W_analytic_cluster_integral` directly on the Wick-restricted Euclidean kernel,
+with support hypotheses strong enough to avoid coincidence singularities and
+to justify dominated convergence.
 
 Structural plumbing the cluster-corollary proof will need (Fubini split
 over `Fin.append`, push-through of `wickRotation` and `tensorProduct`):
@@ -224,7 +230,7 @@ The 2026-03-24 doc above proposed three resolution options. Updated assessment:
   permutation. Probably ~2–4 weeks of independent Edge-of-the-Wedge work
   re-deriving content the E→R lane will provide. Don't pursue.
 - **Option 3 (direct distributional proof)**: confirmed as the right path.
-  The "new infrastructure connecting `wickRotatedBoundaryPairing` to
-  `Wfn.W`" is exactly the existing sorried theorem
-  `schwingerExtension_os_term_eq_wightman_term`, which depends on
-  `boundary_values_tempered`.
+  The needed infrastructure is not a same-test-function
+  `wickRotatedBoundaryPairing = Wfn.W` bridge.  It is a direct Euclidean
+  cluster proof for the Wick-restricted kernel, using the BHW pointwise cluster
+  theorem, Fubini, and dominated convergence.

--- a/docs/os_reconstruction_status.md
+++ b/docs/os_reconstruction_status.md
@@ -53,7 +53,9 @@ algebraic geometry, or topology that are not specific to quantum field theory:
 | `exists_continuousMultilinear_ofSeparatelyContinuous` | FA (Banach-Steinhaus) | Proved in gaussian-field, needs import |
 
 Granting all of these, the **R→E direction becomes sorry-free** modulo:
-- W8 (`schwingerExtension_os_term_eq_wightman_term`): quarantined/false — should be deleted
+- W8 (`schwingerExtension_os_reflection_positive_from_spectralLaplace`):
+  honest direct reflection-positivity theorem boundary replacing the false
+  same-test-function bridge
 - W9 (`W_analytic_cluster_integral`): cluster integral, may be closable from remaining infrastructure
 
 ## QFT-specific sorrys: the irreducible core

--- a/docs/peripheral_sorry_triage.md
+++ b/docs/peripheral_sorry_triage.md
@@ -22,8 +22,8 @@ Here "peripheral" does **not** mean mathematically unimportant. It means:
 
 | File:line | Theorem | Why peripheral right now | Primary doc |
 |---|---|---|---|
-| `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean:2379` | `schwingerExtension_os_term_eq_wightman_term` | false route, should be quarantined not advanced | `docs/r_to_e_blueprint.md` |
-| `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean:3627` | `W_analytic_cluster_integral` | reverse-direction cluster, not current `E -> R` target | `docs/r_to_e_blueprint.md` |
+| `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean:2377` | `schwingerExtension_os_reflection_positive_from_spectralLaplace` | honest reverse reflection-positivity boundary, not current `E -> R` target | `docs/r_to_e_blueprint.md` |
+| `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean:3545` | `W_analytic_cluster_integral` | reverse-direction cluster, not current `E -> R` target | `docs/r_to_e_blueprint.md` |
 | `Wightman/Reconstruction/WickRotation/BHWTranslation.lean:1115` | `isPreconnected_baseFiber` | old-route residual, no longer needed on merged Route 1 path | `docs/r_to_e_blueprint.md` |
 
 ## 2. GNS / uniqueness side lane

--- a/docs/r_to_e_blueprint.md
+++ b/docs/r_to_e_blueprint.md
@@ -106,14 +106,18 @@ Those are not the same theorem surface, and the docs should keep them separate.
 
 ## 5. Honest current route constraints
 
-There is a false route still present elsewhere in `SchwingerAxioms.lean`:
+The earlier false route in `SchwingerAxioms.lean` has been removed from the
+Lean theorem surface:
 
-1. `schwingerExtension_os_term_eq_wightman_term`
-2. `schwingerExtension_os_inner_product_eq_wightman`
-3. `schwingerExtension_os_inner_product_eq_wightman_positivity`
+1. `schwingerExtension_os_term_eq_wightman_term`,
+2. `schwingerExtension_os_inner_product_eq_wightman`,
+3. `schwingerExtension_os_inner_product_eq_wightman_positivity`.
 
-That chain is off-paper. It tries to prove reverse-direction positivity by
-identifying the OS pairing with the Wightman pairing on the nose.
+That chain was off-paper. It tried to prove reverse-direction positivity by
+identifying the OS pairing with the Wightman pairing on the nose.  The
+replacement theorem slot is
+`schwingerExtension_os_reflection_positive_from_spectralLaplace`, which states
+only the direct OS reflection-positivity inequality.
 
 The current `wightman_to_os_full` theorem does **not** depend on that false
 chain. The blueprint should therefore treat the present reverse route as:
@@ -281,14 +285,16 @@ Wightman pairing on the nose.
 
 ### 12.2. Present in the file, but *not* documentation targets
 
-These theorems exist, but their current proof route is off-paper or depends on
-an earlier false theorem shape and therefore should not be copied into a future
-faithful implementation plan.
+These old theorem names no longer exist as Lean theorem surfaces because their
+statements encoded an off-paper same-test-function bridge:
 
 1. `schwingerExtension_os_term_eq_wightman_term`
 2. `schwingerExtension_os_inner_product_eq_wightman`
 3. `schwingerExtension_os_inner_product_eq_wightman_positivity`
-4. `wickRotatedBoundaryPairing_reflection_positive`
+
+The remaining public surface `wickRotatedBoundaryPairing_reflection_positive`
+is now a wrapper around the honest direct theorem
+`schwingerExtension_os_reflection_positive_from_spectralLaplace`.
 
 The future reverse-direction positivity proof should *not* cite those theorems.
 It should instead be documented as a fresh transport of the OS I Section 4.3
@@ -372,13 +378,16 @@ documented as:
 lemma constructSchwinger_positive
     (Wfn : WightmanFunctions d) :
     ReflectionPositive (constructSchwingerFunctions Wfn) := by
-  -- do *not* use `schwingerExtension_os_inner_product_eq_wightman`
-  -- reuse the OS I Section 4.3 transport package on the Wick-restricted family
+  -- do *not* use any same-test-function `OSInnerProduct = WightmanInnerProduct`
+  -- bridge
+  -- prove the direct spectral/Laplace wave-packet positivity theorem for the
+  -- Wick-restricted family
 ```
 
-The reverse blueprint should treat this as a transport theorem from the
-already-understood OS-I positivity package, not as a fresh spectral/semigroup
-construction and not as an algebraic identity of pairings.
+The reverse blueprint should treat this as a direct OS-I positivity theorem for
+the Wick-restricted family, proved through the spectral/Laplace wave-packet
+representation or an equivalent Section 4.3 transport package.  It must never
+be an algebraic identity of pairings on the same coordinate test function.
 
 This should also be documented explicitly as a reverse-direction transport:
 
@@ -553,26 +562,29 @@ The current reverse-direction file should distinguish three statuses:
 
 ### 17.1. DELETE from the active route
 
-These theorem surfaces encode the false "OS pairing = Wightman pairing"
-positivity route and should not appear in later reverse-direction proofs.
+These old theorem surfaces encoded the false "OS pairing = Wightman pairing"
+positivity route and should not reappear in later reverse-direction proofs.
 
 1. `schwingerExtension_os_term_eq_wightman_term`
 2. `schwingerExtension_os_inner_product_eq_wightman`
 3. `schwingerExtension_os_inner_product_eq_wightman_positivity`
 
-If the repo keeps them temporarily for historical reasons, the docs should
-still classify them as deleted from the active route.
+They have now been deleted from the Lean theorem surface.  If they are
+reintroduced for historical comparison, the docs should still classify them as
+deleted from the active route.
 
 ### 17.2. QUARANTINE until re-proved on the honest route
 
-These theorems are not themselves the false route, but they currently sit
-downstream of it and should not be consumed as trusted infrastructure until the
-proofs are rerouted.
+This theorem name is not itself the false route.  It is the public positivity
+surface, and it should remain only as a wrapper around the honest direct
+positivity theorem.
 
 1. `wickRotatedBoundaryPairing_reflection_positive`
 
-The right long-term fate is to re-prove this theorem from the Section 4.3
-transport package and then move it back into the `KEEP` class.
+The current internal target is
+`schwingerExtension_os_reflection_positive_from_spectralLaplace`: prove the OS
+quadratic form is a positive spectral/Laplace wave-packet integral for
+strictly ordered positive-time supports.
 
 ### 17.3. KEEP as honest current surfaces
 

--- a/docs/sorry_triage.md
+++ b/docs/sorry_triage.md
@@ -70,8 +70,8 @@ Note: the raw regex census still sees one commented legacy `sorry` in
 
 | ID | File:line | Theorem | Lane | Status |
 |---|---|---|---|---|
-| W8 | `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean:2379` | `schwingerExtension_os_term_eq_wightman_term` | false positivity route | quarantine/delete |
-| W9 | `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean:3627` | `W_analytic_cluster_integral` | reverse-direction cluster | live but not on shortest path |
+| W8 | `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean:2377` | `schwingerExtension_os_reflection_positive_from_spectralLaplace` | reverse reflection positivity | honest spectral/Laplace theorem boundary |
+| W9 | `Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean:3545` | `W_analytic_cluster_integral` | reverse-direction cluster | live but not on shortest path |
 | W10 | `Wightman/Reconstruction/WickRotation/BHWTranslation.lean:1115` | `isPreconnected_baseFiber` | old-route PET connectivity | peripheral |
 
 ### 3.3. GNS / uniqueness / functional-analysis side lane
@@ -316,7 +316,7 @@ Estimated remaining Lean size:
 The following direct `sorry`s should remain documented but not distract the
 current theorem-2/3/4 execution order:
 
-1. `schwingerExtension_os_term_eq_wightman_term`
+1. `schwingerExtension_os_reflection_positive_from_spectralLaplace`
 2. `W_analytic_cluster_integral`
 3. `isPreconnected_baseFiber`
 4. all of `BochnerMinlos.lean`


### PR DESCRIPTION
## Summary
- remove the false same-test-function OS/Wightman bridge theorem surfaces
- replace them with the honest direct reflection-positivity boundary `schwingerExtension_os_reflection_positive_from_spectralLaplace`
- update route/triage docs and cluster notes so downstream work no longer routes through the deleted bridge

## Verification
- `lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/SchwingerAxioms.lean` passed in the warmed main workspace after the same refactor, with expected theorem-level `sorry` warnings

Note: a direct push to `main` was attempted and rejected by GitHub branch protection: changes must be made through a pull request.