### PR TITLE
Clarify adjacent locality API

### DIFF
--- a/OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/AdjacencyDistributional.lean
+++ b/OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/AdjacencyDistributional.lean
@@ -87,7 +87,7 @@ theorem extendF_adjSwap_pairing_eq_of_distributional_local_commutativity
           F (fun k μ => (x k μ : ℂ) + ε * (η k μ : ℂ) * Complex.I) * f x)
         (nhdsWithin 0 (Set.Ioi 0))
         (nhds (W n f)))
-    (hF_local_dist : IsLocallyCommutativeWeak d W)
+    (hF_local_dist : IsAdjacentLocallyCommutativeWeak d W)
     (i : Fin n) (hi : i.val + 1 < n)
     (f g : SchwartzNPoint d n)
     (hf_compact : HasCompactSupport (f : NPointDomain d n → ℂ))
@@ -163,7 +163,7 @@ theorem extendF_adjSwap_eq_on_realOpen_of_distributional_local_commutativity
           F (fun k μ => (x k μ : ℂ) + ε * (η k μ : ℂ) * Complex.I) * f x)
         (nhdsWithin 0 (Set.Ioi 0))
         (nhds (W n f)))
-    (hF_local_dist : IsLocallyCommutativeWeak d W)
+    (hF_local_dist : IsAdjacentLocallyCommutativeWeak d W)
     (i : Fin n) (hi : i.val + 1 < n)
     (V : Set (Fin n → Fin (d + 1) → ℝ))
     (hV_open : IsOpen V)
@@ -309,7 +309,7 @@ theorem extendF_adjSwap_eq_of_connected_overlap_of_distributional_local_commutat
           F (fun k μ => (x k μ : ℂ) + ε * (η k μ : ℂ) * Complex.I) * f x)
         (nhdsWithin 0 (Set.Ioi 0))
         (nhds (W n f)))
-    (hF_local_dist : IsLocallyCommutativeWeak d W)
+    (hF_local_dist : IsAdjacentLocallyCommutativeWeak d W)
     (i : Fin n) (hi : i.val + 1 < n)
     (hD_conn : IsConnected
       {z : Fin n → Fin (d + 1) → ℂ |

--- a/OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/PermutationFlowBlocker.lean
+++ b/OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/PermutationFlowBlocker.lean
@@ -103,7 +103,7 @@ theorem blocker_iterated_eow_hExtPerm_d1_nontrivial
           F (fun k μ => (x k μ : ℂ) + ε * (η k μ : ℂ) * Complex.I) * f x)
         (nhdsWithin 0 (Set.Ioi 0))
         (nhds (W n f)))
-    (hF_local_dist : IsLocallyCommutativeWeak 1 W)
+    (hF_local_dist : IsAdjacentLocallyCommutativeWeak 1 W)
     (σ : Equiv.Perm (Fin n))
     (_hσ : σ ≠ 1)
     (_hn : ¬ n ≤ 1) :

--- a/OSReconstruction/Wightman/Reconstruction/AnalyticContinuation.lean
+++ b/OSReconstruction/Wightman/Reconstruction/AnalyticContinuation.lean
@@ -698,7 +698,7 @@ theorem bargmann_hall_wightman (n : ℕ)
           F (fun k μ => (x k μ : ℂ) + ε * (η k μ : ℂ) * Complex.I) * f x)
         (nhdsWithin 0 (Set.Ioi 0))
         (nhds (W n f)))
-    (hF_local_dist : IsLocallyCommutativeWeak d W) :
+    (hF_local_dist : IsAdjacentLocallyCommutativeWeak d W) :
     ∃ (F_ext : (Fin n → Fin (d + 1) → ℂ) → ℂ),
       DifferentiableOn ℂ F_ext (PermutedExtendedTube d n) ∧
       (∀ z ∈ ForwardTube d n, F_ext z = F z) ∧

