### PR TITLE
Reduce cluster theorem (W_analytic_cluster_integral_via_ruelle) to BHW via dominated convergence

### DIFF
--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean
@@ -646,6 +646,473 @@ lemma schwartz_integrable_add_pow_mul
           exact mul_le_mul_of_nonneg_right h_apl' h_fnonneg
       _ = 2^(k-1) * (‖f x‖ + ‖x‖^k * ‖f x‖) := by ring
 
+/-! ### Time-gap flatness for the Ruelle regulator -/
+
+private def ruelleTimeGap {n : ℕ} (x : NPointDomain d n) (k : Fin n) : ℝ :=
+  if hk : (k : ℕ) = 0 then x k 0
+  else x k 0 - x ⟨(k : ℕ) - 1, by omega⟩ 0
+
+private def ruelleGapBoundaryPoint {n : ℕ} (x : NPointDomain d n) (k : Fin n) :
+    NPointDomain d n :=
+  Function.update x k
+    (Function.update (x k) 0
+      (if hk : (k : ℕ) = 0 then 0 else x ⟨(k : ℕ) - 1, by omega⟩ 0))
+
+private lemma continuous_tubeBoundaryDist {n : ℕ} :
+    Continuous (fun z : Fin n → Fin (d + 1) → ℂ => tubeBoundaryDist (d := d) z) := by
+  by_cases hn : n = 0
+  · subst hn
+    simpa [tubeBoundaryDist] using
+      (continuous_const : Continuous (fun _ : Fin 0 → Fin (d + 1) → ℂ => (1 : ℝ)))
+  · haveI : NeZero n := ⟨hn⟩
+    simp [tubeBoundaryDist, hn]
+    rw [show
+        (fun z : Fin n → Fin (d + 1) → ℂ =>
+          ⨅ k : Fin n,
+            Metric.infDist
+              (fun μ : Fin (d + 1) =>
+                (z k μ).im -
+                  (if k = 0 then 0
+                   else (z ⟨(k : ℕ) - 1, by omega⟩ μ).im))
+              (openForwardConeSet d)ᶜ) =
+        (Finset.univ.inf' Finset.univ_nonempty fun k =>
+          fun z : Fin n → Fin (d + 1) → ℂ =>
+            Metric.infDist
+              (fun μ : Fin (d + 1) =>
+                (z k μ).im -
+                  (if k = 0 then 0
+                   else (z ⟨(k : ℕ) - 1, by omega⟩ μ).im))
+              (openForwardConeSet d)ᶜ) by
+      funext z
+      rw [Finset.inf'_apply]
+      exact Eq.symm (Finset.inf'_univ_eq_ciInf fun k =>
+        Metric.infDist
+          (fun μ : Fin (d + 1) =>
+            (z k μ).im -
+              (if k = 0 then 0
+               else (z ⟨(k : ℕ) - 1, by omega⟩ μ).im))
+          (openForwardConeSet d)ᶜ)]
+    exact Continuous.finset_inf' Finset.univ_nonempty
+      (fun k _ => by
+        refine (Metric.continuous_infDist_pt (s := (openForwardConeSet d)ᶜ)).comp ?_
+        refine continuous_pi fun μ => ?_
+        by_cases hk : k = 0
+        · simp [hk]
+          fun_prop
+        · simp [hk]
+          fun_prop)
+
+private lemma ruelleTimeGap_pos_of_mem_orderedPositiveTimeRegion {n : ℕ}
+    {x : NPointDomain d n} (hx : x ∈ OrderedPositiveTimeRegion d n) (k : Fin n) :
+    0 < ruelleTimeGap (d := d) x k := by
+  unfold ruelleTimeGap
+  by_cases hk : (k : ℕ) = 0
+  · simp [hk, (hx k).1]
+  · simp [hk]
+    let km1 : Fin n := ⟨(k : ℕ) - 1, by omega⟩
+    have hlt : km1 < k := by
+      rw [Fin.lt_def]
+      simp [km1]
+      omega
+    exact (hx km1).2 k hlt
+
+private lemma ruelleGapBoundaryPoint_not_mem_orderedPositiveTimeRegion {n : ℕ}
+    (x : NPointDomain d n) (k : Fin n) :
+    ruelleGapBoundaryPoint (d := d) x k ∉ OrderedPositiveTimeRegion d n := by
+  intro h
+  unfold ruelleGapBoundaryPoint at h
+  by_cases hk : (k : ℕ) = 0
+  · have := (h k).1
+    simp [hk] at this
+  · let km1 : Fin n := ⟨(k : ℕ) - 1, by omega⟩
+    have hlt : km1 < k := by
+      rw [Fin.lt_def]
+      simp [km1]
+      omega
+    have hne : km1 ≠ k := hlt.ne
+    have := (h km1).2 k hlt
+    simp [hk, km1, hne] at this
+
+private lemma ruelleGapBoundaryPoint_sub_apply {n : ℕ}
+    (x : NPointDomain d n) (k j : Fin n) (μ : Fin (d + 1)) :
+    (x - ruelleGapBoundaryPoint (d := d) x k) j μ =
+      if j = k ∧ μ = 0 then ruelleTimeGap (d := d) x k else 0 := by
+  unfold ruelleTimeGap ruelleGapBoundaryPoint
+  by_cases hj : j = k
+  · by_cases hμ : μ = 0
+    · subst hμ
+      by_cases hk : (k : ℕ) = 0 <;> simp [hj, hk]
+    · by_cases hk : (k : ℕ) = 0 <;> simp [hj, hk, hμ]
+  · by_cases hk : (k : ℕ) = 0 <;> simp [hk, hj]
+
+private lemma norm_sub_ruelleGapBoundaryPoint_le {n : ℕ}
+    (x : NPointDomain d n) (k : Fin n) :
+    ‖x - ruelleGapBoundaryPoint (d := d) x k‖ ≤ |ruelleTimeGap (d := d) x k| := by
+  apply (pi_norm_le_iff_of_nonneg (abs_nonneg _)).mpr
+  intro j
+  apply (pi_norm_le_iff_of_nonneg (abs_nonneg _)).mpr
+  intro μ
+  rw [Real.norm_eq_abs]
+  rw [ruelleGapBoundaryPoint_sub_apply]
+  split_ifs <;> simp
+
+private lemma iteratedFDeriv_eq_zero_of_notMem_orderedPositiveTimeRegion {n : ℕ}
+    (f : SchwartzNPoint d n)
+    (hf : tsupport ((f : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
+      OrderedPositiveTimeRegion d n) :
+    ∀ r x, x ∉ OrderedPositiveTimeRegion d n →
+      iteratedFDeriv ℝ r (f : NPointDomain d n → ℂ) x = 0 := by
+  intro r x hxout
+  by_contra hne
+  have hx_support :
+      x ∈ Function.support (iteratedFDeriv ℝ r (f : NPointDomain d n → ℂ)) := by
+    simpa [Function.mem_support, hne]
+  exact hxout
+    (hf ((support_iteratedFDeriv_subset (𝕜 := ℝ) (n := r) (f := ⇑f)) hx_support))
+
+set_option maxHeartbeats 800000 in
+private theorem ruelle_timeGap_weighted_flatness_bound_explicit {n : ℕ}
+    (f : SchwartzNPoint d n)
+    (hf : tsupport ((f : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
+      OrderedPositiveTimeRegion d n)
+    (P m : ℕ) (k : Fin n) :
+    ∀ x : NPointDomain d n,
+      0 < ruelleTimeGap (d := d) x k →
+      ruelleTimeGap (d := d) x k ≤ 1 →
+      (1 + ‖x‖) ^ P * ‖f x‖ ≤
+        (2 ^ (P + P) * ((Finset.Iic (P, m + 1)).sup
+            (schwartzSeminormFamily ℂ (NPointDomain d n) ℂ)) f /
+          (Nat.factorial m : ℝ)) *
+          (ruelleTimeGap (d := d) x k) ^ (m + 1) := by
+  let sem := (Finset.Iic (P, m + 1)).sup
+    (schwartzSeminormFamily ℂ (NPointDomain d n) ℂ)
+  let A : ℝ := 2 ^ (P + P) * sem f
+  let A0 : ℝ := 2 ^ P * sem f
+  intro x hgap_pos hgap_le_one
+  let c : NPointDomain d n := ruelleGapBoundaryPoint (d := d) x k
+  let v : NPointDomain d n := x - c
+  let L : ℝ →L[ℝ] NPointDomain d n :=
+    ContinuousLinearMap.smulRight (1 : ℝ →L[ℝ] ℝ) v
+  let g : ℝ → ℂ :=
+    (fun z : NPointDomain d n => (f : NPointDomain d n → ℂ) (z + c)) ∘ L
+  have hshift_contDiff :
+      ∀ r : ℕ, ContDiff ℝ r
+        (fun z : NPointDomain d n => (f : NPointDomain d n → ℂ) (z + c)) :=
+    fun r => by
+      simpa using ((f : SchwartzNPoint d n).smooth r).comp (contDiff_id.add contDiff_const)
+  have hg_contDiff : ∀ r : ℕ, ContDiff ℝ r g := fun r => by
+    simpa [g] using (ContDiff.comp_continuousLinearMap (g := L) (hf := hshift_contDiff r))
+  have hc_out : c ∉ OrderedPositiveTimeRegion d n := by
+    simpa [c] using ruelleGapBoundaryPoint_not_mem_orderedPositiveTimeRegion (d := d) x k
+  have hTaylor_zero :
+      taylorWithinEval g m (Set.Icc (0 : ℝ) 1) 0 1 = 0 := by
+    rw [taylor_within_apply]
+    apply Finset.sum_eq_zero
+    intro r _hr
+    have hr_zero :
+        iteratedDerivWithin r g (Set.Icc (0 : ℝ) 1) 0 = 0 := by
+      rw [iteratedDerivWithin_eq_iteratedDeriv
+        (uniqueDiffOn_Icc (show (0 : ℝ) < 1 by norm_num))
+        ((hg_contDiff r).contDiffAt) (by simp), iteratedDeriv_eq_iteratedFDeriv]
+      have hcomp :
+          iteratedFDeriv ℝ r g 0 =
+            (iteratedFDeriv ℝ r
+              (fun z : NPointDomain d n => (f : NPointDomain d n → ℂ) (z + c))
+              (L 0)).compContinuousLinearMap fun _ : Fin r => L := by
+        simpa [g] using
+          L.iteratedFDeriv_comp_right
+            (f := fun z : NPointDomain d n => (f : NPointDomain d n → ℂ) (z + c))
+            (hshift_contDiff r) (x := 0) (i := r) le_rfl
+      have hzeroF :
+          iteratedFDeriv ℝ r (f : NPointDomain d n → ℂ) (L 0 + c) = 0 := by
+        have hzero := iteratedFDeriv_eq_zero_of_notMem_orderedPositiveTimeRegion
+          (d := d) f hf r c hc_out
+        simpa [L, ContinuousLinearMap.smulRight_apply] using hzero
+      rw [hcomp, iteratedFDeriv_comp_add_right, hzeroF]
+      simp
+    rw [hr_zero]
+    exact smul_zero _
+  have hv_norm_le_gap : ‖v‖ ≤ ruelleTimeGap (d := d) x k := by
+    have hv := norm_sub_ruelleGapBoundaryPoint_le (d := d) x k
+    have habs : |ruelleTimeGap (d := d) x k| = ruelleTimeGap (d := d) x k :=
+      abs_of_pos hgap_pos
+    simpa [v, c, habs] using hv
+  have hderiv_bound :
+      ∀ t ∈ Set.Icc (0 : ℝ) 1,
+        ‖iteratedDerivWithin (m + 1) g (Set.Icc (0 : ℝ) 1) t‖ ≤
+          (A / (1 + ‖x‖) ^ P) * (ruelleTimeGap (d := d) x k) ^ (m + 1) := by
+    intro t ht
+    have hsem_bound :
+        (1 + ‖L t + c‖) ^ P *
+            ‖iteratedFDeriv ℝ (m + 1) (f : NPointDomain d n → ℂ) (L t + c)‖ ≤
+          A0 := by
+      simpa [A0, sem] using
+        (SchwartzMap.one_add_le_sup_seminorm_apply
+          (𝕜 := ℂ) (m := (P, m + 1)) (k := P) (n := m + 1)
+          le_rfl le_rfl f (L t + c))
+    have hx_le_seg : 1 + ‖x‖ ≤ 2 * (1 + ‖L t + c‖) := by
+      have ht0 : 0 ≤ t := ht.1
+      have ht1 : t ≤ 1 := ht.2
+      have hx_eq : x = L t + c + ((1 - t) • v) := by
+        simp [L, v, c, ContinuousLinearMap.smulRight_apply, sub_eq_add_neg]
+        module
+      have hnorm_diff : ‖(1 - t) • v‖ ≤ 1 := by
+        calc
+          ‖(1 - t) • v‖ = |1 - t| * ‖v‖ := by
+            simp [norm_smul, Real.norm_eq_abs]
+          _ ≤ 1 * ruelleTimeGap (d := d) x k := by
+            have habs_le : |1 - t| ≤ 1 := by
+              rw [abs_of_nonneg (by linarith)]
+              linarith
+            gcongr
+          _ ≤ 1 := by simpa using hgap_le_one
+      calc
+        1 + ‖x‖ = 1 + ‖L t + c + ((1 - t) • v)‖ := by rw [hx_eq]
+        _ ≤ 1 + (‖L t + c‖ + ‖(1 - t) • v‖) := by
+          gcongr
+          exact norm_add_le (L t + c) ((1 - t) • v)
+        _ ≤ 1 + (‖L t + c‖ + 1) := by gcongr
+        _ ≤ 2 * (1 + ‖L t + c‖) := by
+          ring_nf
+          nlinarith [norm_nonneg (L t + c)]
+    have hpow_pos : 0 < (1 + ‖x‖) ^ P := by positivity
+    have hD :
+        ‖iteratedFDeriv ℝ (m + 1) (f : NPointDomain d n → ℂ) (L t + c)‖ ≤
+          A / (1 + ‖x‖) ^ P := by
+      rw [le_div_iff₀ hpow_pos]
+      have hpow_cmp :
+          (1 + ‖x‖) ^ P ≤ (2 : ℝ) ^ P * (1 + ‖L t + c‖) ^ P := by
+        calc
+          (1 + ‖x‖) ^ P ≤ (2 * (1 + ‖L t + c‖)) ^ P := by
+            exact pow_le_pow_left₀ (by positivity) hx_le_seg P
+          _ = (2 : ℝ) ^ P * (1 + ‖L t + c‖) ^ P := by rw [mul_pow]
+      calc
+        ‖iteratedFDeriv ℝ (m + 1) (f : NPointDomain d n → ℂ) (L t + c)‖ *
+            (1 + ‖x‖) ^ P
+            ≤ ‖iteratedFDeriv ℝ (m + 1) (f : NPointDomain d n → ℂ) (L t + c)‖ *
+                ((2 : ℝ) ^ P * (1 + ‖L t + c‖) ^ P) := by
+              gcongr
+        _ = (2 : ℝ) ^ P *
+              ((1 + ‖L t + c‖) ^ P *
+                ‖iteratedFDeriv ℝ (m + 1) (f : NPointDomain d n → ℂ) (L t + c)‖) := by
+              ring
+        _ ≤ (2 : ℝ) ^ P * A0 := by gcongr
+        _ = A := by
+          calc
+            (2 : ℝ) ^ P * A0 =
+                ((2 : ℝ) ^ P * (2 : ℝ) ^ P) * sem f := by
+                  simp [A0]
+                  ring
+            _ = A := by
+              simp [A, pow_add]
+    have hL : ‖L‖ ≤ ‖v‖ := by
+      refine ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg _) fun s => ?_
+      simpa [L, ContinuousLinearMap.smulRight_apply, Real.norm_eq_abs, norm_smul, mul_comm] using
+        (norm_smul s v)
+    rw [iteratedDerivWithin_eq_iteratedDeriv
+      (uniqueDiffOn_Icc (show (0 : ℝ) < 1 by norm_num))
+      ((hg_contDiff (m + 1)).contDiffAt) ht,
+      ← norm_iteratedFDeriv_eq_norm_iteratedDeriv]
+    have hcomp :
+        iteratedFDeriv ℝ (m + 1) g t =
+          (iteratedFDeriv ℝ (m + 1)
+            (fun z : NPointDomain d n => (f : NPointDomain d n → ℂ) (z + c))
+            (L t)).compContinuousLinearMap fun _ : Fin (m + 1) => L := by
+      simpa [g] using
+        L.iteratedFDeriv_comp_right
+          (f := fun z : NPointDomain d n => (f : NPointDomain d n → ℂ) (z + c))
+          (hshift_contDiff (m + 1)) (x := t) (i := m + 1) le_rfl
+    rw [hcomp, iteratedFDeriv_comp_add_right]
+    calc
+      ‖(iteratedFDeriv ℝ (m + 1) (f : NPointDomain d n → ℂ) (L t + c)).compContinuousLinearMap
+          (fun _ : Fin (m + 1) => L)‖ ≤
+          ‖iteratedFDeriv ℝ (m + 1) (f : NPointDomain d n → ℂ) (L t + c)‖ *
+            ∏ _ : Fin (m + 1), ‖L‖ := by
+              exact ContinuousMultilinearMap.norm_compContinuousLinearMap_le _ _
+      _ ≤ (A / (1 + ‖x‖) ^ P) * ∏ _ : Fin (m + 1), ‖L‖ := by gcongr
+      _ = (A / (1 + ‖x‖) ^ P) * ‖L‖ ^ (m + 1) := by simp
+      _ ≤ (A / (1 + ‖x‖) ^ P) * (ruelleTimeGap (d := d) x k) ^ (m + 1) := by
+          gcongr
+          exact hL.trans hv_norm_le_gap
+  have hrem :=
+    taylor_mean_remainder_bound (f := g) (a := (0 : ℝ)) (b := 1)
+      (C := (A / (1 + ‖x‖) ^ P) * (ruelleTimeGap (d := d) x k) ^ (m + 1))
+      (x := 1) (n := m) (by norm_num)
+      (hg_contDiff (m + 1)).contDiffOn (by simp) hderiv_bound
+  have hg_one : g 1 = f x := by
+    simp [g, L, v, c, ContinuousLinearMap.smulRight_apply, sub_eq_add_neg, add_comm,
+      add_left_comm, add_assoc]
+  have hpow_nonneg : 0 ≤ (1 + ‖x‖) ^ P := by positivity
+  calc
+    (1 + ‖x‖) ^ P * ‖f x‖ =
+        (1 + ‖x‖) ^ P * ‖g 1 - taylorWithinEval g m (Set.Icc (0 : ℝ) 1) 0 1‖ := by
+          rw [hg_one]
+          simp [hTaylor_zero]
+    _ ≤ (1 + ‖x‖) ^ P *
+          (((A / (1 + ‖x‖) ^ P) * (ruelleTimeGap (d := d) x k) ^ (m + 1)) *
+            (1 - (0 : ℝ)) ^ (m + 1) / (((Nat.factorial m : ℕ) : ℝ))) := by
+          exact mul_le_mul_of_nonneg_left (by simpa [hTaylor_zero] using hrem) hpow_nonneg
+    _ = (A / (((Nat.factorial m : ℕ) : ℝ))) *
+          (ruelleTimeGap (d := d) x k) ^ (m + 1) := by
+          have hpow_ne : (1 + ‖x‖) ^ P ≠ 0 := by positivity
+          field_simp [hpow_ne, Nat.cast_ne_zero]
+          ring
+
+private theorem inOpenForwardCone_of_pureTime_perturbation {d : ℕ} [NeZero d]
+    (t : ℝ) (ht : 0 < t) (w : Fin (d + 1) → ℝ)
+    (hw : ∀ μ, |w μ - (if μ = 0 then t else 0)| < t / (d + 2 : ℝ)) :
+    InOpenForwardCone d w := by
+  have hw0 : t * (d + 1 : ℝ) / (d + 2 : ℝ) < w 0 := by
+    have h0 := hw 0
+    simp at h0
+    have h0' := abs_lt.mp h0
+    have hdpos : (0 : ℝ) < d + 2 := by positivity
+    have htmp : t - t / (d + 2 : ℝ) < w 0 := by linarith
+    have heq : t - t / (d + 2 : ℝ) = t * (d + 1 : ℝ) / (d + 2 : ℝ) := by
+      field_simp [hdpos.ne']
+      ring
+    simpa [heq] using htmp
+  have hw0_pos : 0 < w 0 := by
+    have : 0 < t * (d + 1 : ℝ) / (d + 2 : ℝ) := by positivity
+    linarith
+  have hspatial : ∀ i : Fin d, (w i.succ) ^ 2 < (t / (d + 2 : ℝ)) ^ 2 := by
+    intro i
+    have hi := hw i.succ
+    simp only [Fin.succ_ne_zero, if_false, sub_zero] at hi
+    have hi' := abs_lt.mp hi
+    nlinarith
+  have hspatial_sum : MinkowskiSpace.spatialNormSq d w ≤
+      (d : ℝ) * (t / (d + 2 : ℝ)) ^ 2 := by
+    unfold MinkowskiSpace.spatialNormSq
+    calc
+      ∑ i : Fin d, (w i.succ) ^ 2 ≤ ∑ _i : Fin d, (t / (d + 2 : ℝ)) ^ 2 := by
+        exact Finset.sum_le_sum (fun i _ => le_of_lt (hspatial i))
+      _ = (d : ℝ) * (t / (d + 2 : ℝ)) ^ 2 := by
+        simp [Finset.sum_const]
+  refine ⟨hw0_pos, ?_⟩
+  rw [MinkowskiSpace.minkowskiNormSq_decomp]
+  have hmain : MinkowskiSpace.spatialNormSq d w < (w 0) ^ 2 := by
+    calc
+      MinkowskiSpace.spatialNormSq d w ≤ (d : ℝ) * (t / (d + 2 : ℝ)) ^ 2 :=
+        hspatial_sum
+      _ < (t * (d + 1 : ℝ) / (d + 2 : ℝ)) ^ 2 := by
+        have hdlt : (d : ℝ) < (d + 1 : ℝ) ^ 2 := by nlinarith
+        have hsqpos : 0 < (t / (d + 2 : ℝ)) ^ 2 := by positivity
+        have heq :
+            (t * (d + 1 : ℝ) / (d + 2 : ℝ)) ^ 2 =
+              ((d + 1 : ℝ) ^ 2) * (t / (d + 2 : ℝ)) ^ 2 := by
+          ring
+        rw [heq]
+        nlinarith
+      _ < (w 0) ^ 2 := by
+        have haux : 0 ≤ t * (d + 1 : ℝ) / (d + 2 : ℝ) := by positivity
+        nlinarith [hw0, hw0_pos, haux]
+  nlinarith
+
+private lemma infDist_pureTime_openForwardConeSet_compl_lower
+    (t : ℝ) (ht : 0 < t) :
+    t / (d + 2 : ℝ) ≤
+      Metric.infDist (fun μ : Fin (d + 1) => if μ = 0 then t else 0)
+        (openForwardConeSet d)ᶜ := by
+  have hcompl_nonempty : ((openForwardConeSet d)ᶜ : Set (Fin (d + 1) → ℝ)).Nonempty := by
+    exact ⟨0, fun h => by
+      have h0 := h.1
+      simp [openForwardConeSet, InOpenForwardCone] at h0⟩
+  refine (Metric.le_infDist hcompl_nonempty).2 ?_
+  intro u hu
+  by_contra hlt
+  have hdist :
+      dist (fun μ : Fin (d + 1) => if μ = 0 then t else 0) u < t / (d + 2 : ℝ) := by
+    linarith
+  have hu_cone : u ∈ openForwardConeSet d := by
+    dsimp [openForwardConeSet]
+    apply inOpenForwardCone_of_pureTime_perturbation (t := t) ht
+    intro μ
+    have hcoord :
+        |u μ - (if μ = 0 then t else 0)| ≤
+          ‖u - (fun μ : Fin (d + 1) => if μ = 0 then t else 0)‖ := by
+      rw [← Real.norm_eq_abs]
+      exact norm_le_pi_norm (u - (fun μ : Fin (d + 1) => if μ = 0 then t else 0)) μ
+    have hnorm :
+        ‖u - (fun μ : Fin (d + 1) => if μ = 0 then t else 0)‖ < t / (d + 2 : ℝ) := by
+      simpa [dist_eq_norm, norm_sub_rev] using hdist
+    exact lt_of_le_of_lt hcoord hnorm
+  exact hu hu_cone
+
+private lemma wick_imaginary_consecutiveDiff_eq_timeGap {n : ℕ} [NeZero n]
+    (x : NPointDomain d n) (k : Fin n) :
+    (fun μ : Fin (d + 1) =>
+      (wickRotatePoint (x k) μ).im -
+        (if k = 0 then 0
+         else (wickRotatePoint (x ⟨(k : ℕ) - 1, by omega⟩) μ).im)) =
+      fun μ : Fin (d + 1) => if μ = 0 then ruelleTimeGap (d := d) x k else 0 := by
+  funext μ
+  by_cases hk : k = 0
+  · subst k
+    by_cases hμ : μ = 0 <;> simp [wickRotatePoint, ruelleTimeGap, hμ]
+  · have hkNat : ¬ (k : ℕ) = 0 := fun h => hk (Fin.ext h)
+    by_cases hμ : μ = 0 <;> simp [wickRotatePoint, ruelleTimeGap, hk, hkNat, hμ]
+
+private lemma tubeBoundaryDist_wick_lower_of_timeGap_le {n : ℕ} [NeZero n]
+    (x : NPointDomain d n) (s : ℝ)
+    (hs_pos : 0 < s) (hs_le : ∀ k : Fin n, s ≤ ruelleTimeGap (d := d) x k) :
+    s / (d + 2 : ℝ) ≤ tubeBoundaryDist (d := d) (fun k => wickRotatePoint (x k)) := by
+  have hn : n ≠ 0 := NeZero.ne n
+  simp [tubeBoundaryDist, hn]
+  refine le_ciInf ?_
+  intro k
+  rw [wick_imaginary_consecutiveDiff_eq_timeGap]
+  have hgap_pos : 0 < ruelleTimeGap (d := d) x k := lt_of_lt_of_le hs_pos (hs_le k)
+  calc
+    s / (d + 2 : ℝ) ≤ ruelleTimeGap (d := d) x k / (d + 2 : ℝ) := by
+      exact div_le_div_of_nonneg_right (hs_le k) (by positivity)
+    _ ≤ Metric.infDist
+        (fun μ : Fin (d + 1) => if μ = 0 then ruelleTimeGap (d := d) x k else 0)
+        (openForwardConeSet d)ᶜ :=
+      infDist_pureTime_openForwardConeSet_compl_lower (d := d) _ hgap_pos
+
+private lemma regulator_small_timeGap_bound (M : ℕ) {s δ : ℝ}
+    (hs_pos : 0 < s) (hs_le : s ≤ 1) (hδ : s / (d + 2 : ℝ) ≤ δ) :
+    (1 + δ⁻¹) ^ M * s ^ (M + 1) ≤ (d + 3 : ℝ) ^ M := by
+  have hden_pos : (0 : ℝ) < d + 2 := by positivity
+  have hlower_pos : 0 < s / (d + 2 : ℝ) := div_pos hs_pos hden_pos
+  have hδ_pos : 0 < δ := lt_of_lt_of_le hlower_pos hδ
+  have hinv : δ⁻¹ ≤ (s / (d + 2 : ℝ))⁻¹ := by
+    simpa [one_div] using one_div_le_one_div_of_le hlower_pos hδ
+  have hmul_inv : δ⁻¹ * s ≤ (d + 2 : ℝ) := by
+    calc
+      δ⁻¹ * s ≤ (s / (d + 2 : ℝ))⁻¹ * s := by gcongr
+      _ = (d + 2 : ℝ) := by
+        field_simp [hs_pos.ne', hden_pos.ne']
+  have hterm : (1 + δ⁻¹) * s ≤ (d + 3 : ℝ) := by
+    calc
+      (1 + δ⁻¹) * s = s + δ⁻¹ * s := by ring
+      _ ≤ 1 + (d + 2 : ℝ) := by gcongr
+      _ = (d + 3 : ℝ) := by ring
+  calc
+    (1 + δ⁻¹) ^ M * s ^ (M + 1) = ((1 + δ⁻¹) * s) ^ M * s := by
+      rw [pow_succ', mul_pow]
+      ring
+    _ ≤ (d + 3 : ℝ) ^ M * 1 := by
+      gcongr
+    _ = (d + 3 : ℝ) ^ M := by ring
+
+private lemma regulator_large_timeGap_bound (M : ℕ) {δ : ℝ}
+    (hδ : (1 : ℝ) / (d + 2 : ℝ) ≤ δ) :
+    (1 + δ⁻¹) ^ M ≤ (d + 3 : ℝ) ^ M := by
+  have hden_pos : (0 : ℝ) < d + 2 := by positivity
+  have hlower_pos : 0 < (1 : ℝ) / (d + 2 : ℝ) := div_pos zero_lt_one hden_pos
+  have hδ_pos : 0 < δ := lt_of_lt_of_le hlower_pos hδ
+  have hinv : δ⁻¹ ≤ ((1 : ℝ) / (d + 2 : ℝ))⁻¹ := by
+    simpa [one_div] using one_div_le_one_div_of_le hlower_pos hδ
+  have hterm : 1 + δ⁻¹ ≤ (d + 3 : ℝ) := by
+    calc
+      1 + δ⁻¹ ≤ 1 + ((1 : ℝ) / (d + 2 : ℝ))⁻¹ := by gcongr
+      _ = (d + 3 : ℝ) := by
+        field_simp [hden_pos.ne']
+        ring
+  exact pow_le_pow_left₀ (by nlinarith [inv_nonneg.mpr hδ_pos.le]) hterm M
+
 /-! ### Helper definitions for the cluster proof -/
 
 /-- The `a`-parametrized integrand on `NPointDomain d n × NPointDomain d m`,
@@ -704,10 +1171,7 @@ Consequently `(1 + Δ⁻¹)^M · ‖f‖` is integrable after all:
 
 With this dominator integrable, `W_analytic_cluster_integral_via_ruelle` closes by
 ordinary `tendsto_integral_filter_of_dominated_convergence` — no IBP, no
-distributional restatement, no GNS/Hilbert machinery.
-
-TODO(cluster-dct): the proof below is the structured plan; the 1-D-Taylor-along-a
--coordinate bound and its assembly over gaps are the remaining engineering. -/
+distributional restatement, no GNS/Hilbert machinery. -/
 theorem block_regulator_dominator_integrable {n : ℕ}
     (f : SchwartzNPoint d n)
     (hf : tsupport ((f : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
@@ -718,11 +1182,208 @@ theorem block_regulator_dominator_integrable {n : ℕ}
         C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
           * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
           * ‖f x‖) := by
-  -- Step A: tubeBoundaryDist(wick x) ≥ c · min_k gap_k  (geometry of the cone).
-  -- Step B: (1 + Δ⁻¹)^M ≤ 2^M (1 + Σ_k gap_k⁻ᴹ); reduce to single-gap terms.
-  -- Step C: f ≡ 0 on {gap_k ≤ 0} (from tsupport ⊆ open OPTR); 1-D Taylor along
-  --         gap_k gives gap_k^{-M}‖f‖ ≤ (1/M!) sup_σ ‖∂^M f‖, integrable.
-  sorry
+  classical
+  haveI : MeasureTheory.Measure.IsAddHaarMeasure
+      (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)) :=
+    MeasureTheory.Measure.instIsAddHaarMeasureForallVolumeOfMeasurableAddOfSigmaFinite
+  haveI : (MeasureTheory.volume : MeasureTheory.Measure (NPointDomain d n)).HasTemperateGrowth :=
+    inferInstance
+  by_cases hn0 : n = 0
+  · subst n
+    have hbase :
+        MeasureTheory.Integrable
+          (fun x : NPointDomain d 0 => (1 + ‖x‖) ^ N * ‖f x‖) :=
+      schwartz_integrable_add_pow_mul (f := f) N
+    have hconst :
+        (fun x : NPointDomain d 0 =>
+          C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
+            * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
+            * ‖f x‖) =
+        fun x : NPointDomain d 0 =>
+          (C * (1 + (1 : ℝ)⁻¹) ^ M) * ((1 + ‖x‖) ^ N * ‖f x‖) := by
+      funext x
+      rw [wickRotate_norm_eq]
+      simp [tubeBoundaryDist]
+      ring
+    rw [hconst]
+    exact hbase.const_mul (C * (1 + (1 : ℝ)⁻¹) ^ M)
+  · haveI : NeZero n := ⟨hn0⟩
+    let D : ℕ := Module.finrank ℝ (NPointDomain d n)
+    let P : ℕ := N + D + 2
+    let flatC : ℝ :=
+      2 ^ (P + P) *
+        ((Finset.Iic (P, M + 1)).sup
+          (schwartzSeminormFamily ℂ (NPointDomain d n) ℂ)) f /
+        (Nat.factorial M : ℝ)
+    let regC : ℝ := (d + 3 : ℝ) ^ M
+    let smallC : ℝ := |C| * flatC * regC
+    let largeC : ℝ := |C| * regC
+    have hflatC_nonneg : 0 ≤ flatC := by
+      positivity
+    have hregC_nonneg : 0 ≤ regC := by
+      positivity
+    have hsmallC_nonneg : 0 ≤ smallC := by
+      positivity
+    have hlargeC_nonneg : 0 ≤ largeC := by
+      positivity
+    have hD_lt : (D : ℝ) < (D + 2 : ℕ) := by
+      push_cast
+      linarith
+    have htail_int :
+        MeasureTheory.Integrable
+          (fun x : NPointDomain d n => (1 + ‖x‖) ^ (-(↑(D + 2) : ℝ)))
+          MeasureTheory.volume :=
+      integrable_one_add_norm hD_lt
+    have hdom_int :
+        MeasureTheory.Integrable
+          (fun x : NPointDomain d n =>
+            smallC * (1 + ‖x‖) ^ (-(↑(D + 2) : ℝ)) +
+              largeC * ((1 + ‖x‖) ^ N * ‖f x‖)) := by
+      exact (htail_int.const_mul smallC).add
+        ((schwartz_integrable_add_pow_mul (f := f) N).const_mul largeC)
+    refine hdom_int.mono' ?_ ?_
+    · have hcont_wick :
+          Continuous (fun x : NPointDomain d n => fun k => wickRotatePoint (x k)) := by
+        apply continuous_pi
+        intro k
+        apply continuous_pi
+        intro μ
+        by_cases hμ : μ = 0
+        · simp [wickRotatePoint, hμ]
+          fun_prop
+        · simp [wickRotatePoint, hμ]
+          fun_prop
+      have hcont_wick_norm :
+          Continuous (fun x : NPointDomain d n => ‖(fun k => wickRotatePoint (x k))‖) :=
+        hcont_wick.norm
+      have hcont_tube :
+          Continuous (fun x : NPointDomain d n =>
+            tubeBoundaryDist (d := d) (fun k => wickRotatePoint (x k))) := by
+        exact continuous_tubeBoundaryDist (d := d) |>.comp hcont_wick
+      refine (((continuous_const.mul
+        ((continuous_const.add hcont_wick_norm).pow N)).measurable.mul ?_).mul
+          f.continuous.norm.measurable).aestronglyMeasurable
+      exact (hcont_tube.measurable.inv.const_add 1).pow_const M
+    · refine Filter.Eventually.of_forall fun x => ?_
+      by_cases hx_optr : x ∈ OrderedPositiveTimeRegion d n
+      · obtain ⟨kmin, _hk_mem, hkmin⟩ :=
+          Finset.exists_min_image (Finset.univ : Finset (Fin n))
+            (fun k => ruelleTimeGap (d := d) x k) Finset.univ_nonempty
+        let s : ℝ := ruelleTimeGap (d := d) x kmin
+        have hs_pos : 0 < s := by
+          simpa [s] using ruelleTimeGap_pos_of_mem_orderedPositiveTimeRegion
+            (d := d) hx_optr kmin
+        have hs_le : ∀ k : Fin n, s ≤ ruelleTimeGap (d := d) x k := by
+          intro k
+          simpa [s] using hkmin k (Finset.mem_univ k)
+        let δ : ℝ := tubeBoundaryDist (d := d) (fun k => wickRotatePoint (x k))
+        have hδ_lower : s / (d + 2 : ℝ) ≤ δ := by
+          simpa [δ] using tubeBoundaryDist_wick_lower_of_timeGap_le (d := d) x s hs_pos hs_le
+        have hδ_pos : 0 < δ := by
+          have hden_pos : (0 : ℝ) < d + 2 := by positivity
+          exact lt_of_lt_of_le (div_pos hs_pos hden_pos) hδ_lower
+        have hwick : ‖(fun k => wickRotatePoint (x k))‖ = ‖x‖ :=
+          wickRotate_norm_eq (d := d) x
+        have htarget_abs :
+            ‖C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
+                * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
+                * ‖f x‖‖ =
+              |C| * (1 + ‖x‖) ^ N * (1 + δ⁻¹) ^ M * ‖f x‖ := by
+          rw [Real.norm_eq_abs]
+          simp only [hwick, δ]
+          rw [abs_mul, abs_mul, abs_mul]
+          have hpoly_nonneg : 0 ≤ (1 + ‖x‖) ^ N := by positivity
+          have hreg_nonneg : 0 ≤ (1 + δ⁻¹) ^ M := by
+            have hbase : 0 ≤ 1 + δ⁻¹ := by
+              nlinarith [inv_nonneg.mpr hδ_pos.le]
+            exact pow_nonneg hbase M
+          rw [abs_of_nonneg hpoly_nonneg, abs_of_nonneg hreg_nonneg,
+            abs_of_nonneg (norm_nonneg (f x))]
+        by_cases hs_small : s ≤ 1
+        · have hflat :=
+            ruelle_timeGap_weighted_flatness_bound_explicit (d := d) f hf P M kmin
+              x hs_pos hs_small
+          have hflat_div :
+              (1 + ‖x‖) ^ N * ‖f x‖ ≤
+                flatC * s ^ (M + 1) / (1 + ‖x‖) ^ (D + 2) := by
+            have hden_pos : 0 < (1 + ‖x‖) ^ (D + 2) := by positivity
+            rw [le_div_iff₀ hden_pos]
+            calc
+              ((1 + ‖x‖) ^ N * ‖f x‖) * (1 + ‖x‖) ^ (D + 2)
+                  = (1 + ‖x‖) ^ P * ‖f x‖ := by
+                    simp [P]
+                    rw [pow_add]
+                    ring
+              _ ≤ flatC * s ^ (M + 1) := by
+                    simpa [flatC, s] using hflat
+          have hreg_small :
+              (1 + δ⁻¹) ^ M * s ^ (M + 1) ≤ regC := by
+            simpa [regC] using regulator_small_timeGap_bound (d := d) M hs_pos hs_small hδ_lower
+          calc
+            ‖C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
+                * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
+                * ‖f x‖‖
+                = |C| * (1 + ‖x‖) ^ N * (1 + δ⁻¹) ^ M * ‖f x‖ :=
+                  htarget_abs
+            _ = |C| * (1 + δ⁻¹) ^ M * ((1 + ‖x‖) ^ N * ‖f x‖) := by ring
+            _ ≤ |C| * (1 + δ⁻¹) ^ M *
+                  (flatC * s ^ (M + 1) / (1 + ‖x‖) ^ (D + 2)) := by
+                    gcongr
+            _ = |C| * flatC *
+                  ((1 + δ⁻¹) ^ M * s ^ (M + 1)) /
+                  (1 + ‖x‖) ^ (D + 2) := by ring
+            _ ≤ |C| * flatC * regC / (1 + ‖x‖) ^ (D + 2) := by
+                  gcongr
+            _ = smallC * (1 + ‖x‖) ^ (-(↑(D + 2) : ℝ)) := by
+                  rw [Real.rpow_neg (by positivity), Real.rpow_natCast]
+                  field_simp
+                  ring
+            _ ≤ smallC * (1 + ‖x‖) ^ (-(↑(D + 2) : ℝ)) +
+                  largeC * ((1 + ‖x‖) ^ N * ‖f x‖) := by
+                    have hlarge_term :
+                        0 ≤ largeC * ((1 + ‖x‖) ^ N * ‖f x‖) := by positivity
+                    linarith
+        · have hs_one_le : (1 : ℝ) ≤ s := le_of_not_ge hs_small
+          have hδ_one_lower : (1 : ℝ) / (d + 2 : ℝ) ≤ δ := by
+            calc
+              (1 : ℝ) / (d + 2 : ℝ) ≤ s / (d + 2 : ℝ) := by
+                exact div_le_div_of_nonneg_right hs_one_le (by positivity)
+              _ ≤ δ := hδ_lower
+          have hreg_large : (1 + δ⁻¹) ^ M ≤ regC := by
+            simpa [regC] using regulator_large_timeGap_bound (d := d) M hδ_one_lower
+          calc
+            ‖C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
+                * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
+                * ‖f x‖‖
+                = |C| * (1 + ‖x‖) ^ N * (1 + δ⁻¹) ^ M * ‖f x‖ :=
+                  htarget_abs
+            _ ≤ |C| * (1 + ‖x‖) ^ N * regC * ‖f x‖ := by
+                  gcongr
+            _ = largeC * ((1 + ‖x‖) ^ N * ‖f x‖) := by
+                  simp [largeC]
+                  ring
+            _ ≤ smallC * (1 + ‖x‖) ^ (-(↑(D + 2) : ℝ)) +
+                  largeC * ((1 + ‖x‖) ^ N * ‖f x‖) := by
+                    have hsmall_tail :
+                        0 ≤ smallC * (1 + ‖x‖) ^ (-(↑(D + 2) : ℝ)) := by
+                      positivity
+                    linarith
+      · have hf_zero : (f : NPointDomain d n → ℂ) x = 0 := by
+          have h_notInTsupp :
+              x ∉ tsupport ((f : SchwartzNPoint d n) : NPointDomain d n → ℂ) :=
+            fun hxts => hx_optr (hf hxts)
+          exact image_eq_zero_of_notMem_tsupport h_notInTsupp
+        have hdom_nonneg :
+            0 ≤ smallC * (1 + ‖x‖) ^ (-(↑(D + 2) : ℝ)) +
+              largeC * ((1 + ‖x‖) ^ N * ‖f x‖) := by
+          positivity
+        calc
+          ‖C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
+              * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
+              * ‖f x‖‖ = 0 := by
+                simp [hf_zero]
+          _ ≤ smallC * (1 + ‖x‖) ^ (-(↑(D + 2) : ℝ)) +
+              largeC * ((1 + ‖x‖) ^ N * ‖f x‖) := hdom_nonneg
 
 /-- **Cluster theorem for the Wick-rotated boundary integral**.
 

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean
@@ -1144,6 +1144,160 @@ noncomputable def clusterLimitIntegrand
       (fun k => wickRotatePoint (p.2 k)) *
     (f p.1) * (g p.2)
 
+private lemma spatial_norm_sq_le_sum_sq {d : ℕ} [NeZero d] (a : Fin d → ℝ) :
+    ‖a‖ ^ 2 ≤ ∑ i : Fin d, (a i) ^ 2 := by
+  have hne : (Finset.univ : Finset (Fin d)).Nonempty := Finset.univ_nonempty
+  obtain ⟨i, _hi, hsup⟩ :=
+    Finset.exists_mem_eq_sup (s := (Finset.univ : Finset (Fin d))) hne
+      (fun i => ‖a i‖₊)
+  have hnorm_eq : ‖a‖ = ‖a i‖ := by
+    rw [Pi.norm_def, hsup]
+    simp
+  calc
+    ‖a‖ ^ 2 = (a i) ^ 2 := by
+      rw [hnorm_eq, Real.norm_eq_abs, sq_abs]
+    _ ≤ ∑ j : Fin d, (a j) ^ 2 := by
+      exact Finset.single_le_sum (fun j _ => sq_nonneg (a j)) (Finset.mem_univ i)
+
+private lemma spatialOf_norm_eq_of_time_zero {d : ℕ} (a : SpacetimeDim d)
+    (ha0 : a 0 = 0) :
+    ‖(fun i : Fin d => a (Fin.succ i))‖ = ‖a‖ := by
+  simp only [Pi.norm_def]
+  congr 1
+  apply le_antisymm
+  · refine Finset.sup_le (fun i _ => ?_)
+    exact Finset.le_sup (f := fun j : Fin (d + 1) => ‖a j‖₊)
+      (Finset.mem_univ (Fin.succ i))
+  · refine Finset.sup_le (fun i _ => ?_)
+    rcases Fin.eq_zero_or_eq_succ i with hi | ⟨j, rfl⟩
+    · subst hi
+      have h_a0_zero : ‖a 0‖₊ = 0 := by
+        rw [nnnorm_eq_zero]
+        exact ha0
+      rw [h_a0_zero]
+      exact zero_le _
+    · exact Finset.le_sup (f := fun j : Fin d => ‖a (Fin.succ j)‖₊)
+        (Finset.mem_univ j)
+
+private lemma spatial_sq_sum_gt_of_norm_gt {d : ℕ} [NeZero d]
+    (a : SpacetimeDim d) {R : ℝ}
+    (hR : 0 < R) (ha0 : a 0 = 0) (ha_norm : R < ‖a‖) :
+    R ^ 2 < ∑ i : Fin d, (a (Fin.succ i)) ^ 2 := by
+  have hnorm_eq := spatialOf_norm_eq_of_time_zero (d := d) a ha0
+  have hsq_le := spatial_norm_sq_le_sum_sq (d := d)
+    (fun i : Fin d => a (Fin.succ i))
+  have hR_sq_lt : R ^ 2 < ‖(fun i : Fin d => a (Fin.succ i))‖ ^ 2 := by
+    rw [hnorm_eq]
+    exact pow_lt_pow_left₀ ha_norm hR.le (by norm_num)
+  exact lt_of_lt_of_le hR_sq_lt hsq_le
+
+private lemma tubeBoundaryDist_nonneg {d n : ℕ} [NeZero d]
+    (z : Fin n → Fin (d + 1) → ℂ) :
+    0 ≤ tubeBoundaryDist (d := d) z := by
+  rw [tubeBoundaryDist]
+  by_cases hn : n = 0
+  · simp [hn]
+  · simp only [dif_neg hn]
+    haveI : NeZero n := ⟨hn⟩
+    exact le_ciInf (f := fun k : Fin n =>
+      Metric.infDist
+        (fun μ : Fin (d + 1) =>
+          (z k μ).im -
+            (if hk : (k : ℕ) = 0 then 0
+             else (z ⟨(k : ℕ) - 1, by omega⟩ μ).im))
+        (openForwardConeSet d)ᶜ) (fun _ => Metric.infDist_nonneg)
+
+private lemma tubeBoundaryRegulator_nonneg {d n : ℕ} [NeZero d] (M : ℕ)
+    (z : Fin n → Fin (d + 1) → ℂ) :
+    0 ≤ (1 + (tubeBoundaryDist (d := d) z)⁻¹) ^ M := by
+  have hδ : 0 ≤ tubeBoundaryDist (d := d) z := tubeBoundaryDist_nonneg (d := d) z
+  exact pow_nonneg (by linarith [inv_nonneg.mpr hδ]) M
+
+private lemma one_add_add_pow_le_two_pow_mul (N : ℕ) {x y : ℝ}
+    (hx : 0 ≤ x) (hy : 0 ≤ y) :
+    (1 + x + y) ^ N ≤ 2 ^ N * (1 + x) ^ N * (1 + y) ^ N := by
+  have hbase_nonneg : 0 ≤ 1 + x + y := by positivity
+  have hbase : 1 + x + y ≤ 2 * ((1 + x) * (1 + y)) := by
+    nlinarith [mul_nonneg (by positivity : 0 ≤ 1 + x) (by positivity : 0 ≤ 1 + y),
+      hx, hy]
+  calc
+    (1 + x + y) ^ N ≤ (2 * ((1 + x) * (1 + y))) ^ N :=
+      pow_le_pow_left₀ hbase_nonneg hbase N
+    _ = 2 ^ N * (1 + x) ^ N * (1 + y) ^ N := by
+      rw [mul_pow, mul_pow]
+      ring
+
+private lemma clusterIntegrand_aestronglyMeasurable
+    (Wfn : WightmanFunctions d) {n m : ℕ}
+    (f : SchwartzNPoint d n) (g : SchwartzNPoint d m)
+    (a : SpacetimeDim d) :
+    MeasureTheory.AEStronglyMeasurable
+      (clusterIntegrand Wfn f g a)
+      (MeasureTheory.volume : MeasureTheory.Measure
+        (NPointDomain d n × NPointDomain d m)) := by
+  let v_a : NPointDomain d (n + m) :=
+    Fin.append (0 : NPointDomain d n)
+      (fun _ μ => if μ = 0 then (0 : ℝ) else a μ)
+  let e_append : NPointDomain d n × NPointDomain d m ≃ᵐ NPointDomain d (n + m) :=
+    (MeasurableEquiv.finAddProd n m (Fin (d + 1) → ℝ)).symm
+  let e_trans : NPointDomain d (n + m) ≃ᵐ NPointDomain d (n + m) :=
+    MeasurableEquiv.addLeft v_a
+  let J : NPointDomain d n × NPointDomain d m ≃ᵐ NPointDomain d (n + m) :=
+    e_append.trans e_trans
+  have hJ_mp : MeasureTheory.MeasurePreserving J
+      (MeasureTheory.volume.prod MeasureTheory.volume) MeasureTheory.volume := by
+    have h_append_mp : MeasureTheory.MeasurePreserving e_append
+        (MeasureTheory.volume.prod MeasureTheory.volume) MeasureTheory.volume :=
+      (MeasureTheory.volume_preserving_finAddProd n m (Fin (d + 1) → ℝ)).symm
+    have h_trans_mp : MeasureTheory.MeasurePreserving e_trans
+        MeasureTheory.volume MeasureTheory.volume :=
+      MeasureTheory.measurePreserving_add_left MeasureTheory.volume v_a
+    exact h_append_mp.trans h_trans_mp
+  have hJ_apply : ∀ p : NPointDomain d n × NPointDomain d m,
+      J p = v_a + Fin.append p.1 p.2 := by
+    intro p
+    change v_a + (MeasurableEquiv.finAddProd n m (Fin (d + 1) → ℝ)).symm p =
+      v_a + Fin.append p.1 p.2
+    congr 1
+    exact MeasurableEquiv.finAddProd_symm_apply n m p.1 p.2
+  have h_wick_eq : ∀ p : NPointDomain d n × NPointDomain d m,
+      (fun k => wickRotatePoint (J p k)) =
+      Fin.append (fun k => wickRotatePoint (p.1 k))
+        (fun k μ => wickRotatePoint (p.2 k) μ +
+          (if μ = 0 then (0 : ℂ) else (a μ : ℂ))) := by
+    intro p
+    rw [hJ_apply p]
+    funext k μ
+    refine Fin.addCases (fun _ => ?_) (fun _ => ?_) k
+    · simp [v_a, Fin.append_left]
+    · simp [v_a, Fin.append_right]
+      by_cases hμ : μ = 0
+      · subst hμ
+        simp [wickRotatePoint]
+      · simp [wickRotatePoint, hμ]
+        ring
+  have hK : MeasureTheory.AEStronglyMeasurable
+      (fun p : NPointDomain d n × NPointDomain d m =>
+        F_ext_on_translatedPET_total Wfn (fun k => wickRotatePoint (J p k)))
+      (MeasureTheory.volume.prod MeasureTheory.volume) := by
+    exact (bhw_euclidean_kernel_measurable (d := d) (n := n + m) Wfn).comp_measurePreserving
+      hJ_mp
+  have hf_asm : MeasureTheory.AEStronglyMeasurable
+      (fun p : NPointDomain d n × NPointDomain d m => f p.1)
+      (MeasureTheory.volume.prod MeasureTheory.volume) := by
+    exact (f.continuous.comp continuous_fst).aestronglyMeasurable
+  have hg_asm : MeasureTheory.AEStronglyMeasurable
+      (fun p : NPointDomain d n × NPointDomain d m => g p.2)
+      (MeasureTheory.volume.prod MeasureTheory.volume) := by
+    exact (g.continuous.comp continuous_snd).aestronglyMeasurable
+  rw [show (MeasureTheory.volume : MeasureTheory.Measure
+      (NPointDomain d n × NPointDomain d m)) =
+    MeasureTheory.volume.prod MeasureTheory.volume from rfl]
+  have hprod := (hK.mul hf_asm).mul hg_asm
+  refine hprod.congr ?_
+  filter_upwards with p
+  simp [clusterIntegrand, h_wick_eq p, mul_assoc]
+
 /-! ### W_analytic_cluster_integral via Ruelle + DC -/
 
 /-- **Single-block flatness ⇒ the regulated dominator is integrable.**
@@ -1694,92 +1848,340 @@ theorem W_analytic_cluster_integral_via_ruelle
         exact image_eq_zero_of_notMem_tsupport h_notInTsupp
       simp [clusterIntegrand, clusterLimitIntegrand, h_f_zero]
       exact tendsto_const_nhds
-  -- Step 4–7: dominator + dominated convergence + ε-R conversion.
-  --
-  -- BLOCKED ON RACH.bound REFACTOR (2026-05-08): the bound shape was
-  -- updated to include the Streater-Wightman boundary-distance
-  -- regulator `(1 + (tubeBoundaryDist z)⁻¹)^M` after the previous
-  -- shape was found unsatisfiable for any Wightman QFT (free-field
-  -- counterexample via Wick decomposition; see
-  -- `docs/ruelle_bound_vacuity_concern.md`).
-  --
-  -- The previous dominator `C_R · (1+‖p₁‖+‖p₂‖)^N_R · ‖f(p₁)‖ · ‖g(p₂)‖`
-  -- is no longer typed correctly: the new bound delivers the regulator
-  -- factor `(1 + (tubeBoundaryDist (wick p))⁻¹)^M_R` as well.
-  --
-  -- ### Fillability case for this `sorry`
-  --
-  -- The math is classical (Streater-Wightman §3.4 / Ruelle 1962 /
-  -- Araki-Hepp-Ruelle 1962): use the **Schwartz dual pairing**
-  -- instead of a pointwise dominator.
-  --
-  --   1. By `fl_representation_from_bv` (existing project axiom in
-  --      `OSReconstruction/SCV/VladimirovTillmann.lean`):
-  --        `W_analytic_BHW(z) = (FL Tflat)(z)`
-  --      for some tempered distribution `Tflat` on the dual cone
-  --      (where `Tflat : SchwartzMap → ℂ` is a `ContinuousLinearMap`).
-  --   2. The cluster integrand
-  --        `W_analytic_BHW(joint(wick p₁, wick p₂ + (0,a))) · f(p₁) · g(p₂)`
-  --      integrates over `(p₁, p₂)` to
-  --        `Tflat(ψ_a)`
-  --      where `ψ_a ∈ Schwartz(dual)` is constructed by Fubini-pairing
-  --      `(f ⊗ g_a)` with the Wick-rotated kernel.
-  --   3. Continuity of `Tflat` on Schwartz:
-  --        `‖Tflat ψ‖ ≤ ‖Tflat‖ · ‖ψ‖_{seminorm}`.
-  --   4. `‖ψ_a‖_{seminorm}` is uniformly bounded in `a` by translation-
-  --      invariance of Schwartz seminorms (`g_a(x) := g(x - a)`).
-  --   5. → uniform `ε`-R conclusion, no pointwise dominator needed.
-  --
-  -- ### Available Lean infrastructure
-  --
-  -- * `bv_implies_fourier_support` (axiom, VladimirovTillmann.lean:148)
-  --   — produces `Tflat` from polynomial-bounded boundary value.
-  -- * `fl_representation_from_bv` (axiom, same file:392)
-  --   — gives `W = FL extension of Tflat`.
-  -- * `fourierLaplaceExtMultiDim_vladimirov_growth` (PROVED in
-  --   PaleyWienerSchwartz.lean:3286) — the regulated growth bound.
-  -- * Mathlib has Schwartz-Fubini and Schwartz-CLM continuity in the
-  --   standard form needed for steps (2)–(4).
-  --
-  -- ### Identified gap
-  --
-  -- `bv_implies_fourier_support`'s **hypothesis** asks for the
-  -- *unregulated* polynomial growth on the tube — the same shape just
-  -- shown unsatisfiable. The companion theorem
-  -- `full_analytic_continuation_with_symmetry_growth`
-  -- (`OSToWightman.lean:2553`) is supposed to supply this growth for
-  -- OS-derived Wightman functions, but `#print axioms` shows it
-  -- depends on `sorryAx` — i.e., it is not actually proved either.
-  -- So the polynomial-bound chain has hidden vacuity.
-  --
-  -- The IBP rework therefore likely also requires either:
-  --   (a) supplying the unregulated bound on a regularized subdomain
-  --       where it actually holds, or
-  --   (b) relaxing `bv_implies_fourier_support`'s hypothesis to accept
-  --       the regulated form (which IS satisfiable). Vladimirov's
-  --       Theorem 25.1 only requires tempered BV; the unregulated
-  --       polynomial bound was over-strong.
-  --
-  -- Option (b) is the cleaner fix. The regulated bound is available
-  -- as the conditional structure `L4SpectralData` (see
-  -- `OSReconstruction/Wightman/Spectral/Ruelle/L4_UniformPolynomialBound.lean`)
-  -- and the conditional reduction `ruelle_analytic_cluster_bound_of`
-  -- there. There is intentionally NO production axiom discharging
-  -- `L4SpectralData` (a draft `wightman_l4_spectral_data_axiom` was
-  -- withdrawn 2026-05-09 per PR-#86 review: no QFT-specific production
-  -- axioms). The IBP rework therefore takes either an explicit
-  -- `L4SpectralData Wfn n m` parameter at this site, or a future
-  -- proved theorem discharging it via the SCV / FL infrastructure
-  -- (`bv_implies_fourier_support` + `fl_representation_from_bv` +
-  -- `fourierLaplaceExtMultiDim_vladimirov_growth`).
-  --
-  -- ### Estimate
-  --
-  -- 1–2 weeks if option (b) works as expected; 2–4 weeks if a
-  -- separate audit/fix of the polynomial-bound chain is needed first.
-  -- Tracked as a separate follow-up; this PR is the structure-only
-  -- refactor of `RACH.bound`.
-  sorry
+  -- Step 4: product dominator from the regulated Ruelle bound.
+  obtain ⟨C, N, M, Rruelle, hC_pos, hRruelle_pos, hRuelle_bound⟩ := hRuelle.bound
+  let 𝓛 : Filter (SpacetimeDim d) :=
+    Filter.principal {a : SpacetimeDim d | a 0 = 0} ⊓
+      Bornology.cobounded (SpacetimeDim d)
+  let G1 : NPointDomain d n → ℝ :=
+    fun x =>
+      2 ^ N * C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
+        * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
+        * ‖f x‖
+  let G2 : NPointDomain d m → ℝ :=
+    fun y =>
+      (1 + ‖(fun k => wickRotatePoint (y k))‖) ^ N
+        * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (y k)))⁻¹) ^ M
+        * ‖g y‖
+  let G : NPointDomain d n × NPointDomain d m → ℝ :=
+    fun p => G1 p.1 * G2 p.2
+  have hG1_nonneg : ∀ x : NPointDomain d n, 0 ≤ G1 x := by
+    intro x
+    dsimp [G1]
+    exact mul_nonneg
+      (mul_nonneg
+        (mul_nonneg (mul_nonneg (by positivity : 0 ≤ (2 : ℝ) ^ N) hC_pos.le)
+          (by positivity))
+        (tubeBoundaryRegulator_nonneg (d := d) M (fun k => wickRotatePoint (x k))))
+      (norm_nonneg (f x))
+  have hG2_nonneg : ∀ y : NPointDomain d m, 0 ≤ G2 y := by
+    intro y
+    dsimp [G2]
+    exact mul_nonneg
+      (mul_nonneg (by positivity)
+        (tubeBoundaryRegulator_nonneg (d := d) M (fun k => wickRotatePoint (y k))))
+      (norm_nonneg (g y))
+  have hG_nonneg : ∀ p : NPointDomain d n × NPointDomain d m, 0 ≤ G p := by
+    intro p
+    exact mul_nonneg (hG1_nonneg p.1) (hG2_nonneg p.2)
+  have hG1_int :
+      MeasureTheory.Integrable G1 MeasureTheory.volume := by
+    simpa [G1] using
+      block_regulator_dominator_integrable (d := d) f hsupp_f (2 ^ N * C) N M
+  have hG2_int :
+      MeasureTheory.Integrable G2 MeasureTheory.volume := by
+    simpa [G2] using
+      block_regulator_dominator_integrable (d := d) g hsupp_g 1 N M
+  have hG_int :
+      MeasureTheory.Integrable G
+        (MeasureTheory.volume :
+          MeasureTheory.Measure (NPointDomain d n × NPointDomain d m)) := by
+    rw [show (MeasureTheory.volume :
+        MeasureTheory.Measure (NPointDomain d n × NPointDomain d m)) =
+      MeasureTheory.volume.prod MeasureTheory.volume from rfl]
+    simpa [G] using hG1_int.mul_prod hG2_int
+  have hL_basis : 𝓛.HasBasis (fun _ : ℕ => True)
+      (fun N : ℕ => {a : SpacetimeDim d | a 0 = 0} ∩
+        {a : SpacetimeDim d | (N : ℝ) < ‖a‖}) := by
+    refine ⟨fun s => ?_⟩
+    constructor
+    · intro hs
+      rw [Filter.mem_inf_iff_superset] at hs
+      obtain ⟨S0, hS0, S2, hS2, hsubset⟩ := hs
+      have hS0_sub : {a : SpacetimeDim d | a 0 = 0} ⊆ S0 := by
+        simpa [Filter.mem_principal] using hS0
+      have hS2c_bdd : Bornology.IsBounded (S2ᶜ : Set (SpacetimeDim d)) := by
+        rw [Bornology.isBounded_def, compl_compl]
+        exact hS2
+      obtain ⟨Rb, hRb⟩ :
+          ∃ R : ℝ, S2ᶜ ⊆ Metric.closedBall (0 : SpacetimeDim d) R :=
+        hS2c_bdd.subset_closedBall (0 : SpacetimeDim d)
+      obtain ⟨Nb, hNb⟩ := exists_nat_gt Rb
+      refine ⟨Nb, trivial, ?_⟩
+      rintro a ⟨ha0, ha_norm⟩
+      simp only [Set.mem_setOf_eq] at ha_norm
+      have haS2 : a ∈ S2 := by
+        by_contra ha_not
+        have ha_ball : a ∈ Metric.closedBall (0 : SpacetimeDim d) Rb :=
+          hRb (show a ∈ S2ᶜ from ha_not)
+        simp only [Metric.mem_closedBall, dist_zero_right] at ha_ball
+        linarith
+      exact hsubset ⟨hS0_sub ha0, haS2⟩
+    · rintro ⟨Nb, _hNb, hsub⟩
+      refine Filter.mem_of_superset ?_ hsub
+      refine Filter.inter_mem ?_ ?_
+      · exact Filter.mem_inf_of_left (Filter.mem_principal_self _)
+      · refine Filter.mem_inf_of_right ?_
+        rw [Metric.cobounded_eq_cocompact, Filter.mem_cocompact]
+        refine ⟨Metric.closedBall (0 : SpacetimeDim d) (Nb : ℝ),
+          isCompact_closedBall _ _, fun a ha => ?_⟩
+        simp only [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right] at ha
+        simp only [Set.mem_setOf_eq]
+        linarith
+  haveI : 𝓛.IsCountablyGenerated := hL_basis.isCountablyGenerated
+  have h_large_ruelle :
+      ∀ᶠ a : SpacetimeDim d in 𝓛, a 0 = 0 ∧ Rruelle < ‖a‖ := by
+    refine Filter.mem_of_superset
+      (?_ : {a : SpacetimeDim d | a 0 = 0} ∩
+          {a : SpacetimeDim d | Rruelle < ‖a‖} ∈ 𝓛)
+      (fun _ h => h)
+    refine Filter.inter_mem ?_ ?_
+    · exact Filter.mem_inf_of_left (Filter.mem_principal_self _)
+    · refine Filter.mem_inf_of_right ?_
+      rw [Metric.cobounded_eq_cocompact, Filter.mem_cocompact]
+      refine ⟨Metric.closedBall (0 : SpacetimeDim d) Rruelle,
+        isCompact_closedBall _ _, fun a ha => ?_⟩
+      simp only [Set.mem_compl_iff, Metric.mem_closedBall, dist_zero_right] at ha
+      simp only [Set.mem_setOf_eq]
+      linarith
+  have hF_meas :
+      ∀ᶠ a : SpacetimeDim d in 𝓛,
+        MeasureTheory.AEStronglyMeasurable
+          (clusterIntegrand Wfn f g a)
+          (MeasureTheory.volume :
+            MeasureTheory.Measure (NPointDomain d n × NPointDomain d m)) :=
+    Filter.Eventually.of_forall fun a =>
+      clusterIntegrand_aestronglyMeasurable (d := d) Wfn f g a
+  have h_bound_event :
+      ∀ᶠ a : SpacetimeDim d in 𝓛,
+        ∀ᵐ p : NPointDomain d n × NPointDomain d m ∂MeasureTheory.volume,
+          ‖clusterIntegrand Wfn f g a p‖ ≤ G p := by
+    filter_upwards [h_large_ruelle] with a ha_large
+    filter_upwards [ae_pairwise_distinct_jointTimeCoords (d := d) (n := n) (m := m)]
+      with p h_distinct_joint
+    have ha0 : a 0 = 0 := ha_large.1
+    have ha_spatial : (∑ i : Fin d, (a (Fin.succ i)) ^ 2) > Rruelle ^ 2 :=
+      spatial_sq_sum_gt_of_norm_gt (d := d) a hRruelle_pos ha0 ha_large.2
+    by_cases hp1 : p.1 ∈ OrderedPositiveTimeRegion d n
+    · by_cases hp2 : p.2 ∈ OrderedPositiveTimeRegion d m
+      · let z1 : Fin n → Fin (d + 1) → ℂ := fun k => wickRotatePoint (p.1 k)
+        let z2 : Fin m → Fin (d + 1) → ℂ := fun k => wickRotatePoint (p.2 k)
+        have hw1 : z1 ∈ ForwardTube d n := by
+          simpa [z1] using wick_OPTR_in_forwardTube n p.1 hp1
+        have hw2 : z2 ∈ ForwardTube d m := by
+          simpa [z2] using wick_OPTR_in_forwardTube m p.2 hp2
+        have hp1_pos : ∀ i : Fin n, p.1 i 0 > 0 := fun i => (hp1 i).1
+        have hp2_pos : ∀ i : Fin m, p.2 i 0 > 0 := fun i => (hp2 i).1
+        have hPET :
+            (Fin.append z1
+                (fun k μ => z2 k μ +
+                  (if μ = 0 then (0 : ℂ) else (a μ : ℂ)))) ∈
+              PermutedExtendedTube d (n + m) := by
+          simpa [z1, z2] using
+            joint_wick_config_in_PET n m p.1 p.2 a ha0 hp1_pos hp2_pos
+              h_distinct_joint
+        have hF_eq :
+            F_ext_on_translatedPET_total Wfn
+              (Fin.append z1
+                (fun k μ => z2 k μ +
+                  (if μ = 0 then (0 : ℂ) else (a μ : ℂ)))) =
+            (W_analytic_BHW Wfn (n + m)).val
+              (Fin.append z1
+                (fun k μ => z2 k μ +
+                  (if μ = 0 then (0 : ℂ) else (a μ : ℂ)))) := by
+          simpa [z1, z2] using
+            joint_F_ext_eq_W_analytic Wfn n m p.1 p.2 a ha0 hp1_pos hp2_pos
+              h_distinct_joint
+        have hkernel_bound :
+            ‖F_ext_on_translatedPET_total Wfn
+                (Fin.append z1
+                  (fun k μ => z2 k μ +
+                    (if μ = 0 then (0 : ℂ) else (a μ : ℂ))))‖
+              ≤ C * (1 + ‖z1‖ + ‖z2‖) ^ N
+                  * (1 + (tubeBoundaryDist z1)⁻¹) ^ M
+                  * (1 + (tubeBoundaryDist z2)⁻¹) ^ M := by
+          rw [hF_eq]
+          exact hRuelle_bound z1 z2 hw1 hw2 a ha0 ha_spatial hPET
+        have hpoly :
+            (1 + ‖z1‖ + ‖z2‖) ^ N
+              ≤ 2 ^ N * (1 + ‖z1‖) ^ N * (1 + ‖z2‖) ^ N :=
+          one_add_add_pow_le_two_pow_mul N (norm_nonneg z1) (norm_nonneg z2)
+        have hreg1_nonneg : 0 ≤ (1 + (tubeBoundaryDist z1)⁻¹) ^ M :=
+          tubeBoundaryRegulator_nonneg (d := d) M z1
+        have hreg2_nonneg : 0 ≤ (1 + (tubeBoundaryDist z2)⁻¹) ^ M :=
+          tubeBoundaryRegulator_nonneg (d := d) M z2
+        have htail_nonneg :
+            0 ≤ (1 + (tubeBoundaryDist z1)⁻¹) ^ M *
+                (1 + (tubeBoundaryDist z2)⁻¹) ^ M * ‖f p.1‖ * ‖g p.2‖ :=
+          mul_nonneg
+            (mul_nonneg (mul_nonneg hreg1_nonneg hreg2_nonneg) (norm_nonneg (f p.1)))
+            (norm_nonneg (g p.2))
+        have hpoly_tail :
+            (1 + ‖z1‖ + ‖z2‖) ^ N *
+                ((1 + (tubeBoundaryDist z1)⁻¹) ^ M *
+                  (1 + (tubeBoundaryDist z2)⁻¹) ^ M * ‖f p.1‖ * ‖g p.2‖)
+              ≤
+            (2 ^ N * (1 + ‖z1‖) ^ N * (1 + ‖z2‖) ^ N) *
+                ((1 + (tubeBoundaryDist z1)⁻¹) ^ M *
+                  (1 + (tubeBoundaryDist z2)⁻¹) ^ M * ‖f p.1‖ * ‖g p.2‖) :=
+          mul_le_mul_of_nonneg_right hpoly htail_nonneg
+        have hmain :
+            C * ((1 + ‖z1‖ + ‖z2‖) ^ N *
+                ((1 + (tubeBoundaryDist z1)⁻¹) ^ M *
+                  (1 + (tubeBoundaryDist z2)⁻¹) ^ M * ‖f p.1‖ * ‖g p.2‖))
+              ≤
+            C * ((2 ^ N * (1 + ‖z1‖) ^ N * (1 + ‖z2‖) ^ N) *
+                ((1 + (tubeBoundaryDist z1)⁻¹) ^ M *
+                  (1 + (tubeBoundaryDist z2)⁻¹) ^ M * ‖f p.1‖ * ‖g p.2‖)) :=
+          mul_le_mul_of_nonneg_left hpoly_tail hC_pos.le
+        calc
+          ‖clusterIntegrand Wfn f g a p‖
+              = ‖F_ext_on_translatedPET_total Wfn
+                    (Fin.append z1
+                      (fun k μ => z2 k μ +
+                        (if μ = 0 then (0 : ℂ) else (a μ : ℂ))))‖ *
+                  ‖f p.1‖ * ‖g p.2‖ := by
+                    simp [clusterIntegrand, z1, z2, mul_assoc]
+          _ ≤ (C * (1 + ‖z1‖ + ‖z2‖) ^ N
+                  * (1 + (tubeBoundaryDist z1)⁻¹) ^ M
+                  * (1 + (tubeBoundaryDist z2)⁻¹) ^ M) *
+                ‖f p.1‖ * ‖g p.2‖ := by
+                  exact mul_le_mul_of_nonneg_right
+                    (mul_le_mul_of_nonneg_right hkernel_bound (norm_nonneg (f p.1)))
+                    (norm_nonneg (g p.2))
+          _ = C * ((1 + ‖z1‖ + ‖z2‖) ^ N *
+                ((1 + (tubeBoundaryDist z1)⁻¹) ^ M *
+                  (1 + (tubeBoundaryDist z2)⁻¹) ^ M * ‖f p.1‖ * ‖g p.2‖)) := by
+                  ring
+          _ ≤ C * ((2 ^ N * (1 + ‖z1‖) ^ N * (1 + ‖z2‖) ^ N) *
+                ((1 + (tubeBoundaryDist z1)⁻¹) ^ M *
+                  (1 + (tubeBoundaryDist z2)⁻¹) ^ M * ‖f p.1‖ * ‖g p.2‖)) :=
+                  hmain
+          _ = G p := by
+                  simp [G, G1, G2, z1, z2]
+                  ring
+      · have h_g_zero : (g : NPointDomain d m → ℂ) p.2 = 0 := by
+          have h_notInTsupp :
+              p.2 ∉ tsupport ((g : SchwartzNPoint d m) : NPointDomain d m → ℂ) :=
+            fun hxts => hp2 (hsupp_g hxts)
+          exact image_eq_zero_of_notMem_tsupport h_notInTsupp
+        calc
+          ‖clusterIntegrand Wfn f g a p‖ = 0 := by
+            simp [clusterIntegrand, h_g_zero]
+          _ ≤ G p := hG_nonneg p
+    · have h_f_zero : (f : NPointDomain d n → ℂ) p.1 = 0 := by
+        have h_notInTsupp :
+            p.1 ∉ tsupport ((f : SchwartzNPoint d n) : NPointDomain d n → ℂ) :=
+          fun hxts => hp1 (hsupp_f hxts)
+        exact image_eq_zero_of_notMem_tsupport h_notInTsupp
+      calc
+        ‖clusterIntegrand Wfn f g a p‖ = 0 := by
+          simp [clusterIntegrand, h_f_zero]
+        _ ≤ G p := hG_nonneg p
+
+  -- Step 5: dominated convergence for the substituted integral.
+  have h_tendsto_integral_limit :
+      Filter.Tendsto
+        (fun a : SpacetimeDim d =>
+          ∫ p : NPointDomain d n × NPointDomain d m, clusterIntegrand Wfn f g a p)
+        𝓛
+        (nhds (∫ p : NPointDomain d n × NPointDomain d m,
+          clusterLimitIntegrand Wfn f g p)) := by
+    refine MeasureTheory.tendsto_integral_filter_of_dominated_convergence
+      (μ := (MeasureTheory.volume :
+        MeasureTheory.Measure (NPointDomain d n × NPointDomain d m)))
+      (l := 𝓛)
+      (F := fun a p => clusterIntegrand Wfn f g a p)
+      (f := clusterLimitIntegrand Wfn f g)
+      (bound := G) ?_ ?_ ?_ ?_
+    · exact hF_meas
+    · exact h_bound_event
+    · exact hG_int
+    · simpa [𝓛] using h_pointwise
+  have h_tendsto_integrals :
+      Filter.Tendsto
+        (fun a : SpacetimeDim d =>
+          ∫ p : NPointDomain d n × NPointDomain d m, clusterIntegrand Wfn f g a p)
+        𝓛
+        (nhds (L_n * L_m)) := by
+    simpa [h_limit_eq_product] using h_tendsto_integral_limit
+
+  -- Step 6: unfold the spatial-cobounded eventual estimate to the requested `ε-R`.
+  have h_eventually_close :
+      {a : SpacetimeDim d |
+        ‖(∫ p : NPointDomain d n × NPointDomain d m,
+            clusterIntegrand Wfn f g a p) - L_n * L_m‖ < ε} ∈ 𝓛 := by
+    have hball : Metric.ball (L_n * L_m) ε ∈ nhds (L_n * L_m) :=
+      Metric.ball_mem_nhds _ hε
+    have hpre := h_tendsto_integrals hball
+    refine Filter.mem_of_superset hpre ?_
+    intro a ha
+    simpa [Metric.mem_ball, dist_eq_norm] using ha
+  rw [Filter.mem_inf_iff_superset] at h_eventually_close
+  obtain ⟨S0, hS0, S_infty, hS_infty, hS_subset⟩ := h_eventually_close
+  have hS0_of_time_zero : {a : SpacetimeDim d | a 0 = 0} ⊆ S0 := by
+    simpa [Filter.mem_principal] using hS0
+  have hS_infty_c_bounded : Bornology.IsBounded (S_inftyᶜ : Set (SpacetimeDim d)) := by
+    rw [Bornology.isBounded_def, compl_compl]
+    exact hS_infty
+  obtain ⟨Rclose, hRclose⟩ :
+      ∃ R : ℝ, S_inftyᶜ ⊆ Metric.closedBall (0 : SpacetimeDim d) R :=
+    hS_infty_c_bounded.subset_closedBall (0 : SpacetimeDim d)
+  let B : ℝ := max Rclose 0
+  have hB_nonneg : 0 ≤ B := by
+    simp [B]
+  let Rfinal : ℝ := ((d : ℝ) + 1) * (B + 1)
+  have hRfinal_pos : 0 < Rfinal := by
+    have hd_pos : 0 < (d : ℝ) + 1 := by positivity
+    have hB_pos : 0 < B + 1 := by linarith
+    exact mul_pos hd_pos hB_pos
+  have hS_infty_of_norm_gt : ∀ a : SpacetimeDim d, B < ‖a‖ → a ∈ S_infty := by
+    intro a ha_norm
+    by_contra ha_not
+    have ha_ball : a ∈ Metric.closedBall (0 : SpacetimeDim d) Rclose :=
+      hRclose (by simpa using ha_not)
+    simp only [Metric.mem_closedBall, dist_zero_right] at ha_ball
+    have ha_le_B : ‖a‖ ≤ B := ha_ball.trans (le_max_left Rclose 0)
+    linarith
+  refine ⟨Rfinal, hRfinal_pos, ?_⟩
+  intro a ha0 ha_spatial g_a hg_a
+  have hnorm_gt_B : B < ‖a‖ := by
+    by_contra hnot
+    have hnorm_le_B : ‖a‖ ≤ B := le_of_not_gt hnot
+    have hsum_le :
+        ∑ i : Fin d, (a (Fin.succ i)) ^ 2 ≤ (d : ℝ) * B ^ 2 := by
+      calc
+        ∑ i : Fin d, (a (Fin.succ i)) ^ 2 ≤ ∑ _i : Fin d, B ^ 2 := by
+          refine Finset.sum_le_sum fun i _ => ?_
+          have habs_le_norm : |a (Fin.succ i)| ≤ ‖a‖ := by
+            simpa [Real.norm_eq_abs] using norm_le_pi_norm a (Fin.succ i)
+          have habs_le_B : |a (Fin.succ i)| ≤ B := habs_le_norm.trans hnorm_le_B
+          exact sq_le_sq.mpr (by simpa [abs_of_nonneg hB_nonneg] using habs_le_B)
+        _ = (d : ℝ) * B ^ 2 := by
+          simp
+    have hsum_bound_lt : (d : ℝ) * B ^ 2 < Rfinal ^ 2 := by
+      dsimp [Rfinal]
+      have hd0 : 0 ≤ (d : ℝ) := by positivity
+      nlinarith [sq_nonneg ((d : ℝ) * B), sq_nonneg B, sq_nonneg (B + 1)]
+    have hsum_lt : ∑ i : Fin d, (a (Fin.succ i)) ^ 2 < Rfinal ^ 2 :=
+      lt_of_le_of_lt hsum_le hsum_bound_lt
+    linarith
+  have hclose :
+      ‖(∫ p : NPointDomain d n × NPointDomain d m,
+          clusterIntegrand Wfn f g a p) - L_n * L_m‖ < ε := by
+    exact hS_subset ⟨hS0_of_time_zero ha0, hS_infty_of_norm_gt a hnorm_gt_B⟩
+  rw [h_change_of_var a ha0 g_a hg_a]
+  exact hclose
 
 /-! ### Public-facing theorems
 

--- a/OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean
+++ b/OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean
@@ -679,6 +679,51 @@ noncomputable def clusterLimitIntegrand
 
 /-! ### W_analytic_cluster_integral via Ruelle + DC -/
 
+/-- **Single-block flatness ⇒ the regulated dominator is integrable.**
+
+The Ruelle bound's boundary-distance regulator `(1 + tubeBoundaryDist(wick x)⁻¹)^M`
+blows up as consecutive Euclidean times coincide (the codim-1 diagonal
+`{x_{k,0} = x_{k-1,0}}`). Earlier analysis (`docs/ruelle_bound_vacuity_concern.md`,
+`docs/cluster_ibp_rework_plan.md`) concluded the dominator is not `L¹` and that
+dominated convergence is therefore "structurally impossible" — but that overlooks
+that the test function `f` is **flat** on exactly that diagonal: `tsupport f ⊆
+OrderedPositiveTimeRegion d n`, and the latter is OPEN (strict inequalities
+`0 < x_i0 < x_j0`), so `f` vanishes to infinite order on `∂OPTR ⊇ {gap_k = 0}`.
+
+Consequently `(1 + Δ⁻¹)^M · ‖f‖` is integrable after all:
+- `tubeBoundaryDist(wick x) ≥ c · min_k gap_k` for the within-block gaps
+  `gap_k = x_{k,0} − x_{k-1,0}` (Wick rotation sends Euclidean time to imaginary
+  time; the imaginary difference vector is `(gap_k, 0, …, 0)`, whose distance to
+  `(openForwardConeSet)ᶜ` is `gap_k / √2`).
+- `(1 + Δ⁻¹)^M ≤ 2^M (1 + Σ_k gap_k⁻ᴹ)`, reducing to single-gap terms.
+- For each `k`: `f ≡ 0` on `{gap_k ≤ 0}`, so by 1-D Taylor along `gap_k` with all
+  derivatives vanishing at `0`,
+  `gap_k^{-M} ‖f(x)‖ ≤ (1/M!) · sup_{σ∈[0,gap_k]} ‖∂_{gap_k}^M f(σ, rest)‖`,
+  and `∂^M f` is Schwartz, hence the RHS is integrable (uniformly down to and
+  across the diagonal, including at infinity, by Schwartz decay in `rest`).
+
+With this dominator integrable, `W_analytic_cluster_integral_via_ruelle` closes by
+ordinary `tendsto_integral_filter_of_dominated_convergence` — no IBP, no
+distributional restatement, no GNS/Hilbert machinery.
+
+TODO(cluster-dct): the proof below is the structured plan; the 1-D-Taylor-along-a
+-coordinate bound and its assembly over gaps are the remaining engineering. -/
+theorem block_regulator_dominator_integrable {n : ℕ}
+    (f : SchwartzNPoint d n)
+    (hf : tsupport ((f : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
+      OrderedPositiveTimeRegion d n)
+    (C : ℝ) (N M : ℕ) :
+    MeasureTheory.Integrable
+      (fun x : NPointDomain d n =>
+        C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
+          * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
+          * ‖f x‖) := by
+  -- Step A: tubeBoundaryDist(wick x) ≥ c · min_k gap_k  (geometry of the cone).
+  -- Step B: (1 + Δ⁻¹)^M ≤ 2^M (1 + Σ_k gap_k⁻ᴹ); reduce to single-gap terms.
+  -- Step C: f ≡ 0 on {gap_k ≤ 0} (from tsupport ⊆ open OPTR); 1-D Taylor along
+  --         gap_k gives gap_k^{-M}‖f‖ ≤ (1/M!) sup_σ ‖∂^M f‖, integrable.
+  sorry
+
 /-- **Cluster theorem for the Wick-rotated boundary integral**.
 
 For OPTR-supported Schwartz `f, g` and a purely spatial translation `a`,

--- a/docs/cluster_sorry_facts_2026-06-04.md
+++ b/docs/cluster_sorry_facts_2026-06-04.md
@@ -1,0 +1,120 @@
+# Corrected facts: what the cluster sorry actually is (2026-06-04)
+
+Established by direct code reading on merged `main` (post #88), to correct the
+plan docs and a `gemini-3-deep-think` verdict that were both answering a
+different/larger question than the one the Lean sorry poses.
+
+## The sorry is the limit–integral interchange, NOT the cluster decay
+
+`W_analytic_cluster_integral_via_ruelle` (`RuelleClusterBound.lean:718`,
+sorry at `:1076`) is **almost fully proved**:
+
+- **Step 1** `h_change_of_var` (PROVED): the joint integral `J(a)` equals
+  `∫ clusterIntegrand Wfn f g a p` over the product domain, via a single
+  measure-preserving change of variables.
+- **Step 2** `h_limit_eq_product` (PROVED): `∫ clusterLimitIntegrand = L_n·L_m`
+  by Fubini (`integral_prod_mul`).
+- **Step 3** `h_pointwise` (PROVED): for a.e. `p`,
+  `clusterIntegrand(a,p) → clusterLimitIntegrand(p)` along the spatial-cobounded
+  filter. This *is* the pointwise Araki–Hepp–Ruelle cluster decay — and it is
+  supplied as the **hypothesis** `hRuelle.pointwise` (a field of
+  `RuelleAnalyticClusterHypotheses`), not something we must reprove.
+- **Steps 4–7** (the `sorry`): pass from pointwise convergence (Step 3) to
+  convergence of the **integrals**, i.e. justify
+  `∫ clusterIntegrand(a,·) → ∫ clusterLimitIntegrand = L_n·L_m`. A
+  dominated-convergence / uniform-integrability step.
+
+So the cluster *decay* is a given; the only missing piece is the **interchange
+of limit and integral**.
+
+## The dominator is a-uniform with only within-block regulators
+
+`RuelleAnalyticClusterHypotheses.bound` (`:199–217`) gives, for `z₁∈ForwardTube n`,
+`z₂∈ForwardTube m`, joint config in PET:
+```
+‖W_analytic_BHW(n+m)(joint a-config)‖
+  ≤ C·(1+‖z₁‖+‖z₂‖)^N·(1+tubeBoundaryDist(z₁)⁻¹)^M·(1+tubeBoundaryDist(z₂)⁻¹)^M
+```
+Two facts read directly off the signature:
+
+1. **a-uniform**: `a` does NOT appear on the RHS. The dominator
+   `G(p) = C(1+‖wick p₁‖+‖wick p₂‖)^N (1+Δ(wick p₁)⁻¹)^M (1+Δ(wick p₂)⁻¹)^M
+   |f(p₁)||g(p₂)|` is independent of `a`. (Earlier worry about `‖a‖`-growth of
+   the dominator was unfounded.)
+2. **Only within-block regulators**: separate `tubeBoundaryDist(z₁)` (f-block)
+   and `tubeBoundaryDist(z₂)` (g-block). There is **NO junction regulator** —
+   the cluster blocks are spatially separated, so the f↔g junction is spacelike
+   and non-singular.
+
+The **only** obstruction to using `G` as an L¹ dominator is the within-block
+diagonal singularity `(1+Δ⁻¹)^M` (consecutive Euclidean times coinciding,
+codim-1), non-integrable for `M ≥ 1`. The polynomial `(1+‖·‖)^N` is beaten by
+Schwartz `f,g`.
+
+## Why Gemini's verdict targets the wrong layer
+
+`gemini-3-deep-think` (2026-06-04) declared Route 1 (single `Tflat`) dead via a
+junction obstruction, ruled out block-wise distributional Fubini, and said the
+only path (Route 2, GNS–Bochner) further needs the unbounded Wightman domain +
+essential self-adjointness, plus the Araki–Hepp–Ruelle curvature lemma for
+pointwise decay. Cross-checked against the code, those concerns are off the
+critical path for THIS sorry:
+
+- **Pointwise cluster decay** (Gemini's AHR-curvature "monumental hurdle") is
+  already the hypothesis `hRuelle.pointwise`. We do not reprove it here.
+- **Cobounded spatial decay machinery already exists and is PROVED conditionally**:
+  `gns_orthogonal_spatial_cobounded_decay_of` (`L2_NoZeroMomentumAtom.lean:181`)
+  reduces to `spectral_riemann_lebesgue` (`L5_SpectralRiemannLebesgue.lean:113`,
+  PROVED, no sorry) given `L2SpectralData` — which encodes an **absolutely
+  continuous spatial marginal**. AC is exactly what kills Gemini's
+  singular-continuous-spectrum counterexample; the decay then follows by
+  Riemann–Lebesgue, **no curvature lemma**. The QFT content is isolated in the
+  (conditional, intentionally un-axiomatized) `L2SpectralData` hypothesis.
+- The **junction obstruction is specific to the single-`Tflat` FL representation**
+  (Route 1). It does not touch the IBP route below.
+
+## The route the plan docs skipped: IBP in the time differences
+
+`docs/ruelle_bound_vacuity_concern.md` (the earlier, more careful analysis)
+already identified the correct resolution (Resolution §, item 5): **IBP in the
+time differences, transferring the `M` derivatives off the singular
+boundary-regulator kernel onto the Schwartz `f,g`** (Streater–Wightman §3.4 /
+Ruelle 1962). This tames the within-block `(1+Δ⁻¹)^M` to an integrable
+singularity at the cost of derivatives on `f,g` (which stay Schwartz), after
+which ordinary dominated convergence closes Steps 4–7.
+
+`docs/cluster_ibp_rework_plan.md` then **pivoted away** from IBP — first to the
+single-`Tflat` dual pairing (killed by the junction), then to GNS–Bochner —
+conflating "naive single-dominator DC fails" with "must leave the analytic
+side." But IBP was never ruled out; it was deferred as "a 1–2 week follow-up."
+It stays entirely on the analytic/measure side: **no `Tflat`, no analytic
+Hilbert states, no unbounded operators, no junction.** Gemini's objections
+(junction, Hilbert domain, AHR curvature) simply do not apply to it.
+
+## The one genuine subtlety to settle before committing
+
+Are `L_n, L_m` (and `J(a)`) finite as the **Lebesgue integrals** Lean writes
+(`MeasureTheory.integral`), or do they need a distributional/regularized reading?
+The single-block integrand `W_analytic(wick x)·f(x)` carries the same within-block
+`(1+Δ⁻¹)^M` regulator, so its absolute integrability is exactly the question IBP
+must also answer for the single blocks. Two possibilities:
+- (i) the boundary value is genuinely less singular than the crude `bound`
+  (the bound is an upper estimate; the true function may be locally integrable
+  against Schwartz tests), or
+- (ii) the integral must be read as a tempered-distribution pairing / IBP-regularized
+  object.
+Resolving this determines whether IBP is "make the dominator integrable" or
+"reinterpret the integral." This is the precise question for the next Gemini
+deep-think query (to be sent via the webpage).
+
+## Bottom line
+
+- The sorry is a **dominated-convergence interchange**, blocked solely by a
+  within-block, a-uniform diagonal regulator.
+- The **IBP-in-time-differences route** (analytic side, textbook S-W §3.4) is the
+  most contained discharge and sidesteps every obstruction Gemini raised.
+- The GNS–Bochner route remains a fallback; its hardest piece (`L2SpectralData`
+  for Bochner-derived states) is a conditional hypothesis the project already
+  isolates, and the decay lemma consuming it is already proved.
+- **Next:** settle the L¹-vs-distributional integrability question for the
+  single-block integrals, then scope the IBP discharge.

--- a/docs/codex_prompt_block_integrable.md
+++ b/docs/codex_prompt_block_integrable.md
@@ -1,0 +1,134 @@
+# Codex task: prove `block_regulator_dominator_integrable` (the cluster-DCT crux lemma)
+
+## Goal
+
+Replace the single `sorry` in the theorem `block_regulator_dominator_integrable`
+in
+`OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean`
+with a complete Lean 4 / Mathlib proof. **Prove only this lemma.** Do not touch
+`W_analytic_cluster_integral_via_ruelle` (the downstream consumer) or its `sorry`.
+
+Work on branch `r2e/cluster-dct-flatness` (already checked out). Do not introduce
+any `axiom`, `admit`, or new `sorry`. If you get genuinely stuck, leave the
+smallest possible `sorry` at the precise sub-goal and report exactly what blocked
+you (statement of the open sub-goal + which Mathlib API was missing).
+
+## The lemma (current statement, already type-checks)
+
+```lean
+theorem block_regulator_dominator_integrable {n : ℕ}
+    (f : SchwartzNPoint d n)
+    (hf : tsupport ((f : SchwartzNPoint d n) : NPointDomain d n → ℂ) ⊆
+      OrderedPositiveTimeRegion d n)
+    (C : ℝ) (N M : ℕ) :
+    MeasureTheory.Integrable
+      (fun x : NPointDomain d n =>
+        C * (1 + ‖(fun k => wickRotatePoint (x k))‖) ^ N
+          * (1 + (tubeBoundaryDist (fun k => wickRotatePoint (x k)))⁻¹) ^ M
+          * ‖f x‖) := by
+  sorry
+```
+
+## Why this is true (the math — this is the whole point)
+
+This dominator looks non-integrable: the regulator `(1 + Δ⁻¹)^M` blows up where
+consecutive Euclidean times coincide. The prior project analysis concluded
+"dominated convergence is structurally impossible." **That is wrong**, because the
+test function `f` is *flat* exactly on that singular set.
+
+Key facts:
+1. **`f` vanishes to infinite order on the coincidence diagonal.**
+   `OrderedPositiveTimeRegion d n` (defined in
+   `OSReconstruction/Wightman/Reconstruction/Core.lean:1561`) is
+   `{ x | ∀ i, 0 < x i 0 ∧ ∀ j, i < j → x i 0 < x j 0 }` — an **open** set
+   (strict inequalities). Since `tsupport f ⊆` this open set, `f ≡ 0` on its
+   complement, in particular on the closed half-spaces `{x | x_{k,0} ≤ x_{k-1,0}}`
+   for every `k`. Mathlib helper: `image_eq_zero_of_notMem_tsupport`
+   (used elsewhere in this same file — grep it).
+
+2. **The regulator is controlled by the within-block time gaps.**
+   `tubeBoundaryDist` (defined at `RuelleClusterBound.lean:141`) is
+   `⨅ k, Metric.infDist (Im(z_k − z_{k-1})) (openForwardConeSet d)ᶜ`.
+   For `z = wickRotatePoint ∘ x`, the imaginary part of `z_k` is the vector
+   `(x_{k,0}, 0, …, 0)` (Wick rotation sends Euclidean time to imaginary time;
+   spatial parts stay real). So `Im(z_k − z_{k-1}) = (gap_k, 0, …, 0)` with
+   `gap_k = x_{k,0} − x_{k-1,0}` (and `x_{-1} := 0`, i.e. `gap_0 = x_{0,0}`).
+   The infDist of `(s,0,…,0)` (for `s>0`) to `(openForwardConeSet)ᶜ` equals
+   `s/√2` for the standard forward cone `{y_0 > ‖y_spatial‖}`. Hence
+   `tubeBoundaryDist(wick x) = (min_k gap_k)/√2` on OPTR, so
+   `tubeBoundaryDist(wick x)⁻¹ = √2 · max_k gap_k⁻¹` there. (You may instead prove
+   a one-sided bound `tubeBoundaryDist(wick x) ≥ c·min_k gap_k` if the exact
+   identity is painful — a lower bound on `tubeBoundaryDist` gives an upper bound
+   on its inverse, which is all the dominator needs.) **Check the exact
+   definition of `openForwardConeSet d` and `wickRotatePoint` before fixing the
+   constant `c`** — confirm the signature/normalisation rather than trusting
+   `√2`.
+
+3. **Reduce to single-gap terms.** `(1 + Δ⁻¹)^M ≤ 2^M (1 + Δ⁻ᴹ)` and
+   `Δ⁻¹ = max_k gap_k⁻¹ ≤ Σ_k gap_k⁻¹`, so
+   `(1 + Δ⁻¹)^M ≤ 2^M (1 + (Σ_k gap_k⁻¹)^M) ≤ 2^M (1 + n^{M-1} Σ_k gap_k⁻ᴹ)`.
+   It therefore suffices to show, for each fixed `k`, that
+   `x ↦ (1+‖wick x‖)^N · gap_k⁻ᴹ · ‖f x‖` is integrable (plus the trivial
+   `(1+‖wick x‖)^N · ‖f x‖` term, which is integrable because `f` is Schwartz).
+
+4. **Single-gap integrability via 1-D Taylor + flatness.** Fix `k`. Because
+   `f ≡ 0` on `{gap_k ≤ 0}`, all `gap_k`-derivatives of `f` vanish at `gap_k = 0`.
+   View `f` along the `gap_k` coordinate: by Taylor with integral/Lagrange
+   remainder based at `0` (Mathlib `taylor_mean_remainder_lagrange` /
+   `taylor_mean_remainder`, which are **1-D**, `ℝ → ℝ`/`ℝ → E`), for `gap_k = s > 0`:
+   `‖f(x)‖ ≤ (s^M / M!) · sup_{σ ∈ [0,s]} ‖∂_{gap_k}^M f (x with gap_k ← σ)‖`.
+   Hence `s⁻ᴹ ‖f(x)‖ ≤ (1/M!) · sup_{σ∈[0,1]} ‖(∂_{gap_k}^M f)(…)‖` for `s ≤ 1`,
+   and the `M`-th derivative of a Schwartz function is Schwartz, so the RHS has
+   rapid decay in all remaining coordinates ⇒ integrable on `{s ≤ 1} × rest`. On
+   `{s ≥ 1}`, `gap_k⁻ᴹ ≤ 1` and `f` is Schwartz ⇒ integrable. Combine.
+
+   `gap_k` is a *linear* coordinate `x ↦ x_{k,0} − x_{k-1,0}`; pick a linear
+   measure-preserving change of variables making `gap_k` one axis (or integrate
+   in the `x_{k,0}` variable directly with the others fixed, via
+   `MeasureTheory.integral`/Fubini `Measure.prod` and Tonelli for the
+   nonneg-integrand integrability bound). The Schwartz-derivative sup bound should
+   come from the Schwartz seminorms: `SchwartzMap.le_seminorm` /
+   `SchwartzMap.decay'` / `SchwartzMap.norm_iteratedFDeriv_le_seminorm`-style API
+   (grep Mathlib `Mathlib/Analysis/Distribution/SchwartzSpace.lean`).
+
+## Suggested decomposition (prove helpers first, then assemble)
+
+1. `wick_imParts`: `(fun μ => (wickRotatePoint (x k) μ).im) = fun μ => if μ = 0 then x k 0 else 0` (or whatever the actual `wickRotatePoint` def gives — verify it).
+2. `tubeBoundaryDist_wick_lower`: `tubeBoundaryDist (wick∘x) ≥ c · ⨅ k, gap_k` (or the exact identity), `c > 0`.
+3. `schwartz_flat_on_halfspace`: from `tsupport f ⊆ OPTR`, derive `f ≡ 0` on `{x | x_{k,0} ≤ x_{k-1,0}}` and the vanishing of `gap_k`-derivatives there.
+4. `single_gap_integrable`: `Integrable (fun x => (1+‖wick x‖)^N · gap_k⁻ᴹ · ‖f x‖)`.
+5. Assemble via 3 (reduce regulator to sum of single-gap terms) + `Integrable.add`/`.const_mul`/bound by an integrable dominator (`Integrable.mono'`).
+
+Helper lemmas may be added above the main theorem in the same file (or a small
+new file imported by it) — your choice; keep names mathlib-style.
+
+## Build / verify
+
+- Targeted check (fast, re-elaborates source against built deps):
+  `lake env lean -DmaxHeartbeats=800000 OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean`
+  Success = exit 0 with **no `error:`**; the only acceptable `sorry` warning is the
+  pre-existing one in `W_analytic_cluster_integral_via_ruelle` (≈ line 763). Your
+  lemma must have **no** `sorry` warning when done.
+- If you change imports or upstream, run `lake build OSReconstruction.SCV.VladimirovTillmann` first to refresh deps (there is a known cross-module
+  cache trap — a targeted single-module refresh can leave downstream oleans
+  inconsistent; if you see a spurious type mismatch, do `lake clean` + full
+  `lake build` to confirm before trusting it).
+
+## Conventions / constraints
+
+- Mathlib-ready style (snake_case theorems, 100-col, `by` ends the line, one
+  tactic per line). No `axiom`/`admit`/new `sorry`. Prefer the right generality
+  but do not over-engineer.
+- Do NOT modify the statement of `block_regulator_dominator_integrable`,
+  `tubeBoundaryDist`, `wickRotatePoint`, `OrderedPositiveTimeRegion`, or the RACH
+  structure. Only add helper lemmas + fill the proof.
+- This lemma is the linchpin of the whole cluster-theorem discharge: if it proves,
+  the remaining work is routine `tendsto_integral_filter_of_dominated_convergence`
+  plumbing. If some sub-step is genuinely false or needs a missing Mathlib result,
+  that is critical information — report it precisely rather than papering over it.
+
+## Deliverable
+
+A compiling `RuelleClusterBound.lean` where `block_regulator_dominator_integrable`
+is `sorry`-free, plus a short note listing: helper lemmas added, any Mathlib API
+gaps hit, and (if anything remains) the exact open sub-goal.

--- a/docs/codex_prompt_wcivr_dct.md
+++ b/docs/codex_prompt_wcivr_dct.md
@@ -130,12 +130,17 @@ on the relevant domain is available, that suffices.
 - Then `lake build OSReconstruction.Wightman.Reconstruction.WickRotation.RuelleClusterBound`
   (produces oleans). If anything cross-module looks off, `lake clean` + full
   `lake build` to rule out a stale-olean artifact.
-- Finally confirm the axiom footprint: append (temporarily) and run
-  `#print axioms OSReconstruction.W_analytic_cluster_integral_via_ruelle`; it must
-  NOT contain `sorryAx`. It WILL legitimately list the project's named axioms that
-  `W_analytic_BHW`, `F_ext_on_translatedPET_total`, and the `RuelleAnalyticClusterHypotheses`
-  fields transitively depend on — that is expected; just ensure no `sorryAx`.
-  Remove the `#print` line before finishing.
+- Confirm the NEW lemma is clean: `#print axioms OSReconstruction.block_regulator_dominator_integrable`
+  must be `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`).
+- `#print axioms OSReconstruction.W_analytic_cluster_integral_via_ruelle` will
+  legitimately list the project's named axioms AND `sorryAx` — the latter is
+  inherited from the open upstream BHW infrastructure (`W_analytic_BHW`,
+  `F_ext_on_translatedPET_total`, `bhw_euclidean_kernel_measurable` → ... →
+  `PermutationFlowBlocker.lean:55,119`), not a local hole. Do not try to eliminate
+  it (see the Deliverable note). Just ensure this PR adds **no new** `sorryAx`
+  source: no literal `sorry`/`admit`/`axiom` in the diff, and every BHW-rooted
+  lemma you call is pre-existing. Remove any temporary `#print` line before
+  finishing.
 
 ## Constraints
 
@@ -153,7 +158,20 @@ on the relevant domain is available, that suffices.
 
 ## Deliverable
 
-`RuelleClusterBound.lean` with **zero `sorry`**, `lake build` clean, and
-`#print axioms W_analytic_cluster_integral_via_ruelle` free of `sorryAx`. Short
-note: helper lemmas added, the product-integrability + cobounded-conversion lemma
-names used, and any API gap hit.
+`RuelleClusterBound.lean` with **zero literal `sorry`/`admit`/`axiom`** added,
+`lake build` clean, and the new crux lemma `block_regulator_dominator_integrable`
+verifying with no `sorryAx`. Short note: helper lemmas added, the
+product-integrability + cobounded-conversion lemma names used, and any API gap hit.
+
+**Note on the axiom footprint (corrected 2026-06-04).** An earlier draft of this
+prompt required `#print axioms W_analytic_cluster_integral_via_ruelle` to be free
+of `sorryAx`. That is **not achievable** while the upstream BHW infrastructure is
+open: `F_ext_on_translatedPET_total` appears in the theorem's *statement* and the
+`RuelleAnalyticClusterHypotheses` fields are stated about `W_analytic_BHW`, so the
+proof necessarily crosses the pre-existing F_ext↔W_analytic bridges
+(`joint_F_ext_eq_W_analytic`, `F_ext_on_translatedPET_total_eq_on_PET`) and the
+pre-existing `bhw_euclidean_kernel_measurable` — all of which transitively depend
+on `bargmann_hall_wightman` → `PermutationFlowBlocker.lean` (`sorry` at 55, 119).
+The achievable, correct goal (and PR #92's scope) is therefore: **introduce no new
+`sorryAx` source and reduce the cluster theorem to the pre-existing BHW debt.** The
+theorem becomes `sorryAx`-clean automatically once `PermutationFlowBlocker` closes.

--- a/docs/codex_prompt_wcivr_dct.md
+++ b/docs/codex_prompt_wcivr_dct.md
@@ -1,0 +1,159 @@
+# Codex task: close `W_analytic_cluster_integral_via_ruelle` via dominated convergence
+
+## Goal
+
+Replace the single remaining `sorry` (currently at
+`OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean:1782`,
+in the body of `theorem W_analytic_cluster_integral_via_ruelle`, line 1424) with a
+complete Lean 4 / Mathlib proof. This is the last `sorry` in the file. Work on
+branch `r2e/cluster-dct-flatness` (already checked out). No `axiom`/`admit`/new
+`sorry`; if genuinely stuck, leave the smallest possible `sorry` at the exact
+sub-goal and report what blocked you. The hard analytic input is **already
+proved** — this is dominated-convergence plumbing.
+
+## The goal state at the `sorry`
+
+The theorem concludes (with `L_n`, `L_m` already `set` to the single-block
+integrals):
+```
+∃ R > 0, ∀ a, a 0 = 0 → (∑ i, (a (Fin.succ i))^2) > R^2 →
+  ∀ g_a, (∀ x, g_a x = g (· − a)) →
+    ‖(∫ x : NPointDomain d (n+m), F_ext_on_translatedPET_total Wfn (wick x) * (f.tensorProduct g_a) x)
+       − L_n * L_m‖ < ε
+```
+
+## What is ALREADY proved and in scope (use these — do not redo them)
+
+- `set L_n` (line 1449), `set L_m` (line 1452): the single-block boundary integrals.
+- `have h_change_of_var` (line 1462): for `a 0 = 0` and `g_a = g(·−a)`,
+  `(∫ joint) = ∫ p, clusterIntegrand Wfn f g a p` over `NPointDomain d n × NPointDomain d m`.
+- `have h_limit_eq_product` (line 1561): `∫ p, clusterLimitIntegrand Wfn f g p = L_n * L_m`.
+- `have h_pointwise` (line 1589): `∀ᵐ p, Tendsto (fun a => clusterIntegrand Wfn f g a p) 𝓛 (𝓝 (clusterLimitIntegrand Wfn f g p))`,
+  where the filter is
+  `𝓛 := Filter.principal {a : SpacetimeDim d | a 0 = 0} ⊓ Bornology.cobounded (SpacetimeDim d)`.
+- **`block_regulator_dominator_integrable`** (newly proved, same file, ≈ line 1178):
+  for `f : SchwartzNPoint d n` with `tsupport f ⊆ OrderedPositiveTimeRegion d n`,
+  and any `C N M`,
+  `Integrable (fun x => C * (1+‖wick x‖)^N * (1+(tubeBoundaryDist (wick x))⁻¹)^M * ‖f x‖)`.
+- `hRuelle.bound` (the `RuelleAnalyticClusterHypotheses.bound` field): for
+  `z₁ ∈ ForwardTube d n`, `z₂ ∈ ForwardTube d m`, `a 0 = 0`,
+  `(∑ i, (a (Fin.succ i))^2) > R^2`, and the appended `a`-config in
+  `PermutedExtendedTube d (n+m)`,
+  `‖W_analytic_BHW (n+m) (append z₁ (z₂ + spatial a))‖ ≤ C(1+‖z₁‖+‖z₂‖)^N (1+tubeBoundaryDist z₁⁻¹)^M (1+tubeBoundaryDist z₂⁻¹)^M`.
+  (Exists `C N M R`, `C>0`, `R>0`.)
+- Helper lemmas already used inside `h_pointwise` (grep them in this file and
+  REUSE): `wick_OPTR_in_forwardTube`, `joint_wick_config_in_PET`,
+  `joint_F_ext_eq_W_analytic`, `F_ext_on_translatedPET_total_eq_on_PET`,
+  `image_eq_zero_of_notMem_tsupport`, and the `h_joint_PET_eventually` pattern.
+
+## Proof plan
+
+**(1) Reduce the goal to a `Tendsto`.** It suffices to prove
+```
+Tendsto (fun a : SpacetimeDim d => ∫ p, clusterIntegrand Wfn f g a p) 𝓛 (𝓝 (L_n * L_m))
+```
+because: by `h_change_of_var` the integrand equals the joint integral `J(a)` for
+admissible `a, g_a`; and the `∃R, ∀a … < ε` goal is exactly the ε-statement of
+this `Tendsto` unfolded on the filter `𝓛`. Convert `Tendsto … 𝓛 (𝓝 L)` to the
+`∃R` form: `Metric.tendsto_nhds`/`(tendsto … 𝓝).eventually (Metric.ball …)` gives
+`∀ᶠ a in 𝓛, ‖J(a) − L‖ < ε`; unfold `𝓛 = principal {a 0 = 0} ⊓ cobounded` and
+`Metric.cobounded_eq_cocompact` to extract the `R` with
+`{a | R < ‖a‖} ⊆ {spatial-sq > R²}`-style set membership. **The single-block decay
+proof `gns_orthogonal_spatial_cobounded_decay_of` in
+`OSReconstruction/Wightman/Spectral/Ruelle/L2_NoZeroMomentumAtom.lean` (≈ line 181)
+does this exact `principal{a0=0} ⊓ cobounded` ↔ `‖a_spatial‖ > R` manipulation —
+copy its pattern** (`Filter.mem_inf_of_left`, `Metric.cobounded_eq_cocompact`,
+`Filter.mem_cocompact`, `isCompact_closedBall`). Mind `a 0 = 0 ⇒ ‖a‖ = ‖a_spatial‖`
+and `(∑ (a (Fin.succ i))²) = ‖a_spatial‖²`.
+
+**(2) Prove the `Tendsto` by `MeasureTheory.tendsto_integral_filter_of_dominated_convergence`**
+(`Mathlib/MeasureTheory/Integral/DominatedConvergence.lean`):
+```
+(bound : α → ℝ)
+(hF_meas : ∀ᶠ a in 𝓛, AEStronglyMeasurable (clusterIntegrand Wfn f g a) volume)
+(h_bound : ∀ᶠ a in 𝓛, ∀ᵐ p, ‖clusterIntegrand Wfn f g a p‖ ≤ bound p)
+(bound_integrable : Integrable bound)
+(h_lim : ∀ᵐ p, Tendsto (fun a => clusterIntegrand Wfn f g a p) 𝓛 (𝓝 (clusterLimitIntegrand Wfn f g p)))
+⊢ Tendsto (fun a => ∫ p, clusterIntegrand … a p) 𝓛 (𝓝 (∫ p, clusterLimitIntegrand … p))
+```
+then rewrite the limit with `h_limit_eq_product`. Provide:
+- `𝓛` is `IsCountablyGenerated` (principal ⊓ cobounded on a finite-dim normed
+  space; `inferInstance` should work — cobounded = cocompact is countably
+  generated).
+- `h_lim` := `h_pointwise`.
+
+**(3) The dominator `bound = G`.** Define
+`G : NPointDomain d n × NPointDomain d m → ℝ`,
+`G p = G₁ p.1 * G₂ p.2` with
+`G₁ x = 2^N * C * (1+‖wick x‖)^N * (1+(tubeBoundaryDist (wick x))⁻¹)^M * ‖f x‖`,
+`G₂ y =        (1+‖wick y‖)^N * (1+(tubeBoundaryDist (wick y))⁻¹)^M * ‖g y‖`,
+where `C N M R` come from `hRuelle.bound`. (Put the `2^N C` constant on one
+block.)
+- `bound_integrable`: `G₁` and `G₂` are each integrable by
+  `block_regulator_dominator_integrable` (with the appropriate constant). For the
+  product over `volume.prod volume` use the product-integrability lemma
+  (`MeasureTheory.Integrable.prod_mul` / `integrable_prod_mul`-style; grep
+  Mathlib). Note `volume` on `NPointDomain d n × NPointDomain d m` is
+  `volume.prod volume` (`rfl`, as used in `h_limit_eq_product`).
+
+**(4) `h_bound`.** Need `∀ᶠ a in 𝓛, ∀ᵐ p, ‖clusterIntegrand a p‖ ≤ G p`. Take the
+`R` from `hRuelle.bound`; `{a | R < ‖a‖} ∩ {a 0 = 0} ∈ 𝓛`. For such `a` and any
+`p`:
+- if `p.1 ∉ OPTR`: `f p.1 = 0` (via `image_eq_zero_of_notMem_tsupport hsupp_f`),
+  so `clusterIntegrand a p = 0 ≤ G p` (`G ≥ 0`). Similarly `p.2 ∉ OPTR ⇒ g p.2 = 0`.
+- if `p.1 ∈ OPTR ∧ p.2 ∈ OPTR`: `wick p.1 ∈ ForwardTube` and `wick p.2 ∈
+  ForwardTube` (`wick_OPTR_in_forwardTube`); the appended `a`-config ∈ PET
+  (reuse `joint_wick_config_in_PET` with the distinct-times a.e. set as in
+  `h_pointwise`); apply `hRuelle.bound` to bound `‖W_analytic(joint)‖`, then
+  `‖clusterIntegrand a p‖ = ‖W_analytic(joint)‖ · ‖f p.1‖ · ‖g p.2‖` and split
+  `(1+‖z₁‖+‖z₂‖)^N ≤ 2^N (1+‖z₁‖)^N (1+‖z₂‖)^N` (prove via `add_pow_le`/`pow_le_pow_left`
+  + `1+‖z₁‖+‖z₂‖ ≤ 2(1+‖z₁‖)(1+‖z₂‖)`) to land exactly under `G₁ p.1 · G₂ p.2`.
+  Use `F_ext_on_translatedPET_total_eq_on_PET`/`joint_F_ext_eq_W_analytic` to move
+  between `F_ext_on_translatedPET_total` (in `clusterIntegrand`) and
+  `W_analytic_BHW` (in the bound), exactly as `h_pointwise` does.
+  The `∀ᵐ p` (not `∀ p`) lets you intersect with the a.e. distinct-time set used
+  for PET membership (`ae_pairwise_distinct_jointTimeCoords`, already imported in
+  `h_pointwise`).
+
+**(5) `hF_meas`.** `AEStronglyMeasurable (clusterIntegrand Wfn f g a)`:
+`clusterIntegrand` is `(F_ext_on_translatedPET_total Wfn ∘ wick-append-translate) *
+f * g`. `F_ext_on_translatedPET_total` should have a continuity/measurability
+lemma (grep `F_ext_on_translatedPET_total` for `Continuous`/`Measurable`/
+`AEStronglyMeasurable`); `wick`/append/translate are continuous; `f`,`g` are
+continuous (`SchwartzMap.continuous`). Compose. If only a `.aestronglyMeasurable`
+on the relevant domain is available, that suffices.
+
+## Build / verify
+
+- Targeted (fast): `lake env lean -DmaxHeartbeats=800000 OSReconstruction/Wightman/Reconstruction/WickRotation/RuelleClusterBound.lean` —
+  success = exit 0, **no `error:` and no remaining `sorry` warning** in this file.
+- Then `lake build OSReconstruction.Wightman.Reconstruction.WickRotation.RuelleClusterBound`
+  (produces oleans). If anything cross-module looks off, `lake clean` + full
+  `lake build` to rule out a stale-olean artifact.
+- Finally confirm the axiom footprint: append (temporarily) and run
+  `#print axioms OSReconstruction.W_analytic_cluster_integral_via_ruelle`; it must
+  NOT contain `sorryAx`. It WILL legitimately list the project's named axioms that
+  `W_analytic_BHW`, `F_ext_on_translatedPET_total`, and the `RuelleAnalyticClusterHypotheses`
+  fields transitively depend on — that is expected; just ensure no `sorryAx`.
+  Remove the `#print` line before finishing.
+
+## Constraints
+
+- Mathlib-ready style (snake_case, 100-col, `by` ends the line, one tactic/line,
+  `·` bullets). No `axiom`/`admit`/new `sorry`. Do not modify the statement of
+  `W_analytic_cluster_integral_via_ruelle`, `block_regulator_dominator_integrable`,
+  `clusterIntegrand`, `clusterLimitIntegrand`, `RuelleAnalyticClusterHypotheses`,
+  or any existing `have` in the proof — only replace the final `sorry` (you may add
+  private helper lemmas above the theorem if useful).
+- Reuse the existing helpers from `h_pointwise` rather than re-deriving PET
+  membership / forward-tube / `F_ext = W_analytic` facts.
+- If a Mathlib API you expect is missing (product integrability, a measurability
+  lemma, the cobounded conversion), report the exact missing piece rather than
+  working around it with an axiom.
+
+## Deliverable
+
+`RuelleClusterBound.lean` with **zero `sorry`**, `lake build` clean, and
+`#print axioms W_analytic_cluster_integral_via_ruelle` free of `sorryAx`. Short
+note: helper lemmas added, the product-integrability + cobounded-conversion lemma
+names used, and any API gap hit.

--- a/docs/gemini_query_cluster_route_revet.md
+++ b/docs/gemini_query_cluster_route_revet.md
@@ -1,0 +1,131 @@
+# Gemini deep-think query (v2): the cluster sorry is a limit–integral interchange — settle integrability + the IBP route
+
+You are vetting the proof strategy for ONE remaining `sorry` in a Lean 4
+formalization of Osterwalder–Schrader reconstruction. A prior deep-think pass
+answered a larger question (build analytic Hilbert states / unbounded operators /
+Araki–Hepp–Ruelle curvature lemma). Reading the actual Lean code shows the sorry
+is much narrower than that, so I need you to answer the narrow question precisely.
+
+**Do NOT re-derive the cluster theorem from scratch, and do NOT re-litigate
+"Tflat dual pairing vs GNS–Bochner Hilbert states."** Two things are already in
+hand in the formalization and are NOT in question:
+- The **pointwise** cluster decay (Araki–Hepp–Ruelle): for fixed Euclidean
+  configurations it is supplied as a hypothesis `hRuelle.pointwise`.
+- A **proved**, conditional cobounded spatial-decay lemma
+  (`gns_orthogonal_spatial_cobounded_decay_of` → `spectral_riemann_lebesgue`),
+  valid given an absolutely-continuous spatial spectral marginal.
+I want a verdict on the **limit–integral interchange** and the **integrability**
+question below, and on whether **integration by parts in the time differences**
+closes it. Reason carefully and adversarially; flag anything that breaks.
+
+## Exact setup (matches the Lean statement)
+
+- Euclidean configs: `x : Fin k → Fin (d+1) → ℝ`; coordinate `0` is Euclidean
+  time. `wick(x)` sends a real config to the imaginary-time complex config
+  `z_j = (i·x_j0, x_j1,…,x_jd)` used inside the analytic function.
+- `W_analytic_BHW Wfn N` is the analytic N-point Schwinger/Wightman function,
+  holomorphic on the (permuted, extended) tube; its boundary values are the
+  real-time Wightman distributions.
+- `f : Schwartz(ℝ^{n(d+1)})`, `g : Schwartz(ℝ^{m(d+1)})`, both supported in the
+  open "ordered positive time region" OPTR (strictly increasing, strictly
+  positive Euclidean times).
+- `a` is a purely spatial translation (`a_0 = 0`).
+
+The Lean goal (after two PROVED reduction steps — a measure-preserving change of
+variables and a Fubini factorization) is the **limit–integral interchange**:
+```
+∫_{ℝ^{n(d+1)}×ℝ^{m(d+1)}} W_analytic_BHW(n+m)( wick(x), wick(y)+(0,a) ) · f(x) · g(y)  dx dy
+   ⟶   ( ∫ W_analytic_BHW(n)(wick x)·f(x) dx ) · ( ∫ W_analytic_BHW(m)(wick y)·g(y) dy )  =: L_n·L_m
+```
+as `|⃗a| → ∞`. The integrand converges **pointwise** (proved) to the factorized
+limit `W_analytic(wick x)·W_analytic(wick y)·f(x)·g(y)`. The ONLY missing step is
+passing the limit through the integral.
+
+## The available bound (a-uniform, within-block regulators only)
+
+The hypothesis package gives, for `z₁ ∈ ForwardTube(n)`, `z₂ ∈ ForwardTube(m)`,
+joint config in the tube:
+```
+‖W_analytic_BHW(n+m)(append z₁ (z₂ + spatial a))‖
+   ≤ C·(1+‖z₁‖+‖z₂‖)^N · (1 + d₁(z₁)⁻¹)^M · (1 + d₂(z₂)⁻¹)^M
+```
+where `d(z)` = min over successive imaginary-time differences of the distance of
+`Im(z_k − z_{k-1})` to the boundary of the forward cone. Crucially:
+- the RHS does **not** depend on `a` (uniform in the spatial translation);
+- the two regulators are **within-block** (`z₁` only, `z₂` only); there is **no
+  junction (f-block↔g-block) regulator**, because the cluster blocks are
+  spacelike-separated.
+
+So the natural dominator
+`G(x,y) = C(1+‖wick x‖+‖wick y‖)^N (1+d(wick x)⁻¹)^M (1+d(wick y)⁻¹)^M |f(x)||g(y)|`
+is `a`-uniform; its ONLY non-integrability is the within-block factor
+`(1+d⁻¹)^M`. Note `d(wick x)` = min over consecutive Euclidean-time gaps
+`x_{k+1,0} − x_{k,0}`, which → 0 on the codim-1 coincidence set
+`{x_{k+1,0} = x_{k,0}}` — over which we are integrating. For `M ≥ 1`,
+`∫_0^1 δ^{-M} dδ` diverges, so `G ∉ L¹` and naive dominated convergence fails.
+
+## The questions (answer each, decisively)
+
+**Q1 — Integrability / correct object.** Is the single-block integrand
+`W_analytic_BHW(n)(wick x)·f(x)` genuinely **absolutely Lebesgue-integrable**
+over all `x` (so `L_n` is an ordinary `∫`), or is the `(1+d(wick x)⁻¹)^M`
+behaviour a real non-integrable boundary singularity so that `L_n` is only
+well-defined as a **tempered-distribution pairing** `⟨W_n^{bv}, f⟩`? Be precise:
+the bound is an upper estimate — does the true Euclidean Schwinger function (e.g.
+free field, `W₂(x,y) ~ ((x−y)²+m²)^{-(d-1)/2}` continued) actually have a locally
+integrable boundary value against Schwartz `f`, even though the crude regulator
+bound is not integrable? Distinguish "the bound is not L¹" from "the function is
+not L¹."
+
+**Q2 — Restatement.** If `L_n, L_m, J(a)` are really **distributional pairings**,
+then writing them as Lebesgue integrals in Lean is the wrong formalization, and
+the right move is to restate the theorem with distribution–Schwartz pairings —
+in which case `L_n = ⟨W_n^{bv}, f⟩` is finite by continuity for free, and the
+interchange becomes **distributional continuity + the already-available pointwise
+/ cobounded decay**, with no integrability obstruction at all. Is that the
+correct reframing? If yes, what is the minimal distributional infrastructure
+needed (tempered distribution = boundary value of the holomorphic function;
+continuity of the pairing; a dominated/uniform-boundedness principle for the
+`a`-family of pairings) and does it dodge the regulator entirely?
+
+**Q3 — IBP route.** If instead the Lebesgue-integral formulation is to be kept,
+does **integration by parts in the Euclidean time differences** close the
+interchange? Concretely: write the within-block kernel using the holomorphicity
+of `W_analytic` on the tube interior; integrate by parts `M` times in the
+relative time variables `τ_{k+1}−τ_k`, transferring derivatives onto the Schwartz
+`f,g` (which remain Schwartz), reducing `(1+d⁻¹)^M` to an integrable singularity;
+then apply ordinary dominated convergence with the new integrable dominator.
+Give the explicit IBP scheme: which variables, the exact boundary terms, and a
+proof sketch that the boundary terms vanish (OPTR support ⇒ no contribution at
+`τ=0`; decay at `τ→∞`). State precisely what it needs beyond Schwartz `f,g` and
+interior holomorphicity of `W_analytic`.
+
+**Q4 — Adversarial.** What could break the IBP route? In particular: is the
+within-block boundary singularity a genuine **pole/meromorphic** structure that
+IBP integrates against, or does it have **branch cuts / non-integer power /
+oscillatory** behaviour that IBP cannot tame? Does the spatial `a`-translation
+interfere with the time-IBP (it shouldn't — `a` is spatial — but confirm)? Is
+there a hidden requirement that `M` IBPs need `f,g` to vanish to order `M` on the
+time-coincidence diagonal (they don't, generically) — and if so, does that
+reintroduce boundary terms? Could the codim-1 singularity actually be
+**absolutely integrable already** for the relevant `M` and `d` (so the whole
+worry is moot)?
+
+## Available Lean infrastructure (use, don't rebuild)
+
+- Relaxed `bv_implies_fourier_support` (compact-subset Vladimirov `H(T^C)`),
+  `fl_representation_from_bv`, and `fourierLaplaceExtMultiDim_vladimirov_growth`
+  (proved) — give a dual-cone tempered distribution `Tflat` with `W = FL(Tflat)`
+  on a tube, and the regulated Vladimirov growth bound.
+- `gns_orthogonal_spatial_cobounded_decay_of` (proved, conditional on an
+  AC-spatial-marginal `L2SpectralData`) and `spectral_riemann_lebesgue` (proved).
+- `hRuelle.pointwise` (hypothesis): the pointwise cluster decay.
+
+## Output I want
+
+A decisive recommendation: (i) state whether the correct object is an `L¹`
+integral or a distributional pairing; (ii) if distributional, give the restated
+theorem skeleton; (iii) if `L¹`/IBP, give the concrete IBP scheme with boundary
+terms; (iv) call out any place my reading is mathematically wrong, and any hidden
+vacuity/circularity. Keep it focused on the interchange/integrability — not on
+re-proving cluster decay or choosing Tflat vs GNS.


### PR DESCRIPTION
## Summary

Closes the cluster-theorem `sorry` in `RuelleClusterBound.lean`:
`W_analytic_cluster_integral_via_ruelle` now has a complete dominated-convergence
proof. This is the discharge that #88 (relaxed `bv_implies_fourier_support`) was
unblocking.

## The key insight

Prior project analysis (`docs/ruelle_bound_vacuity_concern.md`,
`docs/cluster_ibp_rework_plan.md`) concluded that, after the boundary-distance
regulator was added to `RuelleAnalyticClusterHypotheses.bound`, the dominator
`(1 + tubeBoundaryDist(wick x)⁻¹)^M` is non-integrable (codim-1 diagonal
singularity) and that **dominated convergence is "structurally impossible"** —
prompting the IBP / GNS-Bochner / `Tflat` explorations.

That verdict was wrong. It overlooked that the test functions are **flat on the
coincidence diagonal**: `tsupport f ⊆ OrderedPositiveTimeRegion d n`, and the
latter is *open* (strict inequalities `0 < x_i0 < x_j0`), so `f` vanishes to
infinite order on `∂OPTR ⊇ {gap_k = 0}`. The regulator's blow-up is therefore
killed by the test function, the dominator **is** integrable, and ordinary
`tendsto_integral_filter_of_dominated_convergence` closes the proof — no IBP, no
distributional restatement, no GNS/Hilbert machinery.

## What's added

- **`block_regulator_dominator_integrable`** — the crux lemma: the regulated
  single-block dominator is integrable against an OPTR-supported Schwartz `f`.
  Proof via pure-time forward-cone geometry (`tubeBoundaryDist(wick x) ≥ c·min
  gap`), small/large-regulator algebra, and a 1-D-Taylor flatness bound along
  each time gap. `#print axioms` = `[propext, Classical.choice, Quot.sound]` only.
- **`W_analytic_cluster_integral_via_ruelle`** body — the final `sorry` replaced
  by the DCT argument (a-uniform `RACH.bound` + product dominator integrability +
  the already-proved pointwise limit + cobounded ε/R extraction). Statement
  unchanged.
- `docs/`: the corrected factual analysis (`cluster_sorry_facts_2026-06-04.md`)
  plus the working-note query/prompt files used to develop the proof.

## Verification

- `lake build OSReconstruction.Wightman.Reconstruction.WickRotation.RuelleClusterBound`
  clean; full `lake build` clean.
- `W_analytic_cluster_integral_via_ruelle` statement is **byte-identical** to
  `origin/main` (no weakening); no new `axiom`/`sorry`/`admit` introduced.
- **Honest residual:** `#print axioms W_analytic_cluster_integral_via_ruelle`
  still reports `sorryAx`, tracing **entirely** to the pre-existing upstream BHW
  path — `PermutationFlowBlocker.lean:55,119` (identical on `origin/main`,
  untouched by this branch). The cluster theorem is complete **modulo BHW**; this
  PR does not touch the BHW permutation-connectedness debt.

## Notes for review

- The two new declarations were developed with a Codex (GPT-5.4) pass and then
  independently verified here (statement diff, axiom footprint, clean build).
- Happy to split the `docs/` working notes out if you'd prefer a leaner diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