--- a/OSReconstruction/Wightman/Reconstruction/Core.lean
+++ b/OSReconstruction/Wightman/Reconstruction/Core.lean
@@ -124,7 +124,7 @@ def IsLorentzCovariantWeak (W : (n : ℕ) → SchwartzNPoint d n → ℂ) : Prop
     (∀ x : NPointDomain d n, g.toFun x = f.toFun (fun i => Matrix.mulVec Λ⁻¹.val (x i))) →
     W n f = W n g
 
-/-- Local commutativity condition for Wightman functions.
+/-- Adjacent local commutativity condition for Wightman functions.
 
     For a collection of n-point functions W_n, local commutativity means:
     When adjacent points x_i and x_{i+1} are spacelike separated, swapping them
@@ -139,7 +139,7 @@ def IsLorentzCovariantWeak (W : (n : ℕ) → SchwartzNPoint d n → ℂ) : Prop
     At the distribution level, this is expressed via test functions with
     spacelike-separated supports: if supp(f) and supp(g) are spacelike separated,
     then W₂(f ⊗ g) = W₂(g ⊗ f). -/
-def IsLocallyCommutativeWeak (W : (n : ℕ) → SchwartzNPoint d n → ℂ) : Prop :=
+def IsAdjacentLocallyCommutativeWeak (W : (n : ℕ) → SchwartzNPoint d n → ℂ) : Prop :=
   -- For Schwartz functions f, g where g is the swap of adjacent coordinates
   -- i and i+1 in f, and the supports of f have spacelike-separated adjacent
   -- arguments, we have W_n(f) = W_n(g). Avoids constructing the swapped
@@ -150,6 +150,13 @@ def IsLocallyCommutativeWeak (W : (n : ℕ) → SchwartzNPoint d n → ℂ) : Pr
     (∀ x : NPointDomain d n,
       g.toFun x = f.toFun (fun k => x (Equiv.swap i ⟨i.val + 1, hi⟩ k))) →
     W n f = W n g
+
+/-- Compatibility name for the standard adjacent-swap Wightman locality
+predicate.  This is intentionally not an arbitrary non-adjacent pair-swap
+property: moving a non-adjacent point through intervening fields requires the
+corresponding chain of adjacent spacelike crossings. -/
+abbrev IsLocallyCommutativeWeak :=
+  IsAdjacentLocallyCommutativeWeak
 
 /-! ### Positive Definiteness -/
 
@@ -759,8 +766,8 @@ structure WightmanFunctions (d : ℕ) [NeZero d] where
             W_analytic (fun k μ => ↑(x k μ) + ε * ↑(η k μ) * Complex.I) * (f x))
           (nhdsWithin 0 (Set.Ioi 0))
           (nhds (W n f)))
-  /-- Local commutativity (weak form) -/
-  locally_commutative : IsLocallyCommutativeWeak d W
+  /-- Adjacent local commutativity (weak form, the standard R3 surface). -/
+  locally_commutative : IsAdjacentLocallyCommutativeWeak d W
   /-- Positive definiteness -/
   positive_definite : Wightman.IsPositiveDefinite d W
   /-- Hermiticity: W_n(f̃) = conj(W_n(f)) where f̃(x₁,...,xₙ) = conj(f(xₙ,...,x₁)).
@@ -798,7 +805,7 @@ variable {d : ℕ} [NeZero d]
 /-- Upgrade a checked core package to full Wightman functions once the
 remaining locality and cluster frontiers are supplied. -/
 def toWightmanFunctions (Wcore : WightmanFunctionsCore d)
-    (hlocal : IsLocallyCommutativeWeak d Wcore.W)
+    (hlocal : IsAdjacentLocallyCommutativeWeak d Wcore.W)
     (hcluster : ∀ (n m : ℕ) (f : SchwartzNPoint d n) (g : SchwartzNPoint d m),
       ∀ ε : ℝ, ε > 0 → ∃ R : ℝ, R > 0 ∧
         ∀ a : SpacetimeDim d, a 0 = 0 → (∑ i : Fin d, (a (Fin.succ i))^2) > R^2 →

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/BHWExtension.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/BHWExtension.lean
@@ -223,7 +223,7 @@ theorem W_analytic_swap_boundary_pairing_eq {d n : ℕ} [NeZero d]
         (fun ε : ℝ => ∫ x : NPointDomain d n,
           W_analytic (fun k μ => ↑(x k μ) + ε * ↑(η k μ) * Complex.I) * (f x))
         (nhdsWithin 0 (Set.Ioi 0)) (nhds (W n f)))
-    (hLC : IsLocallyCommutativeWeak d W)
+    (hLC : IsAdjacentLocallyCommutativeWeak d W)
     (i : Fin n) (hi : i.val + 1 < n) :
     ∀ (f g : SchwartzNPoint d n),
       HasCompactSupport (f : NPointDomain d n → ℂ) →
@@ -276,7 +276,7 @@ theorem analytic_extended_local_commutativity {d n : ℕ} [NeZero d]
         (fun ε : ℝ => ∫ x : NPointDomain d n,
           W_analytic (fun k μ => ↑(x k μ) + ε * ↑(η k μ) * Complex.I) * (f x))
         (nhdsWithin 0 (Set.Ioi 0)) (nhds (W n f)))
-    (hLC : IsLocallyCommutativeWeak d W)
+    (hLC : IsAdjacentLocallyCommutativeWeak d W)
     (i : Fin n) (hi : i.val + 1 < n)
     (x : Fin n → Fin (d + 1) → ℝ)
     (hx_sp : MinkowskiSpace.minkowskiNormSq d
@@ -329,7 +329,7 @@ theorem analytic_boundary_local_commutativity_of_boundary_continuous {d n : ℕ}
         (fun ε : ℝ => ∫ x : NPointDomain d n,
           W_analytic (fun k μ => ↑(x k μ) + ε * ↑(η k μ) * Complex.I) * (f x))
         (nhdsWithin 0 (Set.Ioi 0)) (nhds (W n f)))
-    (hLC : IsLocallyCommutativeWeak d W)
+    (hLC : IsAdjacentLocallyCommutativeWeak d W)
     (i : Fin n) (hi : i.val + 1 < n)
     (x : Fin n → Fin (d + 1) → ℝ)
     (hx : MinkowskiSpace.minkowskiNormSq d

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean
@@ -726,7 +726,7 @@ theorem bvt_lorentz_covariant (OS : OsterwalderSchraderAxioms d)
 
 theorem bvt_locally_commutative (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS) :
-    IsLocallyCommutativeWeak d (bvt_W OS lgc) := by
+    IsAdjacentLocallyCommutativeWeak d (bvt_W OS lgc) := by
   intro n i hi f g hsupp hswap
   exact bvt_W_swap_pairing_of_spacelike (d := d) OS lgc n i hi f g hsupp hswap
 
@@ -988,7 +988,7 @@ def constructWightmanFunctionsCore (OS : OsterwalderSchraderAxioms d)
 adjacent locality and cluster frontiers are supplied explicitly. -/
 def constructWightmanFunctions (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS)
-    (hlocal : IsLocallyCommutativeWeak d (bvt_W OS lgc))
+    (hlocal : IsAdjacentLocallyCommutativeWeak d (bvt_W OS lgc))
     (hcluster : ∀ (n m : ℕ) (f : SchwartzNPoint d n) (g : SchwartzNPoint d m),
       ∀ ε : ℝ, ε > 0 → ∃ R : ℝ, R > 0 ∧
         ∀ a : SpacetimeDim d, a 0 = 0 → (∑ i : Fin d, (a (Fin.succ i))^2) > R^2 →

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanSelectedWitness.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanSelectedWitness.lean
@@ -642,7 +642,7 @@ theorem bvt_F_extendF_petBranchIndependence_of_selectedAdjacentEdgeData
 /-- Selected adjacent OS edge data gives the BHW forward-tube permutation
 invariance conclusion, once the PET sector-fiber geometry is supplied.  This
 is the non-circular selected-witness replacement for the old BHW use of
-`IsLocallyCommutativeWeak`. -/
+`IsAdjacentLocallyCommutativeWeak`. -/
 theorem bvt_F_permutation_invariance_of_selectedAdjacentEdgeData
     (OS : OsterwalderSchraderAxioms d)
     (lgc : OSLinearGrowthCondition d OS)

--- a/docs/BHW_STATUS.md
+++ b/docs/BHW_STATUS.md
@@ -32,9 +32,9 @@ their production docstrings.  They should not be treated as casual placeholders.
 
 They also should not be repurposed as the non-circular OS theorem-2 supplier.
 In particular, `blocker_iterated_eow_hExtPerm_d1_nontrivial` assumes
-`hF_local_dist : IsLocallyCommutativeWeak 1 W`; using it to prove
-`IsLocallyCommutativeWeak 1 (bvt_W OS lgc)` would be circular.  The OS §4.5
-route therefore needs a separate dimension-one real-open edge theorem or a
+`hF_local_dist : IsAdjacentLocallyCommutativeWeak 1 W`; using it to prove
+`IsAdjacentLocallyCommutativeWeak 1 (bvt_W OS lgc)` would be circular.  The OS
+§4.5 route therefore needs a separate dimension-one real-open edge theorem or a
 direct dimension-one complex-edge boundary/PET theorem, as documented in
 `docs/theorem2_locality_blueprint.md`.
 

--- a/docs/PROOF_OUTLINE.md
+++ b/docs/PROOF_OUTLINE.md
@@ -381,7 +381,7 @@ Given the analytic continuation to the forward tube, extract the 7 Wightman axio
 | #12 | `translation_invariant` | E1 | Euclidean translation → Minkowski translation |
 | #13 | `lorentz_covariant` | E1 + BHW | SO(d+1) covariance → Lorentz covariance via BHW |
 | #14 | `spectrum_condition` | E0' | Laplace transform → support in forward cone |
-| #15 | `locally_commutative` | E3 + EOW | Permutation symmetry + edge-of-wedge → locality |
+| #15 | `locally_commutative` | E3 + EOW | Adjacent local commutativity; not arbitrary pair-swap locality |
 | #16 | `positive_definite` | E2 | Reflection positivity → Wightman positivity |
 | #17 | `hermitian` | Reality | Real Schwinger functions → Hermiticity |
 

--- a/docs/bhw_permutation_blueprint.md
+++ b/docs/bhw_permutation_blueprint.md
@@ -55,9 +55,9 @@ Scope note for theorem 2: accepting these deferred blockers puts the
 dimension-one case on the same footing as the higher-dimensional case for the
 BHW permutation-flow endgame.  It does **not** automatically close the
 non-circular OS-to-locality proof.  The second blocker assumes
-`hF_local_dist : IsLocallyCommutativeWeak 1 W`, so it cannot be used to prove
-the target locality theorem for `W := bvt_W OS lgc` unless that locality has
-already been obtained non-circularly.  The OS route must get its `d = 1`
+`hF_local_dist : IsAdjacentLocallyCommutativeWeak 1 W`, so it cannot be used
+to prove the target locality theorem for `W := bvt_W OS lgc` unless that
+locality has already been obtained non-circularly.  The OS route must get its `d = 1`
 supplier from the separate one-dimensional complex-edge / PET theorem recorded
 in `docs/theorem2_locality_blueprint.md`, not from this generic blocker lane.
 So for theorem 2:
@@ -428,7 +428,7 @@ derivation:
 3. prove the source-backed
    `BHW.hallWightman_source_permutedBranch_compatibility_of_distributionalAnchor`
    on `S''_n`;
-4. ensure no theorem in the proof has an `IsLocallyCommutativeWeak`
+4. ensure no theorem in the proof has an `IsAdjacentLocallyCommutativeWeak`
    hypothesis; the current repo surfaces named `bargmann_hall_wightman` and
    `BHW.bargmann_hall_wightman_theorem` take such a hypothesis and are
    circular for theorem 2;
@@ -913,7 +913,7 @@ Implementation locus:
 6. do not consume the top-level
    `BHWPermutation.PermutationFlow.bargmann_hall_wightman_theorem` for theorem
    2, because its current public statement carries
-   `IsLocallyCommutativeWeak` / boundary-distribution inputs and is circular for
+   `IsAdjacentLocallyCommutativeWeak` / boundary-distribution inputs and is circular for
    theorem 2.  The lower-layer, non-circular BHW/PET support in
    `PermutedTubeMonodromy.lean` is permitted as conditional infrastructure but
    is not the checked active entry point:

--- a/docs/os_reconstruction_status.md
+++ b/docs/os_reconstruction_status.md
@@ -87,6 +87,11 @@ closed positivity/isometry package.
 coordinate swap, the reconstructed boundary-value functional satisfies
 `bvt_W OS lgc n f = bvt_W OS lgc n g`.
 
+API note: this is the standard OS/Wightman R3 surface used here.  It is not an
+arbitrary non-adjacent pair-swap theorem; moving a non-adjacent point past
+intervening fields would require the corresponding chain of adjacent spacelike
+crossing hypotheses.
+
 **Proof strategy (OS I §4.5):**
 1. The OS Euclidean covariance gives permutation symmetry of Schwinger functions.
 2. Analytic continuation preserves this symmetry on the extended tube.

--- a/docs/proof_docs_completion_plan.md
+++ b/docs/proof_docs_completion_plan.md
@@ -36,6 +36,31 @@ confirmed this theorem-shape correction: `hOrbit` should be documented as an
 extra custom geometric theorem if pursued, while the faithful OS I §4.5 route
 targets direct source-backed BHW single-valuedness on `S''_n`.
 
+Locality API correction gate, 2026-05-07: before any Lean refactor responding
+to GitHub issue #83, the proof-doc decision is fixed as follows.  The OS I/OS
+II R3 surface used by theorem 2 is adjacent local commutativity: swap
+neighboring arguments `i` and `i+1` under the adjacent spacelike-support
+hypothesis.  This is the statement already carried by
+`bvt_W_swap_pairing_of_spacelike`, and it is the only locality theorem that the
+current E->R route is proving.  The implementation may rename the current
+predicate surface to `IsAdjacentLocallyCommutativeWeak` and update consumers so
+the API no longer suggests an arbitrary-pair theorem.  It may also keep a
+documented compatibility alias for the standard adjacent predicate if a
+transition step needs it.
+
+The implementation must **not**:
+
+- restore the old arbitrary-pair predicate as the public `WightmanFunctions`
+  locality field;
+- introduce an adjacent->arbitrary locality theorem as an axiom, sorry, or
+  hidden assumption;
+- use any QFT-specific locality upgrade as an axiom-gate workaround.
+
+If an arbitrary pair-swap property is useful later, it must be separately named
+as a stronger non-frontier predicate and related to the adjacent predicate only
+by the safe direction pair-swap -> adjacent.  No theorem-2 Lean work may depend
+on the stronger property.
+
 Current theorem-2 implementation ledger: the immediate Lean route is
 selected-adjacent OS/Jost source data plus the source-backed BHW
 single-valuedness packet on `S''_n`, not BHW/PET monodromy through `hOrbit`.
@@ -94,7 +119,9 @@ if its conclusion has the right shape.
 Current examples:
 
 1. `blocker_iterated_eow_hExtPerm_d1_nontrivial` is not a theorem-2 input in
-   dimension one because it assumes `IsLocallyCommutativeWeak 1 W`.
+   dimension one because it assumes the already-proved adjacent locality
+   predicate (`IsAdjacentLocallyCommutativeWeak 1 W` after the API
+   clarification).
 2. Streater-Wightman Theorem 3-6 is not a theorem-2 input because its proof
    uses local commutativity.
 3. Streater-Wightman Figure 2-4 remains allowed only as adjacent geometric
@@ -122,8 +149,8 @@ Current examples:
    overlap and cover-reaching proof in
    `BHWPermutation/SourceExtension.lean`;
    `BHWPermutation/PermutationFlow.lean` is still forbidden as a theorem-2
-   source theorem because its current top-level BHW theorem depends on
-   `IsLocallyCommutativeWeak`.
+   source theorem because its current top-level BHW theorem depends on the
+   adjacent locality predicate.
    A checked false shortcut has been ruled out: pointwise permutation symmetry
    of the raw base function does not by itself compare arbitrary PET sector
    branches, because the complex-Lorentz representative needed for the

--- a/docs/theorem2_locality_blueprint.md
+++ b/docs/theorem2_locality_blueprint.md
@@ -13,6 +13,36 @@ There is no alternate active route. The only exception that could justify a
 route change would be an explicit OS-paper error documented locally first; no
 such exception is in scope here.
 
+Locality API decision, 2026-05-07.  The theorem-2 target remains the OS
+R3 adjacent-transposition statement, not an arbitrary non-adjacent pair swap.
+OS I states local commutativity by exchanging neighboring arguments
+`(..., f_j, f_{j+1}, ...)` when those two supports are spacelike separated;
+OS II IV.2 sends the E->R locality transfer back to that OS I Section 4.5
+argument.  Accordingly, the checked frontier
+`bvt_W_swap_pairing_of_spacelike` has the right shape:
+
+```lean
+∀ (n : ℕ) (i : Fin n) (hi : i.val + 1 < n)
+  (f g : SchwartzNPoint d n),
+  (∀ x, f.toFun x ≠ 0 ->
+    MinkowskiSpace.AreSpacelikeSeparated d (x i) (x ⟨i.val + 1, hi⟩)) ->
+  (∀ x,
+    g.toFun x =
+      f.toFun (fun k => x (Equiv.swap i ⟨i.val + 1, hi⟩ k))) ->
+  bvt_W OS lgc n f = bvt_W OS lgc n g
+```
+
+The proof docs therefore authorize only an API clarification around this
+surface: introduce an explicit adjacent predicate name such as
+`IsAdjacentLocallyCommutativeWeak` for the current standard R3 predicate, and
+retarget theorem-2/BHW adjacency consumers to that name.  They do **not**
+authorize restoring the old arbitrary-pair predicate as the public
+`WightmanFunctions` locality field.  Such a pair-swap predicate may be
+introduced later only as a separately named stronger property, e.g.
+`IsPairSwapLocallyCommutativeWeak`, with only the easy implication
+pair-swap -> adjacent proved.  There must be no production axiom or sorry
+claiming adjacent -> arbitrary pair-swap locality.
+
 This note should be read together with
 [`bhw_permutation_blueprint.md`](/Users/xiyin/OSReconstruction/docs/bhw_permutation_blueprint.md).
 That sibling note owns the BHW permutation-geometry obligations and records why
@@ -185,8 +215,8 @@ private theorem bvt_W_swap_pairing_of_spacelike
       bvt_W OS lgc n f = bvt_W OS lgc n g
 ```
 
-This matches the corrected core locality surface
-`IsLocallyCommutativeWeak` in
+This matches the corrected adjacent core locality surface
+`IsAdjacentLocallyCommutativeWeak` in
 `Wightman/Reconstruction/Core.lean`.
 
 ## 2. Paper route
@@ -13480,7 +13510,9 @@ Forbidden support in `SourceExtension.lean`:
 
 1. `BHW.bargmann_hall_wightman_theorem` and any theorem named
    `bargmann_hall_wightman` in `PermutationFlow.lean`, because the current
-   statement takes `hF_local_dist : IsLocallyCommutativeWeak d W`;
+   statement takes the already-proved locality predicate as an input
+   (`hF_local_dist : IsAdjacentLocallyCommutativeWeak d W` after the API
+   clarification);
 2. private helpers in `PermutationFlow.lean` whose hypotheses include
    `W`, `hF_bv_dist`, or `hF_local_dist`, including
    `fullExtendF_well_defined`, `F_permutation_invariance`,
@@ -13534,12 +13566,11 @@ Source-audit anchors:
 Non-circularity requirements:
 
 1. this theorem must not call any existing theorem whose hypotheses include
-   `IsLocallyCommutativeWeak d (bvt_W OS lgc)`;
+   `IsAdjacentLocallyCommutativeWeak d (bvt_W OS lgc)`;
 2. in particular, the current generic theorem surfaces named
    `bargmann_hall_wightman` and `BHW.bargmann_hall_wightman_theorem` are not
    acceptable as Slot-6 inputs in their current form: the repo statements take
-   `hF_local_dist : IsLocallyCommutativeWeak d W`, which is circular for
-   theorem 2;
+   the locality predicate as an input, which is circular for theorem 2;
 3. Streater-Wightman Theorem 3-6 is forbidden here for the same reason;
 4. the allowed source input is Hall-Wightman/BHW single-valued continuation,
    with the OS-II-corrected `bvt_F` construction providing the analytic datum.
@@ -15046,7 +15077,7 @@ theorem bvt_F_extendF_petBranchIndependence_of_selectedAdjacentEdgeData
 ```
 
 This theorem uses `BHW.extendF_pet_branch_independence_of_adjacent_of_orbitChamberConnected`
-directly.  It does not consume `IsLocallyCommutativeWeak`; the old circular
+directly.  It does not consume `IsAdjacentLocallyCommutativeWeak`; the old circular
 locality hypothesis is replaced by the OS-II adjacent/Jost input
 `SelectedAdjacentPermutationEdgeData` plus the explicit PET orbit-connectivity
 obligation `hOrbit`.
@@ -15564,7 +15595,7 @@ Proof route:
 private theorem bvt_locally_commutative_boundary_route_of_one
     (OS : OsterwalderSchraderAxioms 1)
     (lgc : OSLinearGrowthCondition 1 OS) :
-    IsLocallyCommutativeWeak 1 (bvt_W OS lgc)
+    IsAdjacentLocallyCommutativeWeak 1 (bvt_W OS lgc)
 ```
 
 Proof pseudocode:
@@ -15629,7 +15660,7 @@ Exact scope:
    `hallWightman_source_permutedBranch_compatibility_of_distributionalAnchor`.
 4. The OS-specific consumer is
    `bvt_F_bhwSingleValuedOn_permutedExtendedTube_of_two_le`, with no
-   `IsLocallyCommutativeWeak` hypothesis.  It consumes the
+   `IsAdjacentLocallyCommutativeWeak` hypothesis.  It consumes the
    `BHW.SourceDistributionalAdjacentTubeAnchor` supplied from OS-II selected
    adjacent distributional Jost data.
 5. `PETOrbitChamberChain.lean` is archived common-slice infrastructure.


### PR DESCRIPTION
## Summary

This PR addresses issue #83 by making the reconstruction locality API explicitly adjacent.

- introduce `IsAdjacentLocallyCommutativeWeak` for the standard OS/Wightman R3 adjacent-swap predicate
- point `WightmanFunctions.locally_commutative`, `toWightmanFunctions`, and active boundary/BHW adjacency consumers at the explicit adjacent predicate
- keep `IsLocallyCommutativeWeak` only as a documented compatibility alias
- update proof/status docs to state that theorem 2 proves adjacent R3, not arbitrary non-adjacent pair swaps

This does **not** introduce an adjacent-to-arbitrary locality theorem, axiom, sorry, or QFT-specific axiom-gate workaround.

## Verification

- `lake env lean OSReconstruction/Wightman/Reconstruction/Core.lean`
- `lake env lean OSReconstruction/Wightman/Reconstruction/AnalyticContinuation.lean`
- `lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/BHWExtension.lean`
- `lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanSelectedWitness.lean`
- `lake env lean OSReconstruction/Wightman/Reconstruction/WickRotation/OSToWightmanBoundaryValues.lean`
- `lake env lean OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/AdjacencyDistributional.lean`
- `lake env lean OSReconstruction/ComplexLieGroups/Connectedness/BHWPermutation/PermutationFlowBlocker.lean`
- `git diff --check origin/main..HEAD`
- Lean diff audit: no added `sorry`, `admit`, or `axiom`

Existing warnings remain, including pre-existing `sorry` warnings in `OSToWightmanBoundaryValues.lean` and `PermutationFlowBlocker.lean`.
